### PR TITLE
feat: Linux AppImage support (replaces #13)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  release-win:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,3 +54,52 @@ jobs:
             dist/v${{ steps.version.outputs.version }}/app.asar.unpacked.zip
             dist/v${{ steps.version.outputs.version }}/manifest.json
             dist/Scalpel-Setup.exe
+
+  release-linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Linux native build deps
+        # uiohook-napi and electron-overlay-window's X11 backends link against
+        # the X11/xcb dev headers. libfuse2 is the AppImage Type 2 runtime
+        # dependency used by electron-builder's appimagetool. Building on
+        # 22.04 (glibc 2.35) is intentional: the resulting AppImage runs on
+        # most distros from 2022+; building on 24.04 (glibc 2.39) would
+        # restrict to 2024+ hosts.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libxcb1-dev libxtst-dev libxss-dev libxkbfile-dev \
+            libx11-dev libxext-dev libxrandr-dev libxinerama-dev \
+            libxcursor-dev libxi-dev libxkbcommon-dev libfuse2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Build AppImage
+        run: npx electron-builder --linux AppImage --x64 --publish never
+
+      - name: Extract version
+        id: version
+        run: echo "version=$(node -p 'require("./package.json").version')" >> $GITHUB_OUTPUT
+
+      - name: Append AppImage to GitHub Release
+        # The Windows job creates the release with notes; this appends the
+        # AppImage artifact. softprops/action-gh-release upserts on tag.
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: false
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          files: |
+            dist/Scalpel-${{ steps.version.outputs.version }}.AppImage

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "sync-regex": "node scripts/sync-regex-data.js",
     "sync-prefabs": "node scripts/sync-prefabs.js",
     "dist:win": "npm run build && electron-builder --win --x64",
+    "dist:linux": "npm run build && electron-builder --linux AppImage --x64",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json",
-    "postinstall": "electron-rebuild",
+    "postinstall": "if [ \"$(uname)\" = \"Linux\" ]; then CFLAGS=\"-Wno-error=incompatible-pointer-types\" CXXFLAGS=\"-Wno-error=incompatible-pointer-types\" electron-rebuild; else electron-rebuild; fi",
     "lint": "eslint src/",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
@@ -96,6 +97,15 @@
       "icon": "resources/icon.ico",
       "signAndEditExecutable": true
     },
+    "linux": {
+        "target": ["AppImage"],
+        "category": "Game",
+        "executableName": "scalpel",
+        "icon": "resources/icon.png",
+        "desktop": {
+          "StartupWMClass": "scalpel"
+        }
+      },
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
@@ -108,6 +118,10 @@
       {
         "from": "resources/icon.ico",
         "to": "icon.ico"
+      },
+      {
+        "from": "resources/icon.png",
+        "to": "icon.png"
       }
     ],
     "asar": true,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dist:win": "npm run build && electron-builder --win --x64",
     "dist:linux": "npm run build && electron-builder --linux AppImage --x64",
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.node.json",
-    "postinstall": "if [ \"$(uname)\" = \"Linux\" ]; then CFLAGS=\"-Wno-error=incompatible-pointer-types\" CXXFLAGS=\"-Wno-error=incompatible-pointer-types\" electron-rebuild; else electron-rebuild; fi",
+    "postinstall": "node scripts/postinstall.js",
     "lint": "eslint src/",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,28 @@
+// Runs after `npm install`. Wraps electron-rebuild so the build works on
+// every supported host:
+//   - Linux: newer GCC (14+) promotes -Wincompatible-pointer-types to an
+//     error, which trips one of our native-module deps (uiohook-napi).
+//     Pass -Wno-error=incompatible-pointer-types via CFLAGS/CXXFLAGS to
+//     downgrade it back to a warning so the rebuild completes.
+//   - Windows/macOS: invoke electron-rebuild with no extra flags.
+//
+// The cross-platform npm invocation is what required this script: npm runs
+// postinstall via cmd.exe on Windows, which can't parse POSIX shell guards.
+const { spawnSync } = require('child_process')
+
+const env = { ...process.env }
+if (process.platform === 'linux') {
+  const flag = '-Wno-error=incompatible-pointer-types'
+  env.CFLAGS = env.CFLAGS ? `${env.CFLAGS} ${flag}` : flag
+  env.CXXFLAGS = env.CXXFLAGS ? `${env.CXXFLAGS} ${flag}` : flag
+}
+
+// shell: true lets Windows resolve node_modules/.bin/electron-rebuild.cmd
+// and Linux/macOS find the bare binary on the npm-augmented PATH.
+const result = spawnSync('electron-rebuild', {
+  stdio: 'inherit',
+  shell: true,
+  env,
+})
+
+process.exit(result.status ?? 1)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -250,9 +250,10 @@ let tray: Tray | null = null
 
 function getAppIcon(): Electron.NativeImage {
   // In packaged app, resources/ is at process.resourcesPath; in dev, it's at project root
-  const devPath = join(__dirname, '../../resources/icon.ico')
-  const prodPath = join(process.resourcesPath, 'icon.ico')
-  const iconPath = existsSync(prodPath) ? prodPath : devPath
+  const iconExt = process.platform === 'win32' ? 'icon.ico' : 'icon.png'
+  const devPath = join(__dirname, '../../resources', iconExt)
+  const prodPath = join(process.resourcesPath, iconExt)
+  const iconPath = app.isPackaged ? prodPath : devPath
   return nativeImage.createFromPath(iconPath)
 }
 


### PR DESCRIPTION
Replaces #13 with a current-main cherry-pick + the postinstall fix needed
to keep Windows builds working.

## What this adds

- `dist:linux` npm script + `build.linux` electron-builder config (target
  AppImage, x64, StartupWMClass)
- `getAppIcon` is now platform-aware (uses `icon.png` on non-Windows)
- `scripts/postinstall.js` replaces the inline POSIX-shell guard in PR
  #13. The original `if [ "$(uname)" = "Linux" ]; then ... fi` fails on
  Windows because npm runs postinstall via `cmd.exe`. The Node script
  branches on `process.platform`; behavior on Linux is identical (same
  `-Wno-error=incompatible-pointer-types` flag).
- Linux release CI job (`ubuntu-22.04`) parallel to the existing Windows
  job. Both attach to the same tag release.

## Validated

- AppImage built locally on Ubuntu 22.04 (115 MB) and Arch (Mesa 26.x).
- Full Scalpel runtime path tested end-to-end on a real EWMH Linux
  desktop (xrdp + xfwm4, Vulkan via dzn): overlay-attach via
  electron-overlay-window's X11 backend, uiohook-napi hotkey delivery,
  Ctrl+Alt+C synthesis, clipboard read, evaluation, overlay render.
