### PR TITLE
Improve login-related functionality

### DIFF
--- a/src/main/handlers/trade.ts
+++ b/src/main/handlers/trade.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, ipcMain, session } from 'electron'
+import { app, BrowserWindow, ipcMain, net, session } from 'electron'
 import Store from 'electron-store'
 import {
   searchTrade,
@@ -178,39 +178,90 @@ export function register(store: Store<AppSettings>): void {
   })
 
   ipcMain.handle('poe-login', () => {
-    const LOGIN_TITLE = 'Login'
-    const loginWindow = new BrowserWindow({
-      width: 800,
-      height: 700,
-      title: LOGIN_TITLE,
-      autoHideMenuBar: true,
-      webPreferences: {
-        nodeIntegration: false,
-        contextIsolation: true,
-      },
-    })
-    // The PoE login page sets document.title to "Path of Exile", which our overlay
-    // matches by-title and would incorrectly attach to this login popup. Suppress the
-    // OS title update and re-assert our own title in case preventDefault alone isn't
-    // enough on some Windows setups.
-    loginWindow.webContents.on('page-title-updated', (event) => {
-      event.preventDefault()
-      loginWindow.setTitle(LOGIN_TITLE)
-    })
-    loginWindow.loadURL(`${POE_WEBSITE}/login`)
+    return new Promise<void>((resolve) => {
+      const LOGIN_TITLE = 'Login'
+      const loginWindow = new BrowserWindow({
+        width: 800,
+        height: 700,
+        title: LOGIN_TITLE,
+        autoHideMenuBar: true,
+        webPreferences: {
+          nodeIntegration: false,
+          contextIsolation: true,
+        },
+      })
+      // The PoE login page sets document.title to "Path of Exile", which our overlay
+      // matches by-title and would incorrectly attach to this login popup. Suppress the
+      // OS title update and re-assert our own title in case preventDefault alone isn't
+      // enough on some Windows setups.
+      loginWindow.webContents.on('page-title-updated', (event) => {
+        event.preventDefault()
+        loginWindow.setTitle(LOGIN_TITLE)
+      })
+      loginWindow.loadURL(`${POE_WEBSITE}/login`)
 
-    // Close window when user navigates to the account page (login complete)
-    loginWindow.webContents.on('did-navigate', (_event, url) => {
-      if (url.includes('pathofexile.com/my-account') || url === `${POE_WEBSITE}/`) {
-        loginWindow.close()
-      }
+      // Close window when user navigates to the account page (login complete)
+      loginWindow.webContents.on('did-navigate', (_event, url) => {
+        if (url.includes('pathofexile.com/my-account') || url === `${POE_WEBSITE}/`) {
+          loginWindow.close()
+        }
+      })
+
+      // Resolve after the window closes (user logged in or closed without logging in)
+      loginWindow.on('closed', () => resolve())
     })
   })
 
   ipcMain.handle('poe-check-auth', async (): Promise<{ loggedIn: boolean; accountName?: string }> => {
     try {
       const cookies = await session.defaultSession.cookies.get({ domain: 'pathofexile.com', name: 'POESESSID' })
-      return { loggedIn: cookies.length > 0 }
+      if (cookies.length === 0) return { loggedIn: false }
+
+      return await new Promise<{ loggedIn: boolean; accountName?: string }>((resolve) => {
+        const request = net.request({
+          url: `${POE_WEBSITE}/api/profile`,
+          method: 'GET',
+          useSessionCookies: true,
+        })
+        request.setHeader('Accept', 'application/json')
+        request.setHeader('User-Agent', app.userAgentFallback)
+
+        const timeout = setTimeout(() => {
+          try {
+            request.abort()
+          } catch {
+            /* already done */
+          }
+          console.error('[auth] profile check timed out')
+          resolve({ loggedIn: false })
+        }, 5000)
+
+        let data = ''
+        request.on('response', (response) => {
+          if (response.statusCode !== 200) {
+            clearTimeout(timeout)
+            resolve({ loggedIn: false })
+            return
+          }
+          response.on('data', (chunk: Buffer) => {
+            data += chunk.toString()
+          })
+          response.on('end', () => {
+            clearTimeout(timeout)
+            try {
+              const profile = JSON.parse(data) as { name?: string }
+              resolve(profile?.name ? { loggedIn: true, accountName: profile.name } : { loggedIn: false })
+            } catch {
+              resolve({ loggedIn: false })
+            }
+          })
+        })
+        request.on('error', () => {
+          clearTimeout(timeout)
+          resolve({ loggedIn: false })
+        })
+        request.end()
+      })
     } catch {
       return { loggedIn: false }
     }

--- a/src/main/handlers/trade.ts
+++ b/src/main/handlers/trade.ts
@@ -9,7 +9,7 @@ import {
   searchMapsByRegex,
 } from '../trade/trade'
 import type { StatFilter, TradeResult, BulkExchangeResult } from '../trade/trade'
-import type { AppSettings } from '../../shared/types'
+import type { AppSettings, AuthResult } from '../../shared/types'
 import { POE_WEBSITE, getTradeUrls } from '../../shared/endpoints'
 import { getPoeVersion } from '../game-state'
 
@@ -122,6 +122,65 @@ async function clickTradeButton(
   return clicked
 }
 
+function fetchPoeProfile(): Promise<AuthResult> {
+  return new Promise<AuthResult>((resolve) => {
+    const request = net.request({
+      url: `${POE_WEBSITE}/api/profile`,
+      method: 'GET',
+      useSessionCookies: true,
+    })
+    request.setHeader('Accept', 'application/json')
+    request.setHeader('User-Agent', app.userAgentFallback)
+
+    let settled = false
+    const timeout = setTimeout(() => {
+      if (settled) return
+      settled = true
+      request.abort()
+      console.error('[auth] profile check timed out')
+      resolve({ loggedIn: false })
+    }, 5000)
+
+    let data = ''
+    request.on('response', (response) => {
+      if (response.statusCode !== 200) {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        resolve({ loggedIn: false })
+        return
+      }
+      response.on('data', (chunk: Buffer) => {
+        data += chunk.toString()
+      })
+      response.on('end', () => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        try {
+          const profile = JSON.parse(data) as { name?: string }
+          if (profile?.name) {
+            resolve({ loggedIn: true, accountName: profile.name })
+          } else {
+            console.warn('[auth] profile response has no name field, raw:', data)
+            resolve({ loggedIn: false })
+          }
+        } catch (e) {
+          console.error('[auth] profile JSON parse failed:', e, 'raw:', data)
+          resolve({ loggedIn: false })
+        }
+      })
+    })
+    request.on('error', () => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      resolve({ loggedIn: false })
+    })
+    request.end()
+  })
+}
+
 export function register(store: Store<AppSettings>): void {
   ipcMain.handle(
     'trade-search',
@@ -212,56 +271,11 @@ export function register(store: Store<AppSettings>): void {
     })
   })
 
-  ipcMain.handle('poe-check-auth', async (): Promise<{ loggedIn: boolean; accountName?: string }> => {
+  ipcMain.handle('poe-check-auth', async (): Promise<AuthResult> => {
     try {
       const cookies = await session.defaultSession.cookies.get({ domain: 'pathofexile.com', name: 'POESESSID' })
       if (cookies.length === 0) return { loggedIn: false }
-
-      return await new Promise<{ loggedIn: boolean; accountName?: string }>((resolve) => {
-        const request = net.request({
-          url: `${POE_WEBSITE}/api/profile`,
-          method: 'GET',
-          useSessionCookies: true,
-        })
-        request.setHeader('Accept', 'application/json')
-        request.setHeader('User-Agent', app.userAgentFallback)
-
-        const timeout = setTimeout(() => {
-          try {
-            request.abort()
-          } catch {
-            /* already done */
-          }
-          console.error('[auth] profile check timed out')
-          resolve({ loggedIn: false })
-        }, 5000)
-
-        let data = ''
-        request.on('response', (response) => {
-          if (response.statusCode !== 200) {
-            clearTimeout(timeout)
-            resolve({ loggedIn: false })
-            return
-          }
-          response.on('data', (chunk: Buffer) => {
-            data += chunk.toString()
-          })
-          response.on('end', () => {
-            clearTimeout(timeout)
-            try {
-              const profile = JSON.parse(data) as { name?: string }
-              resolve(profile?.name ? { loggedIn: true, accountName: profile.name } : { loggedIn: false })
-            } catch {
-              resolve({ loggedIn: false })
-            }
-          })
-        })
-        request.on('error', () => {
-          clearTimeout(timeout)
-          resolve({ loggedIn: false })
-        })
-        request.end()
-      })
+      return await fetchPoeProfile()
     } catch {
       return { loggedIn: false }
     }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,7 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import type {
   AppSettings,
+  AuthResult,
   FilterBlock,
   FilterListEntry,
   FilterVersion,
@@ -468,7 +469,7 @@ export const api = {
   whisperSeller: (queryId: string, listingId: string, league: string): Promise<void> =>
     ipcRenderer.invoke('whisper-seller', queryId, listingId, league),
   poeLogin: (): Promise<void> => ipcRenderer.invoke('poe-login'),
-  poeCheckAuth: (): Promise<{ loggedIn: boolean; accountName?: string }> => ipcRenderer.invoke('poe-check-auth'),
+  poeCheckAuth: (): Promise<AuthResult> => ipcRenderer.invoke('poe-check-auth'),
   poeLogout: (): Promise<void> => ipcRenderer.invoke('poe-logout'),
   openExternal: (url: string): Promise<void> => ipcRenderer.invoke('open-external', url),
   onGameBounds: (

--- a/src/renderer/src/app-window/onboarding-steps.tsx
+++ b/src/renderer/src/app-window/onboarding-steps.tsx
@@ -291,14 +291,14 @@ export function TradeLoginStep({
   stepNum: number
   totalSteps: number
 }): JSX.Element {
-  const [loggedIn, setLoggedIn] = useState<boolean | null>(null)
+  const [auth, setAuth] = useState<{ loggedIn: boolean; accountName?: string } | null>(null)
 
   useEffect(() => {
-    window.api.poeCheckAuth().then((r) => setLoggedIn(r.loggedIn))
+    window.api.poeCheckAuth().then(setAuth)
   }, [])
 
   const checkAuth = (): void => {
-    window.api.poeCheckAuth().then((r) => setLoggedIn(r.loggedIn))
+    window.api.poeCheckAuth().then(setAuth)
   }
 
   return (
@@ -310,15 +310,15 @@ export function TradeLoginStep({
         subtitle="This is optional, but logging in lets you travel directly to a seller's hideout to buy items from within Scalpel."
       />
       <div className="setting-box mb-6">
-        {loggedIn === null ? (
+        {auth === null ? (
           <span className="value text-text-dim">Checking...</span>
-        ) : loggedIn ? (
+        ) : auth.loggedIn ? (
           <>
-            <span className="value text-accent">Logged in</span>
+            <span className="value text-accent">Logged in as {auth.accountName}</span>
             <button
-              className="primary"
+              className="text-[11px] text-text-dim shrink-0 ml-2 px-3 py-[5px]"
               onClick={() => {
-                window.api.poeLogout().then(() => setLoggedIn(false))
+                window.api.poeLogout().then(() => setAuth({ loggedIn: false }))
               }}
             >
               Logout
@@ -330,7 +330,7 @@ export function TradeLoginStep({
             <button
               className="primary"
               onClick={() => {
-                window.api.poeLogin().then(() => setTimeout(checkAuth, 2000))
+                window.api.poeLogin().then(() => checkAuth())
               }}
             >
               Login
@@ -338,7 +338,7 @@ export function TradeLoginStep({
           </>
         )}
       </div>
-      <NavButtons onBack={onBack} onNext={onNext} nextLabel={loggedIn ? 'Continue' : 'Skip'} />
+      <NavButtons onBack={onBack} onNext={onNext} nextLabel={auth?.loggedIn ? 'Continue' : 'Skip'} />
     </div>
   )
 }

--- a/src/renderer/src/app-window/onboarding-steps.tsx
+++ b/src/renderer/src/app-window/onboarding-steps.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import type { AppSettings } from '../../../shared/types'
+import type { AppSettings, AuthResult } from '../../../shared/types'
 import { getGameFeatures } from '../../../shared/game-features'
 import poeFilterSettingImg from '../assets/other/poe-filter-setting.png'
 import poe1Logo from '../assets/other/poe1-logo.png'
@@ -291,7 +291,7 @@ export function TradeLoginStep({
   stepNum: number
   totalSteps: number
 }): JSX.Element {
-  const [auth, setAuth] = useState<{ loggedIn: boolean; accountName?: string } | null>(null)
+  const [auth, setAuth] = useState<AuthResult | null>(null)
 
   useEffect(() => {
     window.api.poeCheckAuth().then(setAuth)

--- a/src/renderer/src/components/settings/PoeLoginButton.tsx
+++ b/src/renderer/src/components/settings/PoeLoginButton.tsx
@@ -1,26 +1,28 @@
 import { useEffect, useState } from 'react'
 
+type AuthState = { loggedIn: boolean; accountName?: string }
+
 export function PoeLoginButton(): JSX.Element {
-  const [loggedIn, setLoggedIn] = useState<boolean | null>(null)
+  const [auth, setAuth] = useState<AuthState | null>(null)
 
   const checkAuth = (): void => {
-    window.api.poeCheckAuth().then((r) => setLoggedIn(r.loggedIn))
+    window.api.poeCheckAuth().then(setAuth)
   }
 
   useEffect(() => {
     checkAuth()
   }, [])
 
-  if (loggedIn === null) return <span className="text-[11px] text-text-dim">Checking...</span>
+  if (auth === null) return <span className="text-[11px] text-text-dim">Checking...</span>
 
-  if (loggedIn) {
+  if (auth.loggedIn) {
     return (
       <div className="setting-box">
-        <span className="value text-accent">Logged in</span>
+        <span className="value text-accent">Logged in as {auth.accountName}</span>
         <button
-          className="primary"
+          className="text-[11px] text-text-dim shrink-0 ml-2 px-3 py-[5px]"
           onClick={() => {
-            window.api.poeLogout().then(() => setLoggedIn(false))
+            window.api.poeLogout().then(() => setAuth({ loggedIn: false }))
           }}
         >
           Logout
@@ -35,9 +37,7 @@ export function PoeLoginButton(): JSX.Element {
       <button
         className="primary"
         onClick={() => {
-          window.api.poeLogin().then(() => {
-            setTimeout(checkAuth, 2000)
-          })
+          window.api.poeLogin().then(() => checkAuth())
         }}
       >
         Login

--- a/src/renderer/src/components/settings/PoeLoginButton.tsx
+++ b/src/renderer/src/components/settings/PoeLoginButton.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from 'react'
-
-type AuthState = { loggedIn: boolean; accountName?: string }
+import type { AuthResult } from '../../../../shared/types'
 
 export function PoeLoginButton(): JSX.Element {
-  const [auth, setAuth] = useState<AuthState | null>(null)
+  const [auth, setAuth] = useState<AuthResult | null>(null)
 
   const checkAuth = (): void => {
     window.api.poeCheckAuth().then(setAuth)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -540,3 +540,5 @@ export interface Manifest {
    *  Used to build correct deep-links from tagged price entries. */
   poe2NinjaCategories: Record<string, string>
 }
+
+export type AuthResult = { loggedIn: true; accountName: string } | { loggedIn: false }


### PR DESCRIPTION
Fixes a bug with false-positive auth result, when user clicked login but didnt proceed with authentication on poe site. As a result, now a non-valid response keeps unauthenticated state.
Added profile name after succesful login, muted the logout button for consistent ui