### PR TITLE
Imrove onboarding steps, add proper profile management

### DIFF
--- a/src/main/app-window.ts
+++ b/src/main/app-window.ts
@@ -65,11 +65,6 @@ export function getAppWindow(): BrowserWindow | null {
   return appWindow
 }
 
-// Called when onboarding finishes — hide the app window
-ipcMain.handle('finish-onboarding', () => {
-  // Window stays available via tray
-})
-
 ipcMain.on('app-window-mode', (_event, mode: 'onboarding' | 'settings') => {
   if (!appWindow) return
   if (mode === 'onboarding') {

--- a/src/main/cheat-sheets.ts
+++ b/src/main/cheat-sheets.ts
@@ -5,7 +5,7 @@ import {
   CHEAT_SHEET_MINIMIZED_SLACK,
   CHEAT_SHEET_MINIMIZED_WIDTH,
 } from '../shared/cheat-sheet-window'
-import type { AppSettings, CheatSheetsSettings, OverlayAnchor } from '../shared/types'
+import type { CheatSheetsSettings, OverlayAnchor } from '../shared/types'
 import { forwardZoneChangesTo, sendCurrentZoneTo } from './client-log'
 import { setSecondaryOverlayHotkeys } from './hotkeys'
 import { moveCanvasTop, type Rect, registerSecondaryOverlay, type SecondaryOverlay, sendCanvasIpc } from './windowing'

--- a/src/main/cheat-sheets.ts
+++ b/src/main/cheat-sheets.ts
@@ -5,7 +5,7 @@ import {
   CHEAT_SHEET_MINIMIZED_SLACK,
   CHEAT_SHEET_MINIMIZED_WIDTH,
 } from '../shared/cheat-sheet-window'
-import type { AppSettings, OverlayAnchor } from '../shared/types'
+import type { AppSettings, CheatSheetsSettings, OverlayAnchor } from '../shared/types'
 import { forwardZoneChangesTo, sendCurrentZoneTo } from './client-log'
 import { setSecondaryOverlayHotkeys } from './hotkeys'
 import { moveCanvasTop, type Rect, registerSecondaryOverlay, type SecondaryOverlay, sendCanvasIpc } from './windowing'
@@ -138,7 +138,7 @@ export function setCheatSheetsBeforeShow(cb: (() => void) | null): void {
 /** Re-register the cheat-sheet hotkeys (global + per-category) with the
  *  secondary-overlay system. Called once at boot and again whenever the
  *  cheatSheets settings change. */
-export function applyCheatSheetHotkeys(cs: AppSettings['cheatSheets']): void {
+export function applyCheatSheetHotkeys(cs: CheatSheetsSettings): void {
   const hotkeys: Array<{ accelerator: string; handler: () => void }> = []
   const fire = (categoryId?: string): void => {
     beforeShowHook?.()

--- a/src/main/client-log/path-resolver.ts
+++ b/src/main/client-log/path-resolver.ts
@@ -27,15 +27,13 @@ export function resolveClientLogPath(): string | null {
     )
     exePath = out.trim()
   } catch (err) {
-    // biome-ignore lint/suspicious/noConsole: gated behind SCALPEL_DEBUG_LOG
-    if (process.env.SCALPEL_DEBUG_LOG) console.log('[client-log] path resolver: PowerShell shellout failed', err)
+    if (process.env.SCALPEL_DEBUG_LOG) console.warn('[client-log] path resolver: PowerShell shellout failed', err)
     return null
   }
   if (!exePath) return null
   const candidate = join(dirname(exePath), 'logs', 'Client.txt')
   if (!existsSync(candidate)) {
-    // biome-ignore lint/suspicious/noConsole: gated behind SCALPEL_DEBUG_LOG
-    if (process.env.SCALPEL_DEBUG_LOG) console.log('[client-log] path resolver: not found at', candidate)
+    if (process.env.SCALPEL_DEBUG_LOG) console.warn('[client-log] path resolver: not found at', candidate)
     return null
   }
   return candidate

--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -7,6 +7,7 @@ import type { BugReportResult, RendererDiagnosticPayload, SerializedDiagnosticEr
 import { serializeDiagnosticError } from '../shared/diagnostics'
 import { DISCORD_INVITE_URL, GITHUB_NEW_ISSUE_URL } from '../shared/endpoints'
 import type { AppSettings } from '../shared/types'
+import { getActiveProfile } from './profile-settings'
 
 // Tail of the log embedded in a generated bug report.
 const MAX_LOG_BYTES = 256 * 1024
@@ -45,13 +46,12 @@ function redact(text: string): string {
     // app paths may be unavailable during early process errors.
   }
   const settings = storeRef?.store
+  const legacyStore = storeRef as unknown as Store<AppSettings & import('../shared/types').LegacyAppSettings> | null
   for (const value of [
-    settings?.filterPath,
-    settings?.filterDir,
-    settings?.filterPathPoe1,
-    settings?.filterPathPoe2,
-    settings?.filterDirPoe1,
-    settings?.filterDirPoe2,
+    legacyStore?.get('filterPathPoe1'),
+    legacyStore?.get('filterPathPoe2'),
+    legacyStore?.get('filterDirPoe1'),
+    legacyStore?.get('filterDirPoe2'),
   ]) {
     if (typeof value === 'string' && value.length > 0) out = out.split(value).join('<path>')
   }
@@ -160,18 +160,19 @@ function recentLog(): string {
 function settingsSummary(): Record<string, unknown> {
   const s = storeRef?.store
   if (!s) return {}
+  const profile = storeRef ? getActiveProfile(storeRef) : null
   return {
     poeVersion: s.poeVersion,
-    league: s.league,
+    league: profile?.league ?? '',
     updateChannel: s.updateChannel,
     developerMode: s.developerMode,
-    filterConfigured: Boolean(s.filterPath),
-    filterDirConfigured: Boolean(s.filterDir),
+    filterConfigured: Boolean(profile?.filterPath),
+    filterDirConfigured: Boolean(profile?.filterDir),
     closeOnClickOutside: s.closeOnClickOutside,
     overlayScale: s.overlayScale,
     openSide: s.openSide,
     stashScrollEnabled: s.stashScrollEnabled,
-    cheatSheetsCategories: s.cheatSheets?.categories?.length ?? 0,
+    cheatSheetsCategories: profile?.cheatSheets?.categories?.length ?? 0,
   }
 }
 

--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -7,7 +7,7 @@ import type { BugReportResult, RendererDiagnosticPayload, SerializedDiagnosticEr
 import { serializeDiagnosticError } from '../shared/diagnostics'
 import { DISCORD_INVITE_URL, GITHUB_NEW_ISSUE_URL } from '../shared/endpoints'
 import type { AppSettings } from '../shared/types'
-import { getActiveProfile } from './profile-settings'
+import { getActiveProfile } from './profiles/profile-settings'
 
 // Tail of the log embedded in a generated bug report.
 const MAX_LOG_BYTES = 256 * 1024

--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -45,13 +45,18 @@ function redact(text: string): string {
   } catch {
     // app paths may be unavailable during early process errors.
   }
-  const settings = storeRef?.store
-  const legacyStore = storeRef as unknown as Store<AppSettings & import('../shared/types').LegacyAppSettings> | null
+  const _settings = storeRef?.store
+  const legacyData = ((storeRef as unknown as { store: Record<string, unknown> } | null)?.store ?? {}) as Record<
+    string,
+    unknown
+  >
   for (const value of [
-    legacyStore?.get('filterPathPoe1'),
-    legacyStore?.get('filterPathPoe2'),
-    legacyStore?.get('filterDirPoe1'),
-    legacyStore?.get('filterDirPoe2'),
+    legacyData['filterPathPoe1'],
+    legacyData['filterPathPoe2'],
+    legacyData['filterDirPoe1'],
+    legacyData['filterDirPoe2'],
+    legacyData['filterPath'],
+    legacyData['filterDir'],
   ]) {
     if (typeof value === 'string' && value.length > 0) out = out.split(value).join('<path>')
   }

--- a/src/main/evaluation.ts
+++ b/src/main/evaluation.ts
@@ -13,6 +13,7 @@ import type {
 } from '../shared/types'
 import { getCurrentZone } from './client-log'
 import { snapshotClipboard } from './clipboard-preserve'
+import { getProfileBackedSetting } from './profile-settings'
 import {
   evaluateBlock,
   findMatchingBlocks,
@@ -208,7 +209,7 @@ export function evaluateAndSend(item: PoeItem): void {
 // ---- Preload price check ---------------------------------------------------
 
 export async function preloadPriceCheck(item: PoeItem, store: Store<AppSettings>): Promise<void> {
-  const league = store.get('league')
+  const league = getProfileBackedSetting(store, 'league')
   await refreshPrices(league)
   const priceInfo =
     item.rarity === 'Unique'

--- a/src/main/evaluation.ts
+++ b/src/main/evaluation.ts
@@ -13,7 +13,7 @@ import type {
 } from '../shared/types'
 import { getCurrentZone } from './client-log'
 import { snapshotClipboard } from './clipboard-preserve'
-import { getProfileBackedSetting } from './profile-settings'
+import { getProfileBackedSetting } from './profiles/profile-settings'
 import {
   evaluateBlock,
   findMatchingBlocks,

--- a/src/main/filter-state.test.ts
+++ b/src/main/filter-state.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const MOCK_USER_DATA = vi.hoisted(() => `${process.env.TEMP ?? process.cwd()}\\scalpel-filter-state-${Date.now()}`)
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => MOCK_USER_DATA) },
+}))
+
+import { getIntents, record } from './filter/intent-recorder'
+import { __hasKnownBaseTypeForTest } from './trade/clipboard'
+import { clearFilterState, getColorFrequencies, getCurrentFilter, loadFilter } from './filter-state'
+
+function writeFilter(content: string): string {
+  const path = join(mkdtempSync(join(tmpdir(), 'scalpel-filter-')), 'test.filter')
+  writeFileSync(path, content, 'utf-8')
+  return path
+}
+
+const filterContent = `#name: Test Filter
+Show
+  BaseType "Zzz Scalpel Test Base"
+  SetTextColor 255 0 0 255
+`
+
+describe('filter-state', () => {
+  beforeEach(() => {
+    clearFilterState()
+  })
+
+  it('clears loaded filter resources when loading an empty path', () => {
+    const path = writeFilter(filterContent)
+    expect(loadFilter(path)).not.toBeNull()
+    expect(getCurrentFilter()).not.toBeNull()
+    expect(getColorFrequencies().SetTextColor).toHaveLength(1)
+    expect(__hasKnownBaseTypeForTest('Zzz Scalpel Test Base')).toBe(true)
+
+    record({
+      type: 'set-visibility',
+      target: { typePath: 'currency', tier: 't1' },
+      payload: { visibility: 'Hide' },
+      timestamp: 1,
+    })
+    expect(getIntents().intents).toHaveLength(1)
+
+    expect(loadFilter('')).toBeNull()
+
+    expect(getCurrentFilter()).toBeNull()
+    expect(getColorFrequencies()).toEqual({})
+    expect(getIntents().intents).toEqual([])
+    expect(__hasKnownBaseTypeForTest('Zzz Scalpel Test Base')).toBe(false)
+  })
+
+  it('clears stale filter state after a failed load', () => {
+    const path = writeFilter(filterContent)
+    expect(loadFilter(path)).not.toBeNull()
+    expect(getCurrentFilter()?.path).toBe(path)
+
+    expect(loadFilter(join(tmpdir(), 'missing-scalpel-filter.filter'))).toBeNull()
+
+    expect(getCurrentFilter()).toBeNull()
+    expect(getColorFrequencies()).toEqual({})
+    expect(__hasKnownBaseTypeForTest('Zzz Scalpel Test Base')).toBe(false)
+  })
+})

--- a/src/main/filter-state.ts
+++ b/src/main/filter-state.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs'
 import type { FilterFile } from '../shared/types'
-import { loadIntents } from './filter/intent-recorder'
+import { loadIntents, resetIntents } from './filter/intent-recorder'
 import { parseFilterFile } from './filter/parser'
-import { registerFilterBaseTypes } from './trade/clipboard'
+import { clearFilterBaseTypes, registerFilterBaseTypes } from './trade/clipboard'
 import { saveVersion } from './update/versions'
 
 // ---- In-memory filter state ------------------------------------------------
@@ -15,6 +15,14 @@ export function getCurrentFilter(): FilterFile | null {
 
 export function setCurrentFilter(filter: FilterFile | null): void {
   currentFilter = filter
+  for (const cb of filterLoadedCallbacks) cb()
+}
+
+export function clearFilterState(): void {
+  currentFilter = null
+  colorFreqCache = null
+  resetIntents()
+  clearFilterBaseTypes()
   for (const cb of filterLoadedCallbacks) cb()
 }
 
@@ -151,9 +159,15 @@ export function getColorFrequencies(): ColorFreqMap {
 // ---- Filter loading --------------------------------------------------------
 
 export function loadFilter(path: string, autoVersionLabel?: string): FilterFile | null {
+  if (!path) {
+    clearFilterState()
+    return null
+  }
+
   try {
     const content = readFileSync(path, 'utf-8')
     currentFilter = parseFilterFile(path, content)
+    colorFreqCache = null
     for (const cb of filterLoadedCallbacks) cb()
     // Load intent log for this filter
     const filterName =
@@ -174,6 +188,7 @@ export function loadFilter(path: string, autoVersionLabel?: string): FilterFile 
     return currentFilter
   } catch (err) {
     console.error('[FilterScalpel] Failed to load filter:', err)
+    clearFilterState()
     return null
   }
 }

--- a/src/main/filter/intent-recorder.ts
+++ b/src/main/filter/intent-recorder.ts
@@ -51,6 +51,11 @@ export function clearIntents(): void {
   persist()
 }
 
+export function resetIntents(): void {
+  currentFilterPath = null
+  currentLog = { filterName: '', intents: [] }
+}
+
 export function hasIntentLog(filterPath: string): boolean {
   return existsSync(getIntentFilePath(filterPath))
 }

--- a/src/main/game-detector.ts
+++ b/src/main/game-detector.ts
@@ -10,7 +10,9 @@ async function getActiveWindow(): Promise<ActiveWindowFn> {
   return activeWindow
 }
 
-const TITLE_TO_VERSION: Record<string, 1 | 2> = {
+import type { GameVariant } from '../shared/types'
+
+const TITLE_TO_VERSION: Record<string, GameVariant> = {
   'Path of Exile': 1,
   'Path of Exile 2': 2,
 }
@@ -18,7 +20,7 @@ const TITLE_TO_VERSION: Record<string, 1 | 2> = {
 /** Returns the PoE version of whichever window currently has OS foreground focus,
  *  or null if it's not a PoE window (or the OS lookup failed). Called on hotkey
  *  fire to decide whether we need to swap which game the overlay is attached to. */
-export async function detectFocusedPoeVersion(): Promise<1 | 2 | null> {
+export async function detectFocusedPoeVersion(): Promise<GameVariant | null> {
   try {
     const fn = await getActiveWindow()
     const win = await fn()

--- a/src/main/game-state.ts
+++ b/src/main/game-state.ts
@@ -8,12 +8,14 @@
  *  Exposed via a getter (instead of a `let`-export) so consumers can never
  *  cache the value at import time -- every read goes through the function and
  *  reflects the current state, not whatever was set when the module loaded. */
-let _poeVersion: 1 | 2 = 1
+import type { GameVariant } from '../shared/types'
 
-export function getPoeVersion(): 1 | 2 {
+let _poeVersion: GameVariant = 1
+
+export function getPoeVersion(): GameVariant {
   return _poeVersion
 }
 
-export function setPoeVersion(v: 1 | 2): void {
+export function setPoeVersion(v: GameVariant): void {
   _poeVersion = v
 }

--- a/src/main/game-switch.ts
+++ b/src/main/game-switch.ts
@@ -1,7 +1,8 @@
 import { app, ipcMain } from 'electron'
 import type Store from 'electron-store'
-import type { AppSettings } from '../shared/types'
+import type { AppSettings, GameVariant } from '../shared/types'
 import { getAppWindow, showAppWindow } from './app-window'
+import { applySetting } from './settings-write'
 
 // Only one prompt may be in-flight. Extra calls while a prompt is open are
 // ignored (requestGameSwitch returns immediately) so we never stack modals.
@@ -18,7 +19,7 @@ ipcMain.on('game-switch-response', (_event, choice: 'restart' | 'cancel') => {
  *  and a future hotkey press will re-prompt. The caller shouldn't await this --
  *  the current hotkey press is always swallowed because the overlay isn't attached
  *  to the right game yet, and the response may take seconds of user-think-time. */
-export async function requestGameSwitch(store: Store<AppSettings>, target: 1 | 2): Promise<void> {
+export async function requestGameSwitch(store: Store<AppSettings>, target: GameVariant): Promise<void> {
   if (pending) return
   const win = getAppWindow()
   if (!win) return
@@ -30,12 +31,12 @@ export async function requestGameSwitch(store: Store<AppSettings>, target: 1 | 2
   })
 
   if (choice !== 'restart') return
-  store.set('poeVersion', target)
+  applySetting(store, 'poeVersion', target, null)
   if (!app.isPackaged) {
     // electron-vite dev won't come back after app.quit(); persist the version and
     // log so it's obvious the user needs to restart `npm run dev` manually. Full
     // relaunch flow runs in packaged builds.
-    console.warn(`[game-switch] target=PoE${target}; restart dev to re-attach`)
+    console.warn(`[game-switch] target=${target}; restart dev to re-attach`)
     return
   }
   app.relaunch()

--- a/src/main/handlers/editing.ts
+++ b/src/main/handlers/editing.ts
@@ -13,6 +13,7 @@ import {
 import { getCurrentFilter, loadFilter } from '../filter-state'
 import { captureSnapshot } from '../history'
 import { reloadFilterInGame } from '../overlay'
+import { getProfileBackedSetting } from '../profile-settings'
 
 // ---- History description helpers -------------------------------------------
 
@@ -141,7 +142,7 @@ export function register(store: Store<AppSettings>): void {
       }
       writeBlockEdit(currentFilter, blockIndex, updatedBlock)
       // Reload to get fresh parsed state
-      const path = store.get('filterPath')
+      const path = getProfileBackedSetting(store, 'filterPath')
       if (path) loadFilter(path)
 
       // Re-evaluate and send fresh overlay data
@@ -178,7 +179,7 @@ export function register(store: Store<AppSettings>): void {
         }
         moveBaseTypeBetweenTiers(currentFilter, baseType, fromBlockIndex, toBlockIndex)
         // Reload to get fresh parsed state
-        const path = store.get('filterPath')
+        const path = getProfileBackedSetting(store, 'filterPath')
         if (path) loadFilter(path)
 
         // Re-evaluate the item against the updated filter and send fresh data
@@ -224,7 +225,7 @@ export function register(store: Store<AppSettings>): void {
           }
           moveBaseTypeBetweenTiers(currentFilter, bt, fromBlockIndex, toBlockIndex)
         }
-        const path = store.get('filterPath')
+        const path = getProfileBackedSetting(store, 'filterPath')
         if (path) loadFilter(path)
 
         const freshFilter = getCurrentFilter()
@@ -278,7 +279,7 @@ export function register(store: Store<AppSettings>): void {
       }
       updateStackThresholds(currentFilter, oldBoundary, newBoundary)
       // Reload to get fresh parsed state
-      const path = store.get('filterPath')
+      const path = getProfileBackedSetting(store, 'filterPath')
       if (path) loadFilter(path)
 
       // Re-evaluate and send fresh data
@@ -325,7 +326,7 @@ export function register(store: Store<AppSettings>): void {
         }
       }
       updateQualityThresholds(currentFilter, oldBoundary, newBoundary)
-      const path = store.get('filterPath')
+      const path = getProfileBackedSetting(store, 'filterPath')
       if (path) loadFilter(path)
       const freshFilter = getCurrentFilter()
       if (freshFilter && item) {
@@ -368,7 +369,7 @@ export function register(store: Store<AppSettings>): void {
         }
       }
       updateStrandThresholds(currentFilter, oldBoundary, newBoundary)
-      const path = store.get('filterPath')
+      const path = getProfileBackedSetting(store, 'filterPath')
       if (path) loadFilter(path)
       const freshFilter = getCurrentFilter()
       if (freshFilter && item) evaluateAndSend(item)
@@ -380,7 +381,7 @@ export function register(store: Store<AppSettings>): void {
   })
 
   ipcMain.handle('reload-filter', () => {
-    const path = store.get('filterPath')
+    const path = getProfileBackedSetting(store, 'filterPath')
     if (!path) return { ok: false, error: 'No filter path set' }
     return { ok: !!loadFilter(path) }
   })

--- a/src/main/handlers/editing.ts
+++ b/src/main/handlers/editing.ts
@@ -13,7 +13,7 @@ import {
 import { getCurrentFilter, loadFilter } from '../filter-state'
 import { captureSnapshot } from '../history'
 import { reloadFilterInGame } from '../overlay'
-import { getProfileBackedSetting } from '../profile-settings'
+import { getProfileBackedSetting } from '../profiles/profile-settings'
 
 // ---- History description helpers -------------------------------------------
 

--- a/src/main/handlers/files.ts
+++ b/src/main/handlers/files.ts
@@ -4,10 +4,7 @@ import { BrowserWindow, dialog, ipcMain } from 'electron'
 import type Store from 'electron-store'
 import type { AppSettings, FilterListEntry } from '../../shared/types'
 import { getAppWindow } from '../app-window'
-import { clearFilterState, loadFilter } from '../filter-state'
-import { updateOnlineSyncDir } from '../online-sync'
 import { setCloseOnClickOutside, showOverlay } from '../overlay'
-import { applyProfileBackedSetting } from '../settings-write'
 
 export function register(store: Store<AppSettings>): void {
   const defaultFilterFolderForActiveGame = (): string => {
@@ -43,10 +40,6 @@ export function register(store: Store<AppSettings>): void {
     }
 
     const path = result.filePaths[0]
-    if (path) loadFilter(path, 'Switched Filters')
-    else clearFilterState()
-    applyProfileBackedSetting(store, 'filterPath', path, event.sender)
-
     if (isOverlay) showOverlay()
     return path
   })
@@ -75,8 +68,6 @@ export function register(store: Store<AppSettings>): void {
     // folder that contains it. Walk back up so we scan the parent regardless.
     let dir = result.filePaths[0]
     if (basename(dir).toLowerCase() === 'onlinefilters') dir = dirname(dir)
-    updateOnlineSyncDir(dir)
-    applyProfileBackedSetting(store, 'filterDir', dir, event.sender)
     if (isOverlay) showOverlay()
     return dir
   })

--- a/src/main/handlers/files.ts
+++ b/src/main/handlers/files.ts
@@ -4,9 +4,10 @@ import { BrowserWindow, dialog, ipcMain } from 'electron'
 import type Store from 'electron-store'
 import type { AppSettings, FilterListEntry } from '../../shared/types'
 import { getAppWindow } from '../app-window'
+import { clearFilterState, loadFilter } from '../filter-state'
 import { updateOnlineSyncDir } from '../online-sync'
 import { setCloseOnClickOutside, showOverlay } from '../overlay'
-import { applySetting } from '../settings-write'
+import { applySetting, applyProfileBackedSetting } from '../settings-write'
 
 export function register(store: Store<AppSettings>): void {
   const defaultFilterFolderForActiveGame = (): string => {
@@ -42,7 +43,7 @@ export function register(store: Store<AppSettings>): void {
     }
 
     const path = result.filePaths[0]
-    applySetting(store, 'filterPath', path, event.sender)
+    applyProfileBackedSetting(store, 'filterPath', path, event.sender, (p) => { if (p) loadFilter(p, 'Switched Filters'); else clearFilterState() })
 
     if (isOverlay) showOverlay()
     return path
@@ -72,8 +73,7 @@ export function register(store: Store<AppSettings>): void {
     // folder that contains it. Walk back up so we scan the parent regardless.
     let dir = result.filePaths[0]
     if (basename(dir).toLowerCase() === 'onlinefilters') dir = dirname(dir)
-    applySetting(store, 'filterDir', dir, event.sender)
-    updateOnlineSyncDir(dir)
+    applyProfileBackedSetting(store, 'filterDir', dir, event.sender, undefined, updateOnlineSyncDir)
     if (isOverlay) showOverlay()
     return dir
   })

--- a/src/main/handlers/files.ts
+++ b/src/main/handlers/files.ts
@@ -7,7 +7,7 @@ import { getAppWindow } from '../app-window'
 import { clearFilterState, loadFilter } from '../filter-state'
 import { updateOnlineSyncDir } from '../online-sync'
 import { setCloseOnClickOutside, showOverlay } from '../overlay'
-import { applySetting, applyProfileBackedSetting } from '../settings-write'
+import { applyProfileBackedSetting } from '../settings-write'
 
 export function register(store: Store<AppSettings>): void {
   const defaultFilterFolderForActiveGame = (): string => {
@@ -43,7 +43,9 @@ export function register(store: Store<AppSettings>): void {
     }
 
     const path = result.filePaths[0]
-    applyProfileBackedSetting(store, 'filterPath', path, event.sender, (p) => { if (p) loadFilter(p, 'Switched Filters'); else clearFilterState() })
+    if (path) loadFilter(path, 'Switched Filters')
+    else clearFilterState()
+    applyProfileBackedSetting(store, 'filterPath', path, event.sender)
 
     if (isOverlay) showOverlay()
     return path
@@ -73,7 +75,8 @@ export function register(store: Store<AppSettings>): void {
     // folder that contains it. Walk back up so we scan the parent regardless.
     let dir = result.filePaths[0]
     if (basename(dir).toLowerCase() === 'onlinefilters') dir = dirname(dir)
-    applyProfileBackedSetting(store, 'filterDir', dir, event.sender, undefined, updateOnlineSyncDir)
+    updateOnlineSyncDir(dir)
+    applyProfileBackedSetting(store, 'filterDir', dir, event.sender)
     if (isOverlay) showOverlay()
     return dir
   })

--- a/src/main/handlers/online-sync.ts
+++ b/src/main/handlers/online-sync.ts
@@ -11,7 +11,6 @@ import { loadFilter } from '../filter-state'
 import { switchFilterInGame } from '../overlay'
 import { saveVersion } from '../update/versions'
 import { checkOnlineSyncNow } from '../online-sync'
-import { applyProfileBackedSetting } from '../settings-write'
 import { getProfileBackedSetting } from '../profile-settings'
 
 /** Look up the online filter name and path for the currently active local filter */
@@ -82,8 +81,6 @@ export function register(store: Store<AppSettings>): void {
         writeFileSync(targetPath, content, 'utf-8')
         clearIntents()
         // Set as active filter
-        loadFilter(targetPath, 'Online Filter Imported')
-        applyProfileBackedSetting(store, 'filterPath', targetPath, null)
         return { ok: true, path: targetPath }
       } catch (err) {
         return { ok: false, error: String(err) }

--- a/src/main/handlers/online-sync.ts
+++ b/src/main/handlers/online-sync.ts
@@ -11,7 +11,7 @@ import { loadFilter } from '../filter-state'
 import { switchFilterInGame } from '../overlay'
 import { saveVersion } from '../update/versions'
 import { checkOnlineSyncNow } from '../online-sync'
-import { getProfileBackedSetting } from '../profile-settings'
+import { getProfileBackedSetting } from '../profiles/profile-settings'
 
 /** Look up the online filter name and path for the currently active local filter */
 function findOnlineFilter(

--- a/src/main/handlers/online-sync.ts
+++ b/src/main/handlers/online-sync.ts
@@ -8,9 +8,10 @@ import { clearIntents, getIntents } from '../filter/intent-recorder'
 import { replayIntents } from '../filter/intent-replay'
 import { writeFilterSelective } from '../filter/writer'
 import { loadFilter } from '../filter-state'
-import { checkOnlineSyncNow } from '../online-sync'
 import { switchFilterInGame } from '../overlay'
 import { saveVersion } from '../update/versions'
+import { checkOnlineSyncNow } from '../online-sync'
+import { applySetting } from '../settings-write'
 
 /** Look up the online filter name and path for the currently active local filter */
 function findOnlineFilter(
@@ -79,9 +80,8 @@ export function register(store: Store<AppSettings>): void {
         content = content.replace(/^#name:.+$/m, `#name: ${localName}`)
         writeFileSync(targetPath, content, 'utf-8')
         clearIntents()
-        // Set as active filter
-        store.set('filterPath', targetPath)
-        loadFilter(targetPath, 'Online Filter Imported')
+        // Set as active filter (applySetting mirrors + writes to active profile)
+        applySetting(store, 'filterPath', targetPath, null)
         return { ok: true, path: targetPath }
       } catch (err) {
         return { ok: false, error: String(err) }

--- a/src/main/handlers/online-sync.ts
+++ b/src/main/handlers/online-sync.ts
@@ -11,14 +11,15 @@ import { loadFilter } from '../filter-state'
 import { switchFilterInGame } from '../overlay'
 import { saveVersion } from '../update/versions'
 import { checkOnlineSyncNow } from '../online-sync'
-import { applySetting } from '../settings-write'
+import { applySetting, applyProfileBackedSetting } from '../settings-write'
+import { getProfileBackedSetting } from '../profile-settings'
 
 /** Look up the online filter name and path for the currently active local filter */
 function findOnlineFilter(
   store: Store<AppSettings>,
 ): { onlineFilterName: string; onlineFilePath: string; localFileName: string; localPath: string } | { error: string } {
-  const filterDir = store.get('filterDir') as string
-  const filterPath = store.get('filterPath') as string
+  const filterDir = getProfileBackedSetting(store, 'filterDir') as string
+  const filterPath = getProfileBackedSetting(store, 'filterPath') as string
   if (!filterDir || !filterPath) return { error: 'No filter configured' }
 
   const localFileName = basename(filterPath, '.filter')
@@ -80,8 +81,8 @@ export function register(store: Store<AppSettings>): void {
         content = content.replace(/^#name:.+$/m, `#name: ${localName}`)
         writeFileSync(targetPath, content, 'utf-8')
         clearIntents()
-        // Set as active filter (applySetting mirrors + writes to active profile)
-        applySetting(store, 'filterPath', targetPath, null)
+        // Set as active filter
+        applyProfileBackedSetting(store, 'filterPath', targetPath, null, (p) => { if (p) loadFilter(p, 'Online Filter Imported') })
         return { ok: true, path: targetPath }
       } catch (err) {
         return { ok: false, error: String(err) }
@@ -139,7 +140,7 @@ export function register(store: Store<AppSettings>): void {
         saveBaseline(info.onlineFilterName, upstreamContent, info.onlineFilePath, info.localPath)
         saveVersion(info.localPath, false, 'Online Filter Merged')
 
-        const currentPath = store.get('filterPath')
+        const currentPath = getProfileBackedSetting(store, 'filterPath')
         if (currentPath === info.localPath) {
           loadFilter(info.localPath, 'Online Filter Merged')
         }
@@ -185,7 +186,7 @@ export function register(store: Store<AppSettings>): void {
         if (intentLog.intents.length === 0) {
           // No intents - overwrite with upstream
           writeFileSync(localPath, upstreamContent, 'utf-8')
-          const currentPath = store.get('filterPath')
+          const currentPath = getProfileBackedSetting(store, 'filterPath')
           if (currentPath === localPath) loadFilter(localPath, 'Online Filter Updated')
           return { ok: true, stats: { applied: 0, skipped: 0, conflicts: 0 } }
         }
@@ -212,7 +213,7 @@ export function register(store: Store<AppSettings>): void {
 
         saveVersion(localPath, false, 'Online Filter Merged')
 
-        const currentPath = store.get('filterPath')
+        const currentPath = getProfileBackedSetting(store, 'filterPath')
         if (currentPath === localPath) loadFilter(localPath, 'Online Filter Merged')
 
         return { ok: true, stats: result.stats }

--- a/src/main/handlers/online-sync.ts
+++ b/src/main/handlers/online-sync.ts
@@ -11,7 +11,7 @@ import { loadFilter } from '../filter-state'
 import { switchFilterInGame } from '../overlay'
 import { saveVersion } from '../update/versions'
 import { checkOnlineSyncNow } from '../online-sync'
-import { applySetting, applyProfileBackedSetting } from '../settings-write'
+import { applyProfileBackedSetting } from '../settings-write'
 import { getProfileBackedSetting } from '../profile-settings'
 
 /** Look up the online filter name and path for the currently active local filter */
@@ -82,7 +82,8 @@ export function register(store: Store<AppSettings>): void {
         writeFileSync(targetPath, content, 'utf-8')
         clearIntents()
         // Set as active filter
-        applyProfileBackedSetting(store, 'filterPath', targetPath, null, (p) => { if (p) loadFilter(p, 'Online Filter Imported') })
+        loadFilter(targetPath, 'Online Filter Imported')
+        applyProfileBackedSetting(store, 'filterPath', targetPath, null)
         return { ok: true, path: targetPath }
       } catch (err) {
         return { ok: false, error: String(err) }

--- a/src/main/handlers/prices.ts
+++ b/src/main/handlers/prices.ts
@@ -10,6 +10,7 @@ import { evaluateAndSend, preloadPriceCheck, runPriceCheck } from '../evaluation
 import { findMatchingBlocks } from '../filter/matcher'
 import { getCurrentFilter, onFilterLoaded } from '../filter-state'
 import { getPoeVersion } from '../game-state'
+import { getProfileBackedSetting } from '../profile-settings'
 import { loadIconCache } from '../trade/icon-cache'
 import {
   getGemNames,
@@ -250,7 +251,7 @@ function collectStackables(filter: FilterFile): SearchableItem[] {
 }
 
 export async function buildSearchableItems(store: Store<AppSettings>, filter: FilterFile): Promise<SearchableItem[]> {
-  await refreshPrices(store.get('league'))
+  await refreshPrices(getProfileBackedSetting(store, 'league'))
   return [...collectStackables(filter), ...collectUniques(filter), ...collectMaps(filter), ...collectGems(filter)]
 }
 

--- a/src/main/handlers/prices.ts
+++ b/src/main/handlers/prices.ts
@@ -10,7 +10,7 @@ import { evaluateAndSend, preloadPriceCheck, runPriceCheck } from '../evaluation
 import { findMatchingBlocks } from '../filter/matcher'
 import { getCurrentFilter, onFilterLoaded } from '../filter-state'
 import { getPoeVersion } from '../game-state'
-import { getProfileBackedSetting } from '../profile-settings'
+import { getProfileBackedSetting } from '../profiles/profile-settings'
 import { loadIconCache } from '../trade/icon-cache'
 import {
   getGemNames,

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -10,7 +10,7 @@ import {
   deleteProfileAndChooseFallback,
   listProfileSummaries,
   renameProfile,
-  writeRegexPresetsByGameVariant,
+  writeActiveRegexPresetsByGameVariant,
 } from '../profile-settings'
 import type { AppSettings, GameVariant, RegexPreset } from '../../shared/types'
 import { applySetting, broadcastSettingUpdate } from '../settings-write'
@@ -110,7 +110,7 @@ export function register(store: Store<AppSettings>): void {
       presets.push(preset)
     }
     const variant: 1 | 2 = key === 'regexPresetsPoe2' ? 2 : 1
-    writeRegexPresetsByGameVariant(store, variant, presets)
+    writeActiveRegexPresetsByGameVariant(store, variant, presets)
     return presets
   })
 
@@ -119,7 +119,7 @@ export function register(store: Store<AppSettings>): void {
     const presets = store.get(key) ?? []
     const filtered = presets.filter((p) => p.id !== id)
     const variant: 1 | 2 = key === 'regexPresetsPoe2' ? 2 : 1
-    writeRegexPresetsByGameVariant(store, variant, filtered)
+    writeActiveRegexPresetsByGameVariant(store, variant, filtered)
     return filtered
   })
 
@@ -129,7 +129,7 @@ export function register(store: Store<AppSettings>): void {
     const byId = new Map(presets.map((p) => [p.id, p]))
     const reordered = ids.map((id) => byId.get(id)).filter(Boolean) as RegexPreset[]
     const variant: 1 | 2 = key === 'regexPresetsPoe2' ? 2 : 1
-    writeRegexPresetsByGameVariant(store, variant, reordered)
+    writeActiveRegexPresetsByGameVariant(store, variant, reordered)
     return reordered
   })
 }

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -11,14 +11,13 @@ import {
   getEffectiveSettings,
   getProfileBackedSetting,
   getProfileById,
-  isProfileBackedKey,
   listProfileSummaries,
   persistProfileSwitchForRestart,
   renameProfile,
   writeActiveRegexPresetsByGameVariant,
   writeLastUsedProfileSettingByGameVariant,
-  type ProfileBackedKey,
-  type ProfileBackedValue,
+  type ProfileSettingKey,
+  type ProfileSettingValue,
 } from '../profile-settings'
 
 export function register(store: Store<AppSettings>): void {
@@ -41,12 +40,10 @@ export function register(store: Store<AppSettings>): void {
 
   ipcMain.handle(
     'set-profile-setting-for-game',
-    (event, variant: GameVariant, key: ProfileBackedKey, value: ProfileBackedValue) => {
-      const previous = getEffectiveSettings(store)
+    (event, variant: GameVariant, key: ProfileSettingKey, value: ProfileSettingValue<typeof key>) => {
       const changes = writeLastUsedProfileSettingByGameVariant(store, variant, key, value)
-      applyProfileHydrationSideEffects(changes, previous)
-      for (const change of changes) {
-        broadcastSettingUpdate(event.sender, change.key, change.value)
+      if (changes.length > 0) {
+        broadcastSettingUpdate(event.sender, 'activeProfile', getEffectiveSettings(store).activeProfile)
       }
       return getEffectiveSettings(store)
     },
@@ -57,7 +54,7 @@ export function register(store: Store<AppSettings>): void {
   ipcMain.handle(
     'create-profile',
     (_event, input: { name: string; gameVariant: GameVariant; cloneFromId?: string }) => {
-      const profile = createProfile(store, input)
+      const profile = createProfile(input)
       return listProfileSummaries(store).find((summary) => summary.id === profile.id)!
     },
   )
@@ -68,7 +65,7 @@ export function register(store: Store<AppSettings>): void {
   })
 
   ipcMain.handle('duplicate-profile', (_event, id: string, name: string) => {
-    const profile = createProfile(store, { name, gameVariant: 1, cloneFromId: id })
+    const profile = createProfile({ name, gameVariant: 1, cloneFromId: id })
     return listProfileSummaries(store).find((summary) => summary.id === profile.id)!
   })
 
@@ -109,11 +106,7 @@ export function register(store: Store<AppSettings>): void {
     const changed = await refreshLeagues(store)
     const settings = getEffectiveSettings(store)
     for (const key of changed) {
-      if (isProfileBackedKey(key)) {
-        broadcastSettingUpdate(event.sender, key, getProfileBackedSetting(store, key))
-      } else {
-        broadcastSettingUpdate(event.sender, key, settings[key])
-      }
+      broadcastSettingUpdate(event.sender, key, settings[key])
     }
     return {
       leaguesPoe1: store.get('leaguesPoe1'),

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -8,20 +8,26 @@ import { applyProfileHydrationSideEffects, applySetting, broadcastSettingUpdate 
 import {
   createProfile,
   deleteProfileAndChooseFallback,
+  getEffectiveSettings,
+  getProfileBackedSetting,
   getProfileById,
+  isProfileBackedKey,
   listProfileSummaries,
   persistProfileSwitchForRestart,
   renameProfile,
   writeActiveRegexPresetsByGameVariant,
+  writeLastUsedProfileSettingByGameVariant,
+  type ProfileBackedKey,
+  type ProfileBackedValue,
 } from '../profile-settings'
 
 export function register(store: Store<AppSettings>): void {
-  ipcMain.handle('get-settings', () => store.store)
+  ipcMain.handle('get-settings', () => getEffectiveSettings(store))
 
   ipcMain.handle('get-color-frequencies', () => getColorFrequencies())
 
   ipcMain.handle('refresh-prices', async () => {
-    await refreshPrices(store.get('league'))
+    await refreshPrices(getProfileBackedSetting(store, 'league'))
   })
 
   ipcMain.handle('set-setting', (event, key: keyof AppSettings, value: AppSettings[typeof key]) => {
@@ -32,6 +38,19 @@ export function register(store: Store<AppSettings>): void {
     // adds a relaunch prompt; this IPC is the lower-level write.
     applySetting(store, key, value, event.sender)
   })
+
+  ipcMain.handle(
+    'set-profile-setting-for-game',
+    (event, variant: GameVariant, key: ProfileBackedKey, value: ProfileBackedValue) => {
+      const previous = getEffectiveSettings(store)
+      const changes = writeLastUsedProfileSettingByGameVariant(store, variant, key, value)
+      applyProfileHydrationSideEffects(changes, previous)
+      for (const change of changes) {
+        broadcastSettingUpdate(event.sender, change.key, change.value)
+      }
+      return getEffectiveSettings(store)
+    },
+  )
 
   ipcMain.handle('list-profiles', () => listProfileSummaries(store))
 
@@ -54,13 +73,7 @@ export function register(store: Store<AppSettings>): void {
   })
 
   ipcMain.handle('delete-profile', (event, id: string) => {
-    const previous = {
-      activeProfileId: store.get('activeProfileId'),
-      poeVersion: store.get('poeVersion'),
-      filterPath: store.get('filterPath'),
-      league: store.get('league'),
-      cheatSheets: store.get('cheatSheets'),
-    }
+    const previous = getEffectiveSettings(store)
     const changes = deleteProfileAndChooseFallback(store, id)
     applyProfileHydrationSideEffects(changes, previous)
     for (const change of changes) {
@@ -89,20 +102,22 @@ export function register(store: Store<AppSettings>): void {
     }
 
     applySetting(store, 'activeProfileId', id, event.sender)
-    return { ok: true as const, settings: store.store }
+    return { ok: true as const, settings: getEffectiveSettings(store) }
   })
 
   ipcMain.handle('refresh-leagues', async (event) => {
     const changed = await refreshLeagues(store)
+    const settings = getEffectiveSettings(store)
     for (const key of changed) {
-      broadcastSettingUpdate(event.sender, key, store.get(key))
+      if (isProfileBackedKey(key)) {
+        broadcastSettingUpdate(event.sender, key, getProfileBackedSetting(store, key))
+      } else {
+        broadcastSettingUpdate(event.sender, key, settings[key])
+      }
     }
     return {
       leaguesPoe1: store.get('leaguesPoe1'),
       leaguesPoe2: store.get('leaguesPoe2'),
-      leaguePoe1: store.get('leaguePoe1'),
-      leaguePoe2: store.get('leaguePoe2'),
-      league: store.get('league'),
     }
   })
 

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -19,7 +19,7 @@ import {
   type ProfileChangedSetting,
   type ProfileSettingKey,
   type ProfileSettingValue,
-} from '../profile-settings'
+} from '../profiles/profile-settings'
 
 export function register(store: Store<AppSettings>): void {
   ipcMain.handle('get-settings', () => getEffectiveSettings(store))

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -4,7 +4,12 @@ import type { AppSettings, GameVariant, RegexPreset } from '../../shared/types'
 import { getColorFrequencies } from '../filter-state'
 import { refreshPrices } from '../trade/prices'
 import { refreshLeagues } from '../trade/leagues'
-import { applyProfileHydrationSideEffects, applySetting, broadcastSettingUpdates } from '../settings-write'
+import {
+  applyProfileHydrationSideEffects,
+  applyProfileSettingForGame,
+  applySetting,
+  broadcastSettingUpdates,
+} from '../settings-write'
 import {
   createProfile,
   deleteProfileAndChooseFallback,
@@ -15,7 +20,6 @@ import {
   persistProfileSwitchForRestart,
   renameProfile,
   writeActiveRegexPresetsByGameVariant,
-  writeLastUsedProfileSettingByGameVariant,
   type ProfileChangedSetting,
   type ProfileSettingKey,
   type ProfileSettingValue,
@@ -40,14 +44,8 @@ export function register(store: Store<AppSettings>): void {
 
   ipcMain.handle(
     'set-profile-setting-for-game',
-    (event, variant: GameVariant, key: ProfileSettingKey, value: ProfileSettingValue<typeof key>) => {
-      const previous = getEffectiveSettings(store)
-      const changes = writeLastUsedProfileSettingByGameVariant(store, variant, key, value)
-      if (changes.length > 0) {
-        broadcastSettingUpdates(event.sender, changes, previous, getEffectiveSettings(store))
-      }
-      return getEffectiveSettings(store)
-    },
+    (event, variant: GameVariant, key: ProfileSettingKey, value: ProfileSettingValue<typeof key>) =>
+      applyProfileSettingForGame(store, variant, key, value, event.sender),
   )
 
   ipcMain.handle('list-profiles', () => listProfileSummaries(store))

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -3,6 +3,7 @@ import type Store from 'electron-store'
 import type { AppSettings, RegexPreset } from '../../shared/types'
 import { getColorFrequencies } from '../filter-state'
 import { applySetting, broadcastSettingUpdate } from '../settings-write'
+import { writeRegexPresetsByGameVariant } from '../profile-settings'
 import { refreshLeagues } from '../trade/leagues'
 import { refreshPrices } from '../trade/prices'
 
@@ -57,7 +58,8 @@ export function register(store: Store<AppSettings>): void {
     } else {
       presets.push(preset)
     }
-    store.set(key, presets)
+    const variant: 1 | 2 = key === 'regexPresetsPoe2' ? 2 : 1
+    writeRegexPresetsByGameVariant(store, variant, presets)
     return presets
   })
 
@@ -65,7 +67,8 @@ export function register(store: Store<AppSettings>): void {
     const key = regexPresetsKey()
     const presets = store.get(key) ?? []
     const filtered = presets.filter((p) => p.id !== id)
-    store.set(key, filtered)
+    const variant: 1 | 2 = key === 'regexPresetsPoe2' ? 2 : 1
+    writeRegexPresetsByGameVariant(store, variant, filtered)
     return filtered
   })
 
@@ -74,7 +77,8 @@ export function register(store: Store<AppSettings>): void {
     const presets = store.get(key) ?? []
     const byId = new Map(presets.map((p) => [p.id, p]))
     const reordered = ids.map((id) => byId.get(id)).filter(Boolean) as RegexPreset[]
-    store.set(key, reordered)
+    const variant: 1 | 2 = key === 'regexPresetsPoe2' ? 2 : 1
+    writeRegexPresetsByGameVariant(store, variant, reordered)
     return reordered
   })
 }

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -1,6 +1,6 @@
 import { ipcMain } from 'electron'
 import type Store from 'electron-store'
-import type { AppSettings, RegexPreset } from '../../shared/types'
+import type { AppSettings, GameVariant, RegexPreset } from '../../shared/types'
 import { getColorFrequencies } from '../filter-state'
 import { refreshPrices } from '../trade/prices'
 import { refreshLeagues } from '../trade/leagues'
@@ -12,11 +12,6 @@ import {
   renameProfile,
   writeActiveRegexPresetsByGameVariant,
 } from '../profile-settings'
-import type { AppSettings, GameVariant, RegexPreset } from '../../shared/types'
-import { applySetting, broadcastSettingUpdate } from '../settings-write'
-import { writeRegexPresetsByGameVariant } from '../profile-settings'
-import { refreshLeagues } from '../trade/leagues'
-import { refreshPrices } from '../trade/prices'
 
 export function register(store: Store<AppSettings>): void {
   ipcMain.handle('get-settings', () => store.store)

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -87,11 +87,13 @@ export function register(store: Store<AppSettings>): void {
         return { ok: false as const, requiresRestart: true as const, targetGame: profile.gameVariant }
       }
 
-      persistProfileSwitchForRestart(store, profile)
       if (!app.isPackaged) {
+        applySetting(store, 'activeProfileId', id, event.sender)
         console.warn(`[profile-switch] target=PoE${profile.gameVariant}; restart dev to re-attach`)
-        return { ok: true as const, restarting: true as const, devRestartRequired: true as const }
+        return { ok: true as const, settings: getEffectiveSettings(store), devRestartRequired: true as const }
       }
+
+      persistProfileSwitchForRestart(store, profile)
       app.relaunch()
       app.quit()
       return { ok: true as const, restarting: true as const }

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
 import type Store from 'electron-store'
 import type { AppSettings, GameVariant, RegexPreset } from '../../shared/types'
 import { getColorFrequencies } from '../filter-state'
@@ -8,7 +8,9 @@ import { applyProfileHydrationSideEffects, applySetting, broadcastSettingUpdate 
 import {
   createProfile,
   deleteProfileAndChooseFallback,
+  getProfileById,
   listProfileSummaries,
+  persistProfileSwitchForRestart,
   renameProfile,
   writeActiveRegexPresetsByGameVariant,
 } from '../profile-settings'
@@ -66,9 +68,28 @@ export function register(store: Store<AppSettings>): void {
     }
   })
 
-  ipcMain.handle('set-active-profile', async (event, id: string) => {
+  ipcMain.handle('set-active-profile', async (event, id: string, restartIfNeeded = false) => {
+    const profile = getProfileById(id)
+    if (!profile) return { ok: false as const, error: 'Profile not found' }
+
+    const current = store.get('poeVersion') === 2 ? 2 : 1
+    if (profile.gameVariant !== current) {
+      if (!restartIfNeeded) {
+        return { ok: false as const, requiresRestart: true as const, targetGame: profile.gameVariant }
+      }
+
+      persistProfileSwitchForRestart(store, profile)
+      if (!app.isPackaged) {
+        console.warn(`[profile-switch] target=PoE${profile.gameVariant}; restart dev to re-attach`)
+        return { ok: true as const, restarting: true as const, devRestartRequired: true as const }
+      }
+      app.relaunch()
+      app.quit()
+      return { ok: true as const, restarting: true as const }
+    }
+
     applySetting(store, 'activeProfileId', id, event.sender)
-    return store.store
+    return { ok: true as const, settings: store.store }
   })
 
   ipcMain.handle('refresh-leagues', async (event) => {

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -4,7 +4,7 @@ import type { AppSettings, GameVariant, RegexPreset } from '../../shared/types'
 import { getColorFrequencies } from '../filter-state'
 import { refreshPrices } from '../trade/prices'
 import { refreshLeagues } from '../trade/leagues'
-import { applyProfileHydrationSideEffects, applySetting, broadcastSettingUpdate } from '../settings-write'
+import { applyProfileHydrationSideEffects, applySetting, broadcastSettingUpdates } from '../settings-write'
 import {
   createProfile,
   deleteProfileAndChooseFallback,
@@ -16,6 +16,7 @@ import {
   renameProfile,
   writeActiveRegexPresetsByGameVariant,
   writeLastUsedProfileSettingByGameVariant,
+  type ProfileChangedSetting,
   type ProfileSettingKey,
   type ProfileSettingValue,
 } from '../profile-settings'
@@ -31,8 +32,7 @@ export function register(store: Store<AppSettings>): void {
 
   ipcMain.handle('set-setting', (event, key: keyof AppSettings, value: AppSettings[typeof key]) => {
     // poeVersion writes are valid here: the onboarding flow uses them to switch
-    // active game between PoE1 and PoE2 setup steps, atomically writing the
-    // dependent flat fields (filterDir/filterPath/league) on either side.
+    // active game between PoE1 and PoE2 setup steps.
     // requestGameSwitch() in main/game-switch.ts is the user-facing toggle that
     // adds a relaunch prompt; this IPC is the lower-level write.
     applySetting(store, key, value, event.sender)
@@ -41,9 +41,10 @@ export function register(store: Store<AppSettings>): void {
   ipcMain.handle(
     'set-profile-setting-for-game',
     (event, variant: GameVariant, key: ProfileSettingKey, value: ProfileSettingValue<typeof key>) => {
+      const previous = getEffectiveSettings(store)
       const changes = writeLastUsedProfileSettingByGameVariant(store, variant, key, value)
       if (changes.length > 0) {
-        broadcastSettingUpdate(event.sender, 'activeProfile', getEffectiveSettings(store).activeProfile)
+        broadcastSettingUpdates(event.sender, changes, previous, getEffectiveSettings(store))
       }
       return getEffectiveSettings(store)
     },
@@ -73,9 +74,7 @@ export function register(store: Store<AppSettings>): void {
     const previous = getEffectiveSettings(store)
     const changes = deleteProfileAndChooseFallback(store, id)
     applyProfileHydrationSideEffects(changes, previous)
-    for (const change of changes) {
-      broadcastSettingUpdate(event.sender, change.key, change.value)
-    }
+    broadcastSettingUpdates(event.sender, changes, previous, getEffectiveSettings(store))
   })
 
   ipcMain.handle('set-active-profile', async (event, id: string, restartIfNeeded = false) => {
@@ -103,11 +102,14 @@ export function register(store: Store<AppSettings>): void {
   })
 
   ipcMain.handle('refresh-leagues', async (event) => {
+    const previous = getEffectiveSettings(store)
     const changed = await refreshLeagues(store)
     const settings = getEffectiveSettings(store)
-    for (const key of changed) {
-      broadcastSettingUpdate(event.sender, key, settings[key])
-    }
+    const changes: ProfileChangedSetting[] = changed.map((key) => {
+      if (key === 'activeProfile') return { key, value: settings.activeProfile, reason: 'migration' }
+      return { key, value: settings[key] } as ProfileChangedSetting
+    })
+    broadcastSettingUpdates(event.sender, changes, previous, settings)
     return {
       leaguesPoe1: store.get('leaguesPoe1'),
       leaguesPoe2: store.get('leaguesPoe2'),

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -2,6 +2,17 @@ import { ipcMain } from 'electron'
 import type Store from 'electron-store'
 import type { AppSettings, RegexPreset } from '../../shared/types'
 import { getColorFrequencies } from '../filter-state'
+import { refreshPrices } from '../trade/prices'
+import { refreshLeagues } from '../trade/leagues'
+import { applyProfileHydrationSideEffects, applySetting, broadcastSettingUpdate } from '../settings-write'
+import {
+  createProfile,
+  deleteProfileAndChooseFallback,
+  listProfileSummaries,
+  renameProfile,
+  writeRegexPresetsByGameVariant,
+} from '../profile-settings'
+import type { AppSettings, GameVariant, RegexPreset } from '../../shared/types'
 import { applySetting, broadcastSettingUpdate } from '../settings-write'
 import { writeRegexPresetsByGameVariant } from '../profile-settings'
 import { refreshLeagues } from '../trade/leagues'
@@ -23,6 +34,46 @@ export function register(store: Store<AppSettings>): void {
     // requestGameSwitch() in main/game-switch.ts is the user-facing toggle that
     // adds a relaunch prompt; this IPC is the lower-level write.
     applySetting(store, key, value, event.sender)
+  })
+
+  ipcMain.handle('list-profiles', () => listProfileSummaries(store))
+
+  ipcMain.handle(
+    'create-profile',
+    (_event, input: { name: string; gameVariant: GameVariant; cloneFromId?: string }) => {
+      const profile = createProfile(store, input)
+      return listProfileSummaries(store).find((summary) => summary.id === profile.id)!
+    },
+  )
+
+  ipcMain.handle('rename-profile', (_event, id: string, name: string) => {
+    const profile = renameProfile(id, name)
+    return profile ? listProfileSummaries(store).find((summary) => summary.id === profile.id) : null
+  })
+
+  ipcMain.handle('duplicate-profile', (_event, id: string, name: string) => {
+    const profile = createProfile(store, { name, gameVariant: 1, cloneFromId: id })
+    return listProfileSummaries(store).find((summary) => summary.id === profile.id)!
+  })
+
+  ipcMain.handle('delete-profile', (event, id: string) => {
+    const previous = {
+      activeProfileId: store.get('activeProfileId'),
+      poeVersion: store.get('poeVersion'),
+      filterPath: store.get('filterPath'),
+      league: store.get('league'),
+      cheatSheets: store.get('cheatSheets'),
+    }
+    const changes = deleteProfileAndChooseFallback(store, id)
+    applyProfileHydrationSideEffects(changes, previous)
+    for (const change of changes) {
+      broadcastSettingUpdate(event.sender, change.key, change.value)
+    }
+  })
+
+  ipcMain.handle('set-active-profile', async (event, id: string) => {
+    applySetting(store, 'activeProfileId', id, event.sender)
+    return store.store
   })
 
   ipcMain.handle('refresh-leagues', async (event) => {

--- a/src/main/handlers/trade.ts
+++ b/src/main/handlers/trade.ts
@@ -3,6 +3,7 @@ import type Store from 'electron-store'
 import { getTradeUrls, POE_WEBSITE } from '../../shared/endpoints'
 import type { AppSettings, AuthResult } from '../../shared/types'
 import { getPoeVersion } from '../game-state'
+import { getProfileBackedSetting } from '../profile-settings'
 import type { BulkExchangeResult, StatFilter, TradeResult } from '../trade/trade'
 import {
   searchNeedsLogin,
@@ -233,11 +234,11 @@ export function register(store: Store<AppSettings>): void {
       statFilters: StatFilter[],
       searchOptions?: { listedTime?: string; priceOption?: string; statusOption?: string },
     ): Promise<TradeResult> => {
-      const league = store.get('league')
+      const league = getProfileBackedSetting(store, 'league')
       // Per-search overrides from the price-check Settings chip take priority over the
       // persisted global settings.
       const status = searchOptions?.statusOption ?? store.get('tradeStatus') ?? 'available'
-      const price = searchOptions?.priceOption ?? store.get('tradePriceOption') ?? 'chaos_divine'
+      const price = searchOptions?.priceOption ?? getProfileBackedSetting(store, 'tradePriceOption') ?? 'chaos_divine'
       const collapse = store.get('tradeCollapseListings') ?? true
       // Only spend a login check when the search would carry a Weighted Sum group
       // (the trade API rejects those for anonymous users). Most searches skip it.
@@ -255,7 +256,7 @@ export function register(store: Store<AppSettings>): void {
   ipcMain.handle(
     'bulk-exchange',
     async (_event, itemName: string, baseType: string, haveId?: string): Promise<BulkExchangeResult> => {
-      const league = store.get('league')
+      const league = getProfileBackedSetting(store, 'league')
       const wantId = getBulkExchangeId(itemName, baseType)
       if (!wantId) return { total: 0, listings: [], queryId: '' }
       return searchBulkExchange(league, wantId, haveId ?? 'chaos')
@@ -347,9 +348,9 @@ export function register(store: Store<AppSettings>): void {
         corrupted8mod: boolean
       },
     ) => {
-      const league = store.get('league')
+      const league = getProfileBackedSetting(store, 'league')
       const tradeStatus = store.get('tradeStatus') ?? 'available'
-      const tradePriceOption = store.get('tradePriceOption') ?? 'chaos_divine'
+      const tradePriceOption = getProfileBackedSetting(store, 'tradePriceOption') ?? 'chaos_divine'
       const collapse = store.get('tradeCollapseListings') ?? true
       const result = await searchMapsByRegex(
         league,

--- a/src/main/handlers/trade.ts
+++ b/src/main/handlers/trade.ts
@@ -3,7 +3,7 @@ import type Store from 'electron-store'
 import { getTradeUrls, POE_WEBSITE } from '../../shared/endpoints'
 import type { AppSettings, AuthResult } from '../../shared/types'
 import { getPoeVersion } from '../game-state'
-import { getProfileBackedSetting } from '../profile-settings'
+import { getProfileBackedSetting } from '../profiles/profile-settings'
 import type { BulkExchangeResult, StatFilter, TradeResult } from '../trade/trade'
 import {
   searchNeedsLogin,

--- a/src/main/handlers/versions.ts
+++ b/src/main/handlers/versions.ts
@@ -5,26 +5,27 @@ import { evaluateAndSend } from '../evaluation'
 import { getCurrentFilter, loadFilter } from '../filter-state'
 import { clearHistory, getHistory, undoLast } from '../history'
 import { reloadFilterInGame } from '../overlay'
+import { getProfileBackedSetting } from '../profile-settings'
 import { deleteVersion, listVersions, restoreVersion, saveVersion } from '../update/versions'
 
 export function register(store: Store<AppSettings>): void {
   ipcMain.handle('get-history', () => getHistory())
 
   ipcMain.handle('list-versions', () => {
-    const filterPath = store.get('filterPath')
+    const filterPath = getProfileBackedSetting(store, 'filterPath')
     if (!filterPath) return []
     return listVersions(filterPath)
   })
 
   ipcMain.handle('create-checkpoint', (_event, label?: string) => {
-    const filterPath = store.get('filterPath')
+    const filterPath = getProfileBackedSetting(store, 'filterPath')
     if (!filterPath) return { ok: false, error: 'No filter path set' }
     const version = saveVersion(filterPath, true, label)
     return version ? { ok: true } : { ok: false, error: 'Failed to save checkpoint' }
   })
 
   ipcMain.handle('restore-version', (_event, versionFilename: string, itemJson?: string) => {
-    const filterPath = store.get('filterPath')
+    const filterPath = getProfileBackedSetting(store, 'filterPath')
     if (!filterPath) return { ok: false, error: 'No filter path set' }
     // Save current state as auto-version before restoring
     saveVersion(filterPath, false)
@@ -47,7 +48,7 @@ export function register(store: Store<AppSettings>): void {
   })
 
   ipcMain.handle('undo-edit', (_event, itemJson?: string) => {
-    const filterPath = store.get('filterPath')
+    const filterPath = getProfileBackedSetting(store, 'filterPath')
     if (!filterPath) return { ok: false, error: 'No filter path set' }
     const result = undoLast(filterPath)
     if (result.ok) {

--- a/src/main/handlers/versions.ts
+++ b/src/main/handlers/versions.ts
@@ -5,7 +5,7 @@ import { evaluateAndSend } from '../evaluation'
 import { getCurrentFilter, loadFilter } from '../filter-state'
 import { clearHistory, getHistory, undoLast } from '../history'
 import { reloadFilterInGame } from '../overlay'
-import { getProfileBackedSetting } from '../profile-settings'
+import { getProfileBackedSetting } from '../profiles/profile-settings'
 import { deleteVersion, listVersions, restoreVersion, saveVersion } from '../update/versions'
 
 export function register(store: Store<AppSettings>): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -113,7 +113,9 @@ import {
   subscribeToPoeMoves,
 } from './windowing'
 import { initAppMacrosRefresh, withPluginHotkeys } from './app-macros'
-import type { AppSettings, CheatSheetsSettings, RegexPreset } from '../shared/types'
+import type { AppSettings, CheatSheetsSettings, GameVariant, RegexPreset } from '../shared/types'
+import { initProfileStore } from './profiles/store'
+import { hydrateActiveProfileSettings, writeActiveProfileSetting } from './profile-settings'
 
 // ---- Linux display-server setup --------------------------------------------
 
@@ -194,6 +196,8 @@ const store = new Store<AppSettings>({
     themeId: 'default',
     customThemePalette: null,
     pluginRegistryUrl: undefined,
+    activeProfileId: '',
+    onboardingCompleted: false,
   },
 })
 
@@ -206,6 +210,12 @@ if ((store.get('tradeStatus') as string) === 'any') store.set('tradeStatus', 'av
 if (store.get('themeId') === undefined) store.set('themeId', 'default')
 if (store.get('customThemePalette') === undefined) store.set('customThemePalette', null)
 if (store.get('adaptiveDefaultsMode') === undefined) store.set('adaptiveDefaultsMode', 'eager')
+
+const profileStore = initProfileStore(app.getPath('userData'))
+
+// Backfill new profile/onboarding keys for existing users
+if (store.get('activeProfileId') === undefined) store.set('activeProfileId', '')
+if (store.get('onboardingCompleted') === undefined) store.set('onboardingCompleted', false)
 
 // Auto-detect overlay scale on first run (deferred until app ready since screen API requires it)
 if (!IS_E2E)
@@ -245,18 +255,22 @@ if (!store.get('tradePriceOptionPoe1')) store.set('tradePriceOptionPoe1', store.
   if (legacy && legacy.length > 0 && poe1Empty) store.set('regexPresetsPoe1', legacy)
 }
 
-// On startup, sync the flat active fields to match whichever version is current.
-// The relaunch-on-game-switch flow (ensureCorrectGameForHotkey) means this runs
-// with the right version after the user confirms a switch in the modal. Writes
-// from the settings UI mirror in the other direction -- see handlers/settings.ts.
-{
-  const suffix: 'Poe1' | 'Poe2' = store.get('poeVersion') === 2 ? 'Poe2' : 'Poe1'
-  store.set('league', store.get(`league${suffix}`))
-  store.set('filterPath', store.get(`filterPath${suffix}`))
-  store.set('filterDir', store.get(`filterDir${suffix}`))
-  store.set('tradePriceOption', store.get(`tradePriceOption${suffix}`))
-  store.set('cheatSheets', store.get(`cheatSheets${suffix}`))
+// Migrate: seed profiles from per-version mirror keys. Creates one profile per
+// game in the profiles/ directory under userData. Determines whether onboarding
+// was already completed (any legacy filter path set). Sets activeProfileId to
+// match the current poeVersion. Runs once -- guarded by empty activeProfileId.
+if (!store.get('activeProfileId')) {
+  const profiles = profileStore.migrateFromLegacy(store)
+  const version = store.get('poeVersion')
+  const activeId = (version === 2 ? profiles[1] : profiles[0]).id
+  store.set('activeProfileId', activeId)
+  const hadFilter = (store.get('filterPathPoe1') ?? '') !== '' || (store.get('filterPathPoe2') ?? '') !== ''
+  store.set('onboardingCompleted', hadFilter)
 }
+
+// On every startup, hydrate flat + per-version mirror fields from the active
+// profile. The profile file is the source of truth for per-game settings.
+hydrateActiveProfileSettings(store)
 
 // Fire-and-forget league refresh on launch. Updates persist + auto-migrate the
 // user's selected league if their old challenge league rotated out. Deferred
@@ -321,7 +335,7 @@ function createTray(): void {
   tray.setToolTip('Scalpel')
 
   const current = store.get('poeVersion') === 2 ? 2 : 1
-  const other: 1 | 2 = current === 1 ? 2 : 1
+  const other: GameVariant = current === 1 ? 2 : 1
 
   const contextMenu = Menu.buildFromTemplate([
     { label: `Current Game: PoE${current}`, enabled: false },
@@ -441,7 +455,7 @@ app.whenReady().then(() => {
   // Seed the overlay with the last-known game version so attachByTitle waits for
   // that window. The hotkey handler re-detects the focused PoE on every fire and
   // relaunches to swap versions if needed (ensureCorrectGameForHotkey).
-  if (!IS_E2E) createOverlayWindow(store.get('poeVersion') ?? 1)
+  if (!IS_E2E) createOverlayWindow((store.get('poeVersion') as GameVariant) ?? 1)
   // Let the secondary-overlay system know about the main overlay window so its
   // isAnyScalpelWindowFocused predicate can include it.
   setMainOverlayGetter(getOverlayWindow)
@@ -566,9 +580,7 @@ app.whenReady().then(() => {
   const patchCheatSheets = (patch: Partial<CheatSheetsSettings>): void => {
     const cs = store.get('cheatSheets') ?? { globalHotkey: '', categories: [], pinned: false }
     const next: CheatSheetsSettings = { ...cs, ...patch }
-    store.set('cheatSheets', next)
-    const v = store.get('poeVersion')
-    store.set(v === 2 ? 'cheatSheetsPoe2' : 'cheatSheetsPoe1', next)
+    writeActiveProfileSetting(store, 'cheatSheets', next)
   }
   registerCheatSheetsOverlay({
     storedAnchor: () => store.get('cheatSheets')?.windowAnchor,
@@ -609,7 +621,7 @@ app.whenReady().then(() => {
   if (!IS_E2E) startLiveServices()
 
   // Show onboarding on first launch, otherwise stay in tray
-  if (IS_E2E || !filterPath) {
+  if (IS_E2E || !store.get('onboardingCompleted')) {
     showAppWindow()
   }
 })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -573,14 +573,9 @@ app.whenReady().then(() => {
   })
   setAppMacros(withPluginHotkeys((store.get('appMacros') as AppSettings['appMacros']) ?? []))
   // Register the cheat-sheets overlay with the secondary-overlay system. The
-  // anchor persists into settings.cheatSheets.windowAnchor; the system handles
-  // window lifecycle, snap, alt-tab guard, etc. and the wireCheatSheetHotkeys
-  // helper below feeds the global + per-category hotkeys into the shared system.
-  // Persist a partial cheatSheets update from a main-side callback (anchor
-  // drag, etc.). Mirrors the flat write to the active game's per-version slot
-  // so the user's change survives a game switch. The IPC settings path
-  // (set-setting -> applySetting) does this via MIRROR_KEYS for renderer-
-  // initiated writes; this is the parallel path for main-initiated ones.
+  // anchor persists into the active profile's cheatSheets.windowAnchor; the
+  // system handles window lifecycle, snap, alt-tab guard, etc. and the helper
+  // below feeds global + per-category hotkeys into the shared system.
   const patchCheatSheets = (patch: Partial<CheatSheetsSettings>): void => {
     const cs = getProfileBackedSetting(store, 'cheatSheets') ?? { globalHotkey: '', categories: [], pinned: false }
     const next: CheatSheetsSettings = { ...cs, ...patch }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -115,7 +115,14 @@ import {
 import { initAppMacrosRefresh, withPluginHotkeys } from './app-macros'
 import type { AppSettings, CheatSheetsSettings, GameVariant, RegexPreset } from '../shared/types'
 import { initProfileStore } from './profiles/store'
-import { hydrateActiveProfileSettings, writeActiveProfileSetting } from './profile-settings'
+import {
+  ACTIVE_PROFILE_ID_KEY,
+  LAST_PROFILE_ID_POE1_KEY,
+  LAST_PROFILE_ID_POE2_KEY,
+  PROFILE_VERSION_KEY,
+  hydrateActiveProfileSettings,
+  writeActiveProfileSetting,
+} from './profile-settings'
 
 // ---- Linux display-server setup --------------------------------------------
 
@@ -196,7 +203,9 @@ const store = new Store<AppSettings>({
     themeId: 'default',
     customThemePalette: null,
     pluginRegistryUrl: undefined,
-    activeProfileId: '',
+    [ACTIVE_PROFILE_ID_KEY]: '',
+    [LAST_PROFILE_ID_POE1_KEY]: '',
+    [LAST_PROFILE_ID_POE2_KEY]: '',
     onboardingCompleted: false,
   },
 })
@@ -214,7 +223,9 @@ if (store.get('adaptiveDefaultsMode') === undefined) store.set('adaptiveDefaults
 const profileStore = initProfileStore(app.getPath('userData'))
 
 // Backfill new profile/onboarding keys for existing users
-if (store.get('activeProfileId') === undefined) store.set('activeProfileId', '')
+if (store.get(ACTIVE_PROFILE_ID_KEY) === undefined) store.set(ACTIVE_PROFILE_ID_KEY, '')
+if (store.get(LAST_PROFILE_ID_POE1_KEY) === undefined) store.set(LAST_PROFILE_ID_POE1_KEY, '')
+if (store.get(LAST_PROFILE_ID_POE2_KEY) === undefined) store.set(LAST_PROFILE_ID_POE2_KEY, '')
 if (store.get('onboardingCompleted') === undefined) store.set('onboardingCompleted', false)
 
 // Auto-detect overlay scale on first run (deferred until app ready since screen API requires it)
@@ -259,13 +270,28 @@ if (!store.get('tradePriceOptionPoe1')) store.set('tradePriceOptionPoe1', store.
 // game in the profiles/ directory under userData. Determines whether onboarding
 // was already completed (any legacy filter path set). Sets activeProfileId to
 // match the current poeVersion. Runs once -- guarded by empty activeProfileId.
-if (!store.get('activeProfileId')) {
+if (!store.get(ACTIVE_PROFILE_ID_KEY)) {
   const profiles = profileStore.migrateFromLegacy(store)
-  const version = store.get('poeVersion')
+  const version = store.get(PROFILE_VERSION_KEY)
   const activeId = (version === 2 ? profiles[1] : profiles[0]).id
-  store.set('activeProfileId', activeId)
+  store.set(ACTIVE_PROFILE_ID_KEY, activeId)
+  store.set(LAST_PROFILE_ID_POE1_KEY, profiles[0].id)
+  store.set(LAST_PROFILE_ID_POE2_KEY, profiles[1].id)
   const hadFilter = (store.get('filterPathPoe1') ?? '') !== '' || (store.get('filterPathPoe2') ?? '') !== ''
   store.set('onboardingCompleted', hadFilter)
+}
+
+{
+  const profiles = profileStore.listProfiles()
+  const activeProfile = profileStore.getProfile(store.get(ACTIVE_PROFILE_ID_KEY))
+  if (!store.get(LAST_PROFILE_ID_POE1_KEY)) {
+    const fallback = activeProfile?.gameVariant === 1 ? activeProfile : profiles.find((p) => p.gameVariant === 1)
+    store.set(LAST_PROFILE_ID_POE1_KEY, fallback?.id ?? '')
+  }
+  if (!store.get(LAST_PROFILE_ID_POE2_KEY)) {
+    const fallback = activeProfile?.gameVariant === 2 ? activeProfile : profiles.find((p) => p.gameVariant === 2)
+    store.set(LAST_PROFILE_ID_POE2_KEY, fallback?.id ?? '')
+  }
 }
 
 // On every startup, hydrate flat + per-version mirror fields from the active
@@ -334,7 +360,7 @@ function createTray(): void {
   tray = new Tray(icon)
   tray.setToolTip('Scalpel')
 
-  const current = store.get('poeVersion') === 2 ? 2 : 1
+  const current = store.get(PROFILE_VERSION_KEY) === 2 ? 2 : 1
   const other: GameVariant = current === 1 ? 2 : 1
 
   const contextMenu = Menu.buildFromTemplate([
@@ -455,7 +481,7 @@ app.whenReady().then(() => {
   // Seed the overlay with the last-known game version so attachByTitle waits for
   // that window. The hotkey handler re-detects the focused PoE on every fire and
   // relaunches to swap versions if needed (ensureCorrectGameForHotkey).
-  if (!IS_E2E) createOverlayWindow((store.get('poeVersion') as GameVariant) ?? 1)
+  if (!IS_E2E) createOverlayWindow((store.get(PROFILE_VERSION_KEY) as GameVariant) ?? 1)
   // Let the secondary-overlay system know about the main overlay window so its
   // isAnyScalpelWindowFocused predicate can include it.
   setMainOverlayGetter(getOverlayWindow)
@@ -529,7 +555,7 @@ app.whenReady().then(() => {
     }
     if (action === 'useSavedRegex') {
       if (!tag) return
-      const key = store.get('poeVersion') === 2 ? 'regexPresetsPoe2' : 'regexPresetsPoe1'
+      const key = store.get(PROFILE_VERSION_KEY) === 2 ? 'regexPresetsPoe2' : 'regexPresetsPoe1'
       const presets = store.get(key) ?? []
       const preset = presets.find((p) => p.tags?.some((t) => t.text === tag && (!t.source || t.source === 'custom')))
       if (preset?.regex) pasteRegexToSearch(preset.regex)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -123,7 +123,7 @@ import {
   getProfileBackedSetting,
   hydrateActiveProfileSettings,
   writeActiveProfileSetting,
-} from './profile-settings'
+} from './profiles/profile-settings'
 
 // ---- Linux display-server setup --------------------------------------------
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -113,13 +113,14 @@ import {
   subscribeToPoeMoves,
 } from './windowing'
 import { initAppMacrosRefresh, withPluginHotkeys } from './app-macros'
-import type { AppSettings, CheatSheetsSettings, GameVariant, RegexPreset } from '../shared/types'
+import type { AppSettings, CheatSheetsSettings, GameVariant, LegacyAppSettings, RegexPreset } from '../shared/types'
 import { initProfileStore } from './profiles/store'
 import {
   ACTIVE_PROFILE_ID_KEY,
   LAST_PROFILE_ID_POE1_KEY,
   LAST_PROFILE_ID_POE2_KEY,
   PROFILE_VERSION_KEY,
+  getProfileBackedSetting,
   hydrateActiveProfileSettings,
   writeActiveProfileSetting,
 } from './profile-settings'
@@ -161,15 +162,6 @@ function isElevated(): boolean {
 
 const store = new Store<AppSettings>({
   defaults: {
-    filterPath: '',
-    filterDir: '',
-    filterPathPoe1: '',
-    filterPathPoe2: '',
-    filterDirPoe1: '',
-    filterDirPoe2: '',
-    league: 'Mirage',
-    leaguePoe1: 'Mirage',
-    leaguePoe2: 'Fate of the Vaal',
     hotkey: 'CommandOrControl+Shift+D',
     priceCheckHotkey: 'CommandOrControl+Shift+A',
     overlayOpacity: 0.95,
@@ -182,17 +174,11 @@ const store = new Store<AppSettings>({
     tradeStatus: 'available',
     tradeCollapseListings: true,
     previewVolume: 0.25,
-    tradePriceOption: 'chaos_divine',
-    tradePriceOptionPoe1: 'chaos_divine',
-    tradePriceOptionPoe2: 'exalted_divine',
     priceCheckDefaultPercent: 90,
     adaptiveDefaultsMode: 'eager',
     tradeDefaultToBase: false,
     chatCommands: [],
     appMacros: [],
-    cheatSheets: { globalHotkey: '', categories: [], pinned: false },
-    cheatSheetsPoe1: { globalHotkey: '', categories: [], pinned: false },
-    cheatSheetsPoe2: { globalHotkey: '', categories: [], pinned: false },
     stashScrollEnabled: false,
     poeVersion: 1,
     regexPresetsPoe1: [],
@@ -241,20 +227,24 @@ if (!IS_E2E)
     }
   })
 
-// Migrate: derive filterDir from existing filterPath for users upgrading
-if (!store.get('filterDir') && store.get('filterPath')) {
-  store.set('filterDir', dirname(store.get('filterPath')))
-} else if (!store.get('filterDir')) {
-  store.set('filterDir', '')
-}
+// Migrate: derive filterDir from existing filterPath for users upgrading.
+// Uses legacy key reads via cast — these keys no longer exist on AppSettings
+// but may still be present in the electron-store JSON from a prior version.
+{
+  const legacyStore = store as unknown as Store<AppSettings & LegacyAppSettings>
+  if (!legacyStore.get('filterDir') && legacyStore.get('filterPath')) {
+    legacyStore.set('filterDir', dirname(legacyStore.get('filterPath')!))
+  } else if (!legacyStore.get('filterDir')) {
+    legacyStore.set('filterDir', '')
+  }
 
-// Migrate: seed per-version fields from the pre-existing flat values. Before this
-// change everyone had a single league/filter/price-option -- treat that as their
-// PoE1 setup. Guarded by empty-check so we only migrate once.
-if (!store.get('leaguePoe1')) store.set('leaguePoe1', store.get('league'))
-if (!store.get('filterPathPoe1')) store.set('filterPathPoe1', store.get('filterPath'))
-if (!store.get('filterDirPoe1')) store.set('filterDirPoe1', store.get('filterDir'))
-if (!store.get('tradePriceOptionPoe1')) store.set('tradePriceOptionPoe1', store.get('tradePriceOption'))
+  // Seed per-version mirror fields from the pre-existing flat values so
+  // migrateFromLegacy can read them. Guarded by empty-check (runs once).
+  if (!legacyStore.get('leaguePoe1')) legacyStore.set('leaguePoe1', legacyStore.get('league'))
+  if (!legacyStore.get('filterPathPoe1')) legacyStore.set('filterPathPoe1', legacyStore.get('filterPath'))
+  if (!legacyStore.get('filterDirPoe1')) legacyStore.set('filterDirPoe1', legacyStore.get('filterDir'))
+  if (!legacyStore.get('tradePriceOptionPoe1')) legacyStore.set('tradePriceOptionPoe1', legacyStore.get('tradePriceOption'))
+}
 
 // Migrate: regex presets used to be a single flat `regexPresets` array. Now
 // they're per-version. Existing users only ever ran PoE1 (regex tool was off
@@ -273,11 +263,12 @@ if (!store.get('tradePriceOptionPoe1')) store.set('tradePriceOptionPoe1', store.
 if (!store.get(ACTIVE_PROFILE_ID_KEY)) {
   const profiles = profileStore.migrateFromLegacy(store)
   const version = store.get(PROFILE_VERSION_KEY)
-  const activeId = (version === 2 ? profiles[1] : profiles[0]).id
-  store.set(ACTIVE_PROFILE_ID_KEY, activeId)
-  store.set(LAST_PROFILE_ID_POE1_KEY, profiles[0].id)
-  store.set(LAST_PROFILE_ID_POE2_KEY, profiles[1].id)
-  const hadFilter = (store.get('filterPathPoe1') ?? '') !== '' || (store.get('filterPathPoe2') ?? '') !== ''
+  const active = profiles.find((profile) => profile.gameVariant === version) ?? profiles[0] ?? null
+  store.set(ACTIVE_PROFILE_ID_KEY, active?.id ?? '')
+  store.set(LAST_PROFILE_ID_POE1_KEY, profiles.find((profile) => profile.gameVariant === 1)?.id ?? '')
+  store.set(LAST_PROFILE_ID_POE2_KEY, profiles.find((profile) => profile.gameVariant === 2)?.id ?? '')
+  const legacyStore = store as unknown as Store<AppSettings & LegacyAppSettings>
+  const hadFilter = (legacyStore.get('filterPathPoe1') ?? '') !== '' || (legacyStore.get('filterPathPoe2') ?? '') !== ''
   store.set('onboardingCompleted', hadFilter)
 }
 
@@ -508,7 +499,7 @@ app.whenReady().then(() => {
     getOverlayWindow()?.webContents.send('rate-limit', state)
   })
 
-  const filterPath = store.get('filterPath')
+  const filterPath = getProfileBackedSetting(store, 'filterPath')
   if (!IS_E2E && filterPath) loadFilter(filterPath, 'App Launch')
 
   // Start low-level keyboard hook
@@ -604,24 +595,24 @@ app.whenReady().then(() => {
   // (set-setting -> applySetting) does this via MIRROR_KEYS for renderer-
   // initiated writes; this is the parallel path for main-initiated ones.
   const patchCheatSheets = (patch: Partial<CheatSheetsSettings>): void => {
-    const cs = store.get('cheatSheets') ?? { globalHotkey: '', categories: [], pinned: false }
+    const cs = getProfileBackedSetting(store, 'cheatSheets') ?? { globalHotkey: '', categories: [], pinned: false }
     const next: CheatSheetsSettings = { ...cs, ...patch }
     writeActiveProfileSetting(store, 'cheatSheets', next)
   }
   registerCheatSheetsOverlay({
-    storedAnchor: () => store.get('cheatSheets')?.windowAnchor,
+    storedAnchor: () => getProfileBackedSetting(store, 'cheatSheets')?.windowAnchor,
     onAnchorChanged: (anchor) => patchCheatSheets({ windowAnchor: anchor }),
   })
   // Hide the main overlay before showing the cheat sheet (keeps things tidy if
   // the user hotkeys the cheat sheet while the main overlay was open).
   setCheatSheetsBeforeShow(() => hideOverlay())
-  applyCheatSheetHotkeys(store.get('cheatSheets'))
+  applyCheatSheetHotkeys(getProfileBackedSetting(store, 'cheatSheets'))
   registerWhiteboardOverlay()
   registerPinnedZoneOverlay({
-    storedAnchor: () => store.get('cheatSheets')?.pinnedAnchor,
+    storedAnchor: () => getProfileBackedSetting(store, 'cheatSheets')?.pinnedAnchor,
     onAnchorChanged: (anchor) => patchCheatSheets({ pinnedAnchor: anchor }),
   })
-  applyPinnedZoneEnabled(store.get('cheatSheets')?.pinned === true)
+  applyPinnedZoneEnabled(getProfileBackedSetting(store, 'cheatSheets')?.pinned === true)
   subscribeToPoeMoves()
   setStashScrollEnabled(store.get('stashScrollEnabled') ?? false)
   setOpenSide(store.get('openSide') ?? 'both')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -74,8 +74,14 @@ import { requestGameSwitch } from './game-switch'
 import { startOnlineSync, stopOnlineSync } from './online-sync'
 import { initUpdater } from './update/updater'
 import { applyPendingUpdate } from './update/update-swap'
-import { loadFilter } from './filter-state'
-import { createHotkeyHandler, createPriceCheckHandler, setOpenSide, setEvaluationStore } from './evaluation'
+import { getCurrentFilter, loadFilter, onFilterLoaded } from './filter-state'
+import {
+  createHotkeyHandler,
+  createPriceCheckHandler,
+  reEvaluateLastItem,
+  setOpenSide,
+  setEvaluationStore,
+} from './evaluation'
 import { initLearning } from './learning'
 import { snapshotClipboard } from './clipboard-preserve'
 import * as tradeHandlers from './handlers/trade'
@@ -484,6 +490,16 @@ app.whenReady().then(() => {
   // Broadcast rate limit state to overlay
   onRateLimitUpdate((state) => {
     getOverlayWindow()?.webContents.send('rate-limit', state)
+  })
+
+  // Keep open overlay views (item view, dust/div explorers) in sync whenever the
+  // filter reloads -- filter switch, online update, version restore -- without a
+  // fresh hotkey press. reEvaluateLastItem is a no-op until an item is analyzed,
+  // and re-sending the same item never switches the view or pops the overlay, so
+  // this is non-intrusive.
+  onFilterLoaded(() => {
+    getOverlayWindow()?.webContents.send('filter-changed')
+    if (getCurrentFilter()) reEvaluateLastItem()
   })
 
   const filterPath = getProfileBackedSetting(store, 'filterPath')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,7 +39,7 @@ installEarlyDiagnostics()
 // uncaughtException handler, so this is the only trace it leaves on Windows.
 crashReporter.start({ uploadToServer: false })
 
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import { execSync } from 'node:child_process'
 import { uIOhook, UiohookKey } from 'uiohook-napi'
 import Store from 'electron-store'
@@ -227,24 +227,8 @@ if (!IS_E2E)
     }
   })
 
-// Migrate: derive filterDir from existing filterPath for users upgrading.
-// Uses legacy key reads via cast — these keys no longer exist on AppSettings
-// but may still be present in the electron-store JSON from a prior version.
-{
-  const legacyStore = store as unknown as Store<AppSettings & LegacyAppSettings>
-  if (!legacyStore.get('filterDir') && legacyStore.get('filterPath')) {
-    legacyStore.set('filterDir', dirname(legacyStore.get('filterPath')!))
-  } else if (!legacyStore.get('filterDir')) {
-    legacyStore.set('filterDir', '')
-  }
-
-  // Seed per-version mirror fields from the pre-existing flat values so
-  // migrateFromLegacy can read them. Guarded by empty-check (runs once).
-  if (!legacyStore.get('leaguePoe1')) legacyStore.set('leaguePoe1', legacyStore.get('league'))
-  if (!legacyStore.get('filterPathPoe1')) legacyStore.set('filterPathPoe1', legacyStore.get('filterPath'))
-  if (!legacyStore.get('filterDirPoe1')) legacyStore.set('filterDirPoe1', legacyStore.get('filterDir'))
-  if (!legacyStore.get('tradePriceOptionPoe1')) legacyStore.set('tradePriceOptionPoe1', legacyStore.get('tradePriceOption'))
-}
+// Legacy profile-backed settings are read once by migrateFromLegacy(). After
+// profiles exist, only active-profile references remain in electron-store.
 
 // Migrate: regex presets used to be a single flat `regexPresets` array. Now
 // they're per-version. Existing users only ever ran PoE1 (regex tool was off
@@ -268,7 +252,9 @@ if (!store.get(ACTIVE_PROFILE_ID_KEY)) {
   store.set(LAST_PROFILE_ID_POE1_KEY, profiles.find((profile) => profile.gameVariant === 1)?.id ?? '')
   store.set(LAST_PROFILE_ID_POE2_KEY, profiles.find((profile) => profile.gameVariant === 2)?.id ?? '')
   const legacyStore = store as unknown as Store<AppSettings & LegacyAppSettings>
-  const hadFilter = (legacyStore.get('filterPathPoe1') ?? '') !== '' || (legacyStore.get('filterPathPoe2') ?? '') !== ''
+  const hadFilter = Boolean(
+    legacyStore.get('filterPathPoe1') || legacyStore.get('filterPathPoe2') || legacyStore.get('filterPath'),
+  )
   store.set('onboardingCompleted', hadFilter)
 }
 
@@ -285,8 +271,9 @@ if (!store.get(ACTIVE_PROFILE_ID_KEY)) {
   }
 }
 
-// On every startup, hydrate flat + per-version mirror fields from the active
-// profile. The profile file is the source of truth for per-game settings.
+// On every startup, hydrate store keys from the active profile (lastProfileId,
+// poeVersion, regexPresets). Profile-backed fields (league, filterPath, etc.)
+// live only in the profile JSON files and are read via getProfileBackedSetting.
 hydrateActiveProfileSettings(store)
 
 // Fire-and-forget league refresh on launch. Updates persist + auto-migrate the

--- a/src/main/profile-settings.test.ts
+++ b/src/main/profile-settings.test.ts
@@ -6,6 +6,10 @@ import type Store from 'electron-store'
 import type { AppSettings } from '../shared/types'
 import { initProfileStore } from './profiles/store'
 import {
+  ACTIVE_PROFILE_ID_KEY,
+  LAST_PROFILE_ID_POE1_KEY,
+  LAST_PROFILE_ID_POE2_KEY,
+  PROFILE_VERSION_KEY,
   deleteProfileAndChooseFallback,
   listProfileSummaries,
   switchActiveProfileByGameVariant,
@@ -34,7 +38,12 @@ describe('profile-settings', () => {
     const poe1 = profiles.createDefault(1)
     profiles.saveProfile(poe1)
 
-    const store = makeStore({ poeVersion: 1, activeProfileId: poe1.id, league: 'Mirage', leaguePoe1: 'Mirage' })
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      league: 'Mirage',
+      leaguePoe1: 'Mirage',
+    })
 
     writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
 
@@ -50,7 +59,12 @@ describe('profile-settings', () => {
     profiles.saveProfile(trade)
     profiles.saveProfile(ssf)
 
-    const store = makeStore({ poeVersion: 1, activeProfileId: ssf.id, league: 'Standard', leaguePoe1: 'Standard' })
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: ssf.id,
+      league: 'Standard',
+      leaguePoe1: 'Standard',
+    })
 
     writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
 
@@ -77,7 +91,7 @@ describe('profile-settings', () => {
       qualifiers: {},
       nightmare: false,
     }
-    const store = makeStore({ poeVersion: 1, activeProfileId: ssf.id, regexPresetsPoe1: [] })
+    const store = makeStore({ [PROFILE_VERSION_KEY]: 1, [ACTIVE_PROFILE_ID_KEY]: ssf.id, regexPresetsPoe1: [] })
 
     writeActiveRegexPresetsByGameVariant(store, 1, [preset])
 
@@ -94,8 +108,9 @@ describe('profile-settings', () => {
     profiles.saveProfile(poe2)
 
     const store = makeStore({
-      poeVersion: 1,
-      activeProfileId: poe1.id,
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE2_KEY]: poe2.id,
       filterPath: 'C:\\filters\\poe1.filter',
       filterPathPoe2: 'C:\\stale\\mirror.filter',
       leaguePoe2: 'Stale League',
@@ -103,11 +118,44 @@ describe('profile-settings', () => {
 
     switchActiveProfileByGameVariant(store, 2)
 
-    expect(store.get('activeProfileId')).toBe(poe2.id)
-    expect(store.get('poeVersion')).toBe(2)
+    expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(poe2.id)
+    expect(store.get(PROFILE_VERSION_KEY)).toBe(2)
     expect(store.get('filterPath')).toBe('C:\\filters\\poe2.filter')
     expect(store.get('filterPathPoe2')).toBe('C:\\filters\\poe2.filter')
     expect(store.get('league')).toBe('Fate of the Vaal')
+  })
+
+  it('switches games to the explicit last-used profile instead of the newest touched profile', () => {
+    const profiles = setupProfiles()
+    const poe1 = profiles.createDefault(1)
+    const olderChoice = {
+      ...profiles.createDefault(2),
+      name: 'Bossing',
+      filterPath: 'C:\\filters\\bossing.filter',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }
+    const newerTouched = {
+      ...profiles.createDefault(2),
+      name: 'Mapping',
+      filterPath: 'C:\\filters\\mapping.filter',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    }
+    profiles.saveProfile(poe1)
+    profiles.saveProfile(olderChoice)
+    profiles.saveProfile(newerTouched)
+
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE2_KEY]: olderChoice.id,
+      filterPath: 'C:\\filters\\poe1.filter',
+    })
+
+    switchActiveProfileByGameVariant(store, 2)
+
+    expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(olderChoice.id)
+    expect(store.get(LAST_PROFILE_ID_POE2_KEY)).toBe(olderChoice.id)
+    expect(store.get('filterPath')).toBe('C:\\filters\\bossing.filter')
   })
 
   it('discovers multiple profiles per game and marks the active one', () => {
@@ -117,7 +165,7 @@ describe('profile-settings', () => {
     profiles.saveProfile(trade)
     profiles.saveProfile(ssf)
 
-    const store = makeStore({ activeProfileId: ssf.id })
+    const store = makeStore({ [ACTIVE_PROFILE_ID_KEY]: ssf.id })
 
     const summaries = listProfileSummaries(store)
 
@@ -132,11 +180,17 @@ describe('profile-settings', () => {
     profiles.saveProfile(trade)
     profiles.saveProfile(ssf)
 
-    const store = makeStore({ activeProfileId: ssf.id, poeVersion: 1, league: ssf.league })
+    const store = makeStore({
+      [ACTIVE_PROFILE_ID_KEY]: ssf.id,
+      [LAST_PROFILE_ID_POE1_KEY]: ssf.id,
+      [PROFILE_VERSION_KEY]: 1,
+      league: ssf.league,
+    })
 
     deleteProfileAndChooseFallback(store, ssf.id)
 
-    expect(store.get('activeProfileId')).toBe(trade.id)
+    expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(trade.id)
+    expect(store.get(LAST_PROFILE_ID_POE1_KEY)).toBe(trade.id)
     expect(store.get('league')).toBe('Mirage')
     expect(profiles.getProfile(ssf.id)).toBeNull()
   })

--- a/src/main/profile-settings.test.ts
+++ b/src/main/profile-settings.test.ts
@@ -19,7 +19,7 @@ import {
   writeLastUsedProfileSettingByGameVariant,
 } from './profile-settings'
 
-function makeStore(initial: Partial<AppSettings>): Store<AppSettings> {
+function makeStore(initial: Record<string, unknown>): Store<AppSettings> {
   const data: Record<string, unknown> = { ...initial }
   return {
     get: (key: string) => data[key],
@@ -35,7 +35,7 @@ function setupProfiles(): ReturnType<typeof initProfileStore> {
 }
 
 describe('profile-settings', () => {
-  it('writes active profile-backed settings to the profile file without persisting flat config', () => {
+  it('writes active profile-backed settings to the profile file with edit reason', () => {
     const profiles = setupProfiles()
     const poe1 = profiles.createDefault(1)
     profiles.saveProfile(poe1)
@@ -43,16 +43,17 @@ describe('profile-settings', () => {
     const store = makeStore({
       [PROFILE_VERSION_KEY]: 1,
       [ACTIVE_PROFILE_ID_KEY]: poe1.id,
-      league: 'Mirage',
-      leaguePoe1: 'Mirage',
     })
 
     const changes = writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
 
-    expect(changes).toContainEqual({ key: 'league', value: 'Return of the Settlers' })
-    expect(store.get('league')).toBe('Mirage')
-    expect(store.get('leaguePoe1')).toBe('Mirage')
-    expect(getEffectiveSettings(store).league).toBe('Return of the Settlers')
+    expect(changes).toHaveLength(1)
+    const change = changes[0]
+    expect(change.key).toBe('activeProfile')
+    if (change.key === 'activeProfile') {
+      expect(change.reason).toBe('edit')
+    }
+    expect(getEffectiveSettings(store).activeProfile?.league).toBe('Return of the Settlers')
     expect(profiles.getProfile(poe1.id)?.league).toBe('Return of the Settlers')
   })
 
@@ -66,16 +67,17 @@ describe('profile-settings', () => {
     const store = makeStore({
       [PROFILE_VERSION_KEY]: 1,
       [ACTIVE_PROFILE_ID_KEY]: ssf.id,
-      league: 'Standard',
-      leaguePoe1: 'Standard',
     })
 
     const changes = writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
 
-    expect(changes).toContainEqual({ key: 'league', value: 'Return of the Settlers' })
-    expect(store.get('league')).toBe('Standard')
-    expect(store.get('leaguePoe1')).toBe('Standard')
-    expect(getEffectiveSettings(store).league).toBe('Return of the Settlers')
+    expect(changes).toHaveLength(1)
+    const change2 = changes[0]
+    expect(change2.key).toBe('activeProfile')
+    if (change2.key === 'activeProfile') {
+      expect(change2.reason).toBe('edit')
+    }
+    expect(getEffectiveSettings(store).activeProfile?.league).toBe('Return of the Settlers')
     expect(profiles.getProfile(ssf.id)?.league).toBe('Return of the Settlers')
     expect(profiles.getProfile(trade.id)?.league).toBe('Mirage')
   })
@@ -106,7 +108,7 @@ describe('profile-settings', () => {
     expect(profiles.getProfile(trade.id)?.regexPresets).toEqual([])
   })
 
-  it('writes inactive profile settings to the last-used profile for that game', () => {
+  it('writes inactive profile settings to the last-used profile without affecting active', () => {
     const profiles = setupProfiles()
     const poe1 = profiles.createDefault(1)
     const poe2 = { ...profiles.createDefault(2), league: 'Fate of the Vaal' }
@@ -117,19 +119,37 @@ describe('profile-settings', () => {
       [PROFILE_VERSION_KEY]: 1,
       [ACTIVE_PROFILE_ID_KEY]: poe1.id,
       [LAST_PROFILE_ID_POE2_KEY]: poe2.id,
-      league: 'Mirage',
-      leaguePoe2: 'Fate of the Vaal',
     })
 
     const changes = writeLastUsedProfileSettingByGameVariant(store, 2, 'league', 'Standard')
 
     expect(changes).toEqual([])
-    expect(store.get('leaguePoe2')).toBe('Fate of the Vaal')
-    expect(store.get('league')).toBe('Mirage')
     expect(profiles.getProfile(poe2.id)?.league).toBe('Standard')
   })
 
-  it('switches game variant from the target profile instead of stale mirror settings', () => {
+  it('returns edit event when writing to the active profile via last-used', () => {
+    const profiles = setupProfiles()
+    const poe1 = { ...profiles.createDefault(1), league: 'Mirage' }
+    profiles.saveProfile(poe1)
+
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
+    })
+
+    const changes = writeLastUsedProfileSettingByGameVariant(store, 1, 'league', 'Standard')
+
+    expect(changes).toHaveLength(1)
+    const change3 = changes[0]
+    expect(change3.key).toBe('activeProfile')
+    if (change3.key === 'activeProfile') {
+      expect(change3.reason).toBe('edit')
+    }
+    expect(profiles.getProfile(poe1.id)?.league).toBe('Standard')
+  })
+
+  it('switches game variant with activation reason from target profile', () => {
     const profiles = setupProfiles()
     const poe1 = profiles.createDefault(1)
     const poe2 = { ...profiles.createDefault(2), filterPath: 'C:\\filters\\poe2.filter', league: 'Fate of the Vaal' }
@@ -140,21 +160,20 @@ describe('profile-settings', () => {
       [PROFILE_VERSION_KEY]: 1,
       [ACTIVE_PROFILE_ID_KEY]: poe1.id,
       [LAST_PROFILE_ID_POE2_KEY]: poe2.id,
-      filterPath: 'C:\\filters\\poe1.filter',
-      filterPathPoe2: 'C:\\stale\\mirror.filter',
-      leaguePoe2: 'Stale League',
     })
 
     const changes = switchActiveProfileByGameVariant(store, 2)
 
     expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(poe2.id)
     expect(store.get(PROFILE_VERSION_KEY)).toBe(2)
-    expect(store.get('filterPath')).toBe('C:\\filters\\poe1.filter')
-    expect(store.get('filterPathPoe2')).toBe('C:\\stale\\mirror.filter')
-    expect(changes).toContainEqual({ key: 'filterPath', value: 'C:\\filters\\poe2.filter' })
-    expect(changes).toContainEqual({ key: 'league', value: 'Fate of the Vaal' })
-    expect(getEffectiveSettings(store).filterPath).toBe('C:\\filters\\poe2.filter')
-    expect(getEffectiveSettings(store).league).toBe('Fate of the Vaal')
+    const activeChange = changes.find((c) => c.key === 'activeProfile')
+    expect(activeChange).toBeDefined()
+    if (activeChange && activeChange.key === 'activeProfile') {
+      expect(activeChange.reason).toBe('activation')
+      expect(activeChange.value).toEqual(poe2)
+    }
+    expect(getEffectiveSettings(store).activeProfile?.filterPath).toBe('C:\\filters\\poe2.filter')
+    expect(getEffectiveSettings(store).activeProfile?.league).toBe('Fate of the Vaal')
   })
 
   it('switches games to the explicit last-used profile instead of the newest touched profile', () => {
@@ -180,16 +199,18 @@ describe('profile-settings', () => {
       [PROFILE_VERSION_KEY]: 1,
       [ACTIVE_PROFILE_ID_KEY]: poe1.id,
       [LAST_PROFILE_ID_POE2_KEY]: olderChoice.id,
-      filterPath: 'C:\\filters\\poe1.filter',
     })
 
     const changes = switchActiveProfileByGameVariant(store, 2)
 
     expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(olderChoice.id)
     expect(store.get(LAST_PROFILE_ID_POE2_KEY)).toBe(olderChoice.id)
-    expect(store.get('filterPath')).toBe('C:\\filters\\poe1.filter')
-    expect(changes).toContainEqual({ key: 'filterPath', value: 'C:\\filters\\bossing.filter' })
-    expect(getEffectiveSettings(store).filterPath).toBe('C:\\filters\\bossing.filter')
+    const activeChange = changes.find((c) => c.key === 'activeProfile')
+    expect(activeChange).toBeDefined()
+    if (activeChange && activeChange.key === 'activeProfile') {
+      expect(activeChange.reason).toBe('activation')
+    }
+    expect(getEffectiveSettings(store).activeProfile?.filterPath).toBe('C:\\filters\\bossing.filter')
   })
 
   it('discovers multiple profiles per game and marks the active one', () => {
@@ -218,16 +239,18 @@ describe('profile-settings', () => {
       [ACTIVE_PROFILE_ID_KEY]: ssf.id,
       [LAST_PROFILE_ID_POE1_KEY]: ssf.id,
       [PROFILE_VERSION_KEY]: 1,
-      league: ssf.league,
     })
 
     const changes = deleteProfileAndChooseFallback(store, ssf.id)
 
     expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(trade.id)
     expect(store.get(LAST_PROFILE_ID_POE1_KEY)).toBe(trade.id)
-    expect(store.get('league')).toBe('Standard')
-    expect(changes).toContainEqual({ key: 'league', value: 'Mirage' })
-    expect(getEffectiveSettings(store).league).toBe('Mirage')
+    const activeChange = changes.find((c) => c.key === 'activeProfile')
+    expect(activeChange).toBeDefined()
+    if (activeChange && activeChange.key === 'activeProfile') {
+      expect(activeChange.reason).toBe('activation')
+    }
+    expect(getEffectiveSettings(store).activeProfile?.league).toBe('Mirage')
     expect(profiles.getProfile(ssf.id)).toBeNull()
   })
 
@@ -242,7 +265,6 @@ describe('profile-settings', () => {
       [ACTIVE_PROFILE_ID_KEY]: poe2.id,
       [LAST_PROFILE_ID_POE2_KEY]: poe2.id,
       [PROFILE_VERSION_KEY]: 2,
-      league: poe2.league,
     })
 
     deleteProfileAndChooseFallback(store, poe2.id)
@@ -265,7 +287,6 @@ describe('profile-settings', () => {
       [ACTIVE_PROFILE_ID_KEY]: poe1.id,
       [LAST_PROFILE_ID_POE2_KEY]: poe2.id,
       [PROFILE_VERSION_KEY]: 1,
-      league: poe1.league,
     })
 
     deleteProfileAndChooseFallback(store, poe2.id)
@@ -274,7 +295,6 @@ describe('profile-settings', () => {
     expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(poe1.id)
     expect(store.get(LAST_PROFILE_ID_POE2_KEY)).toBe('')
     expect(store.get(PROFILE_VERSION_KEY)).toBe(1)
-    expect(store.get('league')).toBe('Mirage')
   })
 
   it('normalizes legacy profile files that are missing metadata', () => {

--- a/src/main/profile-settings.test.ts
+++ b/src/main/profile-settings.test.ts
@@ -12,6 +12,7 @@ import {
   PROFILE_VERSION_KEY,
   deleteProfileAndChooseFallback,
   getEffectiveSettings,
+  getProfileBackedSetting,
   listProfileSummaries,
   switchActiveProfileByGameVariant,
   writeActiveRegexPresetsByGameVariant,
@@ -267,13 +268,19 @@ describe('profile-settings', () => {
       [PROFILE_VERSION_KEY]: 2,
     })
 
-    deleteProfileAndChooseFallback(store, poe2.id)
+    const changes = deleteProfileAndChooseFallback(store, poe2.id)
 
     expect(profiles.listProfiles().find((profile) => profile.gameVariant === 2)).toBeUndefined()
     expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe('')
     expect(store.get(LAST_PROFILE_ID_POE2_KEY)).toBe('')
     expect(store.get(PROFILE_VERSION_KEY)).toBe(2)
     expect(profiles.getProfile(poe2.id)).toBeNull()
+    const nullChange = changes.find((c) => c.key === 'activeProfile')
+    expect(nullChange).toBeDefined()
+    if (nullChange && nullChange.key === 'activeProfile') {
+      expect(nullChange.reason).toBe('activation')
+      expect(nullChange.value).toBeNull()
+    }
   })
 
   it('deleting an inactive last profile for a game clears that game without changing active profile', () => {
@@ -312,5 +319,49 @@ describe('profile-settings', () => {
     expect(legacy?.schemaVersion).toBe(1)
     expect(legacy?.createdAt).toEqual(expect.any(String))
     expect(legacy?.tradePriceOption).toBe('exalted_divine')
+  })
+
+  it('switching to a game variant with no profile clears the active profile', () => {
+    const profiles = setupProfiles()
+    const poe1 = profiles.createDefault(1)
+    profiles.saveProfile(poe1)
+
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+    })
+
+    const changes = switchActiveProfileByGameVariant(store, 2)
+
+    expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe('')
+    expect(store.get(PROFILE_VERSION_KEY)).toBe(2)
+    const nullChange = changes.find((c) => c.key === 'activeProfile')
+    expect(nullChange).toBeDefined()
+    if (nullChange && nullChange.key === 'activeProfile') {
+      expect(nullChange.reason).toBe('activation')
+      expect(nullChange.value).toBeNull()
+    }
+  })
+
+  it('returns default tradePriceOption when no profile is active', () => {
+    const store = makeStore({ [ACTIVE_PROFILE_ID_KEY]: '' })
+
+    expect(getProfileBackedSetting(store, 'tradePriceOption')).toBe('chaos_divine')
+  })
+
+  it('returns default cheatSheets when no profile is active', () => {
+    const store = makeStore({ [ACTIVE_PROFILE_ID_KEY]: '' })
+
+    expect(getProfileBackedSetting(store, 'cheatSheets')).toEqual({
+      globalHotkey: '',
+      categories: [],
+      pinned: false,
+    })
+  })
+
+  it('returns empty string for league when no profile is active', () => {
+    const store = makeStore({ [ACTIVE_PROFILE_ID_KEY]: '' })
+
+    expect(getProfileBackedSetting(store, 'league')).toBe('')
   })
 })

--- a/src/main/profile-settings.test.ts
+++ b/src/main/profile-settings.test.ts
@@ -11,10 +11,12 @@ import {
   LAST_PROFILE_ID_POE2_KEY,
   PROFILE_VERSION_KEY,
   deleteProfileAndChooseFallback,
+  getEffectiveSettings,
   listProfileSummaries,
   switchActiveProfileByGameVariant,
   writeActiveRegexPresetsByGameVariant,
   writeActiveProfileSetting,
+  writeLastUsedProfileSettingByGameVariant,
 } from './profile-settings'
 
 function makeStore(initial: Partial<AppSettings>): Store<AppSettings> {
@@ -33,7 +35,7 @@ function setupProfiles(): ReturnType<typeof initProfileStore> {
 }
 
 describe('profile-settings', () => {
-  it('writes active profile-backed settings to flat settings, mirror settings, and profile file', () => {
+  it('writes active profile-backed settings to the profile file without persisting flat config', () => {
     const profiles = setupProfiles()
     const poe1 = profiles.createDefault(1)
     profiles.saveProfile(poe1)
@@ -45,10 +47,12 @@ describe('profile-settings', () => {
       leaguePoe1: 'Mirage',
     })
 
-    writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
+    const changes = writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
 
-    expect(store.get('league')).toBe('Return of the Settlers')
-    expect(store.get('leaguePoe1')).toBe('Return of the Settlers')
+    expect(changes).toContainEqual({ key: 'league', value: 'Return of the Settlers' })
+    expect(store.get('league')).toBe('Mirage')
+    expect(store.get('leaguePoe1')).toBe('Mirage')
+    expect(getEffectiveSettings(store).league).toBe('Return of the Settlers')
     expect(profiles.getProfile(poe1.id)?.league).toBe('Return of the Settlers')
   })
 
@@ -66,10 +70,12 @@ describe('profile-settings', () => {
       leaguePoe1: 'Standard',
     })
 
-    writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
+    const changes = writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
 
-    expect(store.get('league')).toBe('Return of the Settlers')
-    expect(store.get('leaguePoe1')).toBe('Return of the Settlers')
+    expect(changes).toContainEqual({ key: 'league', value: 'Return of the Settlers' })
+    expect(store.get('league')).toBe('Standard')
+    expect(store.get('leaguePoe1')).toBe('Standard')
+    expect(getEffectiveSettings(store).league).toBe('Return of the Settlers')
     expect(profiles.getProfile(ssf.id)?.league).toBe('Return of the Settlers')
     expect(profiles.getProfile(trade.id)?.league).toBe('Mirage')
   })
@@ -100,6 +106,29 @@ describe('profile-settings', () => {
     expect(profiles.getProfile(trade.id)?.regexPresets).toEqual([])
   })
 
+  it('writes inactive profile settings to the last-used profile for that game', () => {
+    const profiles = setupProfiles()
+    const poe1 = profiles.createDefault(1)
+    const poe2 = { ...profiles.createDefault(2), league: 'Fate of the Vaal' }
+    profiles.saveProfile(poe1)
+    profiles.saveProfile(poe2)
+
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE2_KEY]: poe2.id,
+      league: 'Mirage',
+      leaguePoe2: 'Fate of the Vaal',
+    })
+
+    const changes = writeLastUsedProfileSettingByGameVariant(store, 2, 'league', 'Standard')
+
+    expect(changes).toEqual([])
+    expect(store.get('leaguePoe2')).toBe('Fate of the Vaal')
+    expect(store.get('league')).toBe('Mirage')
+    expect(profiles.getProfile(poe2.id)?.league).toBe('Standard')
+  })
+
   it('switches game variant from the target profile instead of stale mirror settings', () => {
     const profiles = setupProfiles()
     const poe1 = profiles.createDefault(1)
@@ -116,13 +145,16 @@ describe('profile-settings', () => {
       leaguePoe2: 'Stale League',
     })
 
-    switchActiveProfileByGameVariant(store, 2)
+    const changes = switchActiveProfileByGameVariant(store, 2)
 
     expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(poe2.id)
     expect(store.get(PROFILE_VERSION_KEY)).toBe(2)
-    expect(store.get('filterPath')).toBe('C:\\filters\\poe2.filter')
-    expect(store.get('filterPathPoe2')).toBe('C:\\filters\\poe2.filter')
-    expect(store.get('league')).toBe('Fate of the Vaal')
+    expect(store.get('filterPath')).toBe('C:\\filters\\poe1.filter')
+    expect(store.get('filterPathPoe2')).toBe('C:\\stale\\mirror.filter')
+    expect(changes).toContainEqual({ key: 'filterPath', value: 'C:\\filters\\poe2.filter' })
+    expect(changes).toContainEqual({ key: 'league', value: 'Fate of the Vaal' })
+    expect(getEffectiveSettings(store).filterPath).toBe('C:\\filters\\poe2.filter')
+    expect(getEffectiveSettings(store).league).toBe('Fate of the Vaal')
   })
 
   it('switches games to the explicit last-used profile instead of the newest touched profile', () => {
@@ -151,11 +183,13 @@ describe('profile-settings', () => {
       filterPath: 'C:\\filters\\poe1.filter',
     })
 
-    switchActiveProfileByGameVariant(store, 2)
+    const changes = switchActiveProfileByGameVariant(store, 2)
 
     expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(olderChoice.id)
     expect(store.get(LAST_PROFILE_ID_POE2_KEY)).toBe(olderChoice.id)
-    expect(store.get('filterPath')).toBe('C:\\filters\\bossing.filter')
+    expect(store.get('filterPath')).toBe('C:\\filters\\poe1.filter')
+    expect(changes).toContainEqual({ key: 'filterPath', value: 'C:\\filters\\bossing.filter' })
+    expect(getEffectiveSettings(store).filterPath).toBe('C:\\filters\\bossing.filter')
   })
 
   it('discovers multiple profiles per game and marks the active one', () => {
@@ -187,12 +221,60 @@ describe('profile-settings', () => {
       league: ssf.league,
     })
 
-    deleteProfileAndChooseFallback(store, ssf.id)
+    const changes = deleteProfileAndChooseFallback(store, ssf.id)
 
     expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(trade.id)
     expect(store.get(LAST_PROFILE_ID_POE1_KEY)).toBe(trade.id)
-    expect(store.get('league')).toBe('Mirage')
+    expect(store.get('league')).toBe('Standard')
+    expect(changes).toContainEqual({ key: 'league', value: 'Mirage' })
+    expect(getEffectiveSettings(store).league).toBe('Mirage')
     expect(profiles.getProfile(ssf.id)).toBeNull()
+  })
+
+  it('deleting the active last profile for a game leaves no active profile for that game', () => {
+    const profiles = setupProfiles()
+    const poe1 = { ...profiles.createDefault(1), league: 'Mirage' }
+    const poe2 = { ...profiles.createDefault(2), league: 'Fate of the Vaal' }
+    profiles.saveProfile(poe1)
+    profiles.saveProfile(poe2)
+
+    const store = makeStore({
+      [ACTIVE_PROFILE_ID_KEY]: poe2.id,
+      [LAST_PROFILE_ID_POE2_KEY]: poe2.id,
+      [PROFILE_VERSION_KEY]: 2,
+      league: poe2.league,
+    })
+
+    deleteProfileAndChooseFallback(store, poe2.id)
+
+    expect(profiles.listProfiles().find((profile) => profile.gameVariant === 2)).toBeUndefined()
+    expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe('')
+    expect(store.get(LAST_PROFILE_ID_POE2_KEY)).toBe('')
+    expect(store.get(PROFILE_VERSION_KEY)).toBe(2)
+    expect(profiles.getProfile(poe2.id)).toBeNull()
+  })
+
+  it('deleting an inactive last profile for a game clears that game without changing active profile', () => {
+    const profiles = setupProfiles()
+    const poe1 = { ...profiles.createDefault(1), league: 'Mirage' }
+    const poe2 = { ...profiles.createDefault(2), league: 'Fate of the Vaal' }
+    profiles.saveProfile(poe1)
+    profiles.saveProfile(poe2)
+
+    const store = makeStore({
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE2_KEY]: poe2.id,
+      [PROFILE_VERSION_KEY]: 1,
+      league: poe1.league,
+    })
+
+    deleteProfileAndChooseFallback(store, poe2.id)
+
+    expect(profiles.listProfiles().find((profile) => profile.gameVariant === 2)).toBeUndefined()
+    expect(store.get(ACTIVE_PROFILE_ID_KEY)).toBe(poe1.id)
+    expect(store.get(LAST_PROFILE_ID_POE2_KEY)).toBe('')
+    expect(store.get(PROFILE_VERSION_KEY)).toBe(1)
+    expect(store.get('league')).toBe('Mirage')
   })
 
   it('normalizes legacy profile files that are missing metadata', () => {

--- a/src/main/profile-settings.test.ts
+++ b/src/main/profile-settings.test.ts
@@ -1,0 +1,63 @@
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { describe, expect, it } from 'vitest'
+import type Store from 'electron-store'
+import type { AppSettings } from '../shared/types'
+import { initProfileStore } from './profiles/store'
+import { switchActiveProfileByGameVariant, writeActiveProfileSetting } from './profile-settings'
+
+function makeStore(initial: Partial<AppSettings>): Store<AppSettings> {
+  const data: Record<string, unknown> = { ...initial }
+  return {
+    get: (key: string) => data[key],
+    set: (key: string, value: unknown) => {
+      data[key] = value
+    },
+    store: data,
+  } as unknown as Store<AppSettings>
+}
+
+function setupProfiles(): ReturnType<typeof initProfileStore> {
+  return initProfileStore(mkdtempSync(join(tmpdir(), 'scalpel-profiles-')))
+}
+
+describe('profile-settings', () => {
+  it('writes active profile-backed settings to flat settings, mirror settings, and profile file', () => {
+    const profiles = setupProfiles()
+    const poe1 = profiles.createDefault(1)
+    profiles.saveProfile(poe1)
+
+    const store = makeStore({ poeVersion: 1, activeProfileId: poe1.id, league: 'Mirage', leaguePoe1: 'Mirage' })
+
+    writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
+
+    expect(store.get('league')).toBe('Return of the Settlers')
+    expect(store.get('leaguePoe1')).toBe('Return of the Settlers')
+    expect(profiles.getProfile(poe1.id)?.league).toBe('Return of the Settlers')
+  })
+
+  it('switches game variant from the target profile instead of stale mirror settings', () => {
+    const profiles = setupProfiles()
+    const poe1 = profiles.createDefault(1)
+    const poe2 = { ...profiles.createDefault(2), filterPath: 'C:\\filters\\poe2.filter', league: 'Fate of the Vaal' }
+    profiles.saveProfile(poe1)
+    profiles.saveProfile(poe2)
+
+    const store = makeStore({
+      poeVersion: 1,
+      activeProfileId: poe1.id,
+      filterPath: 'C:\\filters\\poe1.filter',
+      filterPathPoe2: 'C:\\stale\\mirror.filter',
+      leaguePoe2: 'Stale League',
+    })
+
+    switchActiveProfileByGameVariant(store, 2)
+
+    expect(store.get('activeProfileId')).toBe(poe2.id)
+    expect(store.get('poeVersion')).toBe(2)
+    expect(store.get('filterPath')).toBe('C:\\filters\\poe2.filter')
+    expect(store.get('filterPathPoe2')).toBe('C:\\filters\\poe2.filter')
+    expect(store.get('league')).toBe('Fate of the Vaal')
+  })
+})

--- a/src/main/profile-settings.test.ts
+++ b/src/main/profile-settings.test.ts
@@ -1,11 +1,16 @@
-import { mkdtempSync } from 'fs'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import { describe, expect, it } from 'vitest'
 import type Store from 'electron-store'
 import type { AppSettings } from '../shared/types'
 import { initProfileStore } from './profiles/store'
-import { switchActiveProfileByGameVariant, writeActiveProfileSetting } from './profile-settings'
+import {
+  deleteProfileAndChooseFallback,
+  listProfileSummaries,
+  switchActiveProfileByGameVariant,
+  writeActiveProfileSetting,
+} from './profile-settings'
 
 function makeStore(initial: Partial<AppSettings>): Store<AppSettings> {
   const data: Record<string, unknown> = { ...initial }
@@ -59,5 +64,53 @@ describe('profile-settings', () => {
     expect(store.get('filterPath')).toBe('C:\\filters\\poe2.filter')
     expect(store.get('filterPathPoe2')).toBe('C:\\filters\\poe2.filter')
     expect(store.get('league')).toBe('Fate of the Vaal')
+  })
+
+  it('discovers multiple profiles per game and marks the active one', () => {
+    const profiles = setupProfiles()
+    const trade = { ...profiles.createDefault(1), name: 'Mirage trade', league: 'Mirage' }
+    const ssf = { ...profiles.createDefault(1), name: 'SSF strict', league: 'Standard' }
+    profiles.saveProfile(trade)
+    profiles.saveProfile(ssf)
+
+    const store = makeStore({ activeProfileId: ssf.id })
+
+    const summaries = listProfileSummaries(store)
+
+    expect(summaries.filter((profile) => profile.gameVariant === 1)).toHaveLength(2)
+    expect(summaries.find((profile) => profile.id === ssf.id)?.active).toBe(true)
+  })
+
+  it('deleting the active profile switches to a remaining profile for the same game', () => {
+    const profiles = setupProfiles()
+    const trade = { ...profiles.createDefault(1), name: 'Mirage trade', league: 'Mirage' }
+    const ssf = { ...profiles.createDefault(1), name: 'SSF strict', league: 'Standard' }
+    profiles.saveProfile(trade)
+    profiles.saveProfile(ssf)
+
+    const store = makeStore({ activeProfileId: ssf.id, poeVersion: 1, league: ssf.league })
+
+    deleteProfileAndChooseFallback(store, ssf.id)
+
+    expect(store.get('activeProfileId')).toBe(trade.id)
+    expect(store.get('league')).toBe('Mirage')
+    expect(profiles.getProfile(ssf.id)).toBeNull()
+  })
+
+  it('normalizes legacy profile files that are missing metadata', () => {
+    const root = mkdtempSync(join(tmpdir(), 'scalpel-profiles-'))
+    mkdirSync(join(root, 'profiles'))
+    writeFileSync(
+      join(root, 'profiles', 'legacy.json'),
+      JSON.stringify({ id: 'legacy', name: 'Legacy', gameVariant: 2, league: 'Standard' }),
+      'utf-8',
+    )
+    const profiles = initProfileStore(root)
+
+    const legacy = profiles.getProfile('legacy')
+
+    expect(legacy?.schemaVersion).toBe(1)
+    expect(legacy?.createdAt).toEqual(expect.any(String))
+    expect(legacy?.tradePriceOption).toBe('exalted_divine')
   })
 })

--- a/src/main/profile-settings.test.ts
+++ b/src/main/profile-settings.test.ts
@@ -9,6 +9,7 @@ import {
   deleteProfileAndChooseFallback,
   listProfileSummaries,
   switchActiveProfileByGameVariant,
+  writeActiveRegexPresetsByGameVariant,
   writeActiveProfileSetting,
 } from './profile-settings'
 
@@ -40,6 +41,49 @@ describe('profile-settings', () => {
     expect(store.get('league')).toBe('Return of the Settlers')
     expect(store.get('leaguePoe1')).toBe('Return of the Settlers')
     expect(profiles.getProfile(poe1.id)?.league).toBe('Return of the Settlers')
+  })
+
+  it('writes same-game profile-backed settings only to the active profile', () => {
+    const profiles = setupProfiles()
+    const trade = { ...profiles.createDefault(1), name: 'Trade', league: 'Mirage' }
+    const ssf = { ...profiles.createDefault(1), name: 'SSF', league: 'Standard' }
+    profiles.saveProfile(trade)
+    profiles.saveProfile(ssf)
+
+    const store = makeStore({ poeVersion: 1, activeProfileId: ssf.id, league: 'Standard', leaguePoe1: 'Standard' })
+
+    writeActiveProfileSetting(store, 'league', 'Return of the Settlers')
+
+    expect(store.get('league')).toBe('Return of the Settlers')
+    expect(store.get('leaguePoe1')).toBe('Return of the Settlers')
+    expect(profiles.getProfile(ssf.id)?.league).toBe('Return of the Settlers')
+    expect(profiles.getProfile(trade.id)?.league).toBe('Mirage')
+  })
+
+  it('writes regex presets only to the active same-game profile', () => {
+    const profiles = setupProfiles()
+    const trade = { ...profiles.createDefault(1), name: 'Trade' }
+    const ssf = { ...profiles.createDefault(1), name: 'SSF' }
+    profiles.saveProfile(trade)
+    profiles.saveProfile(ssf)
+
+    const preset = {
+      id: 'preset-1',
+      regex: '"reflect"',
+      tags: [],
+      avoid: [],
+      want: [],
+      wantMode: 'any' as const,
+      qualifiers: {},
+      nightmare: false,
+    }
+    const store = makeStore({ poeVersion: 1, activeProfileId: ssf.id, regexPresetsPoe1: [] })
+
+    writeActiveRegexPresetsByGameVariant(store, 1, [preset])
+
+    expect(store.get('regexPresetsPoe1')).toEqual([preset])
+    expect(profiles.getProfile(ssf.id)?.regexPresets).toEqual([preset])
+    expect(profiles.getProfile(trade.id)?.regexPresets).toEqual([])
   })
 
   it('switches game variant from the target profile instead of stale mirror settings', () => {

--- a/src/main/profile-settings.ts
+++ b/src/main/profile-settings.ts
@@ -1,5 +1,5 @@
 import Store from 'electron-store'
-import type { AppSettings, GameVariant, PoeProfile, RegexPreset } from '../shared/types'
+import type { AppSettings, GameVariant, PoeProfile, PoeProfileSummary, RegexPreset } from '../shared/types'
 import { getProfileStore, type ProfileStore } from './profiles/store'
 
 export type ProfileBackedKey = 'league' | 'filterPath' | 'filterDir' | 'tradePriceOption' | 'cheatSheets'
@@ -75,7 +75,25 @@ export function findProfileByGameVariant(variant: GameVariant): PoeProfile | nul
   )
 }
 
+export function listProfileSummaries(store: Store<AppSettings>): PoeProfileSummary[] {
+  const activeId = store.get('activeProfileId')
+  return profileStore()
+    .listProfiles()
+    .map((profile) => ({
+      id: profile.id,
+      name: profile.name,
+      gameVariant: profile.gameVariant,
+      league: profile.league,
+      filterDir: profile.filterDir,
+      filterPath: profile.filterPath,
+      createdAt: profile.createdAt,
+      updatedAt: profile.updatedAt,
+      active: profile.id === activeId,
+    }))
+}
+
 export function hydrateProfileSettings(store: Store<AppSettings>, profile: PoeProfile): ProfileChangedSetting[] {
+  profileStore().touchProfile(profile.id)
   const changed: ProfileChangedSetting[] = []
   rememberChange(store, changed, 'activeProfileId', profile.id)
   rememberChange(store, changed, profileVersionKey, profile.gameVariant)
@@ -123,6 +141,40 @@ export function switchActiveProfileByGameVariant(
   return hydrateProfileSettings(store, profile)
 }
 
+export function createProfile(
+  store: Store<AppSettings>,
+  input: { name: string; gameVariant: GameVariant; cloneFromId?: string },
+): PoeProfile {
+  const profile = profileStore().createProfile(input)
+  if (profileStore().listProfiles().length === 1) hydrateProfileSettings(store, profile)
+  return profile
+}
+
+export function renameProfile(id: string, name: string): PoeProfile | null {
+  return profileStore().renameProfile(id, name)
+}
+
+export function deleteProfileAndChooseFallback(store: Store<AppSettings>, id: string): ProfileChangedSetting[] {
+  const activeId = store.get('activeProfileId')
+  const deleting = profileStore().getProfile(id)
+  profileStore().deleteProfile(id)
+
+  let remaining = profileStore().listProfiles()
+  if (remaining.length === 0) {
+    const created = profileStore().createProfile({
+      name: 'Path of Exile 1',
+      gameVariant: 1,
+    })
+    remaining = [created]
+  }
+
+  if (activeId !== id) return []
+
+  const fallback =
+    (deleting ? remaining.find((profile) => profile.gameVariant === deleting.gameVariant) : null) ?? remaining[0]
+  return hydrateProfileSettings(store, fallback)
+}
+
 export function writeActiveProfileSetting<K extends ProfileBackedKey>(
   store: Store<AppSettings>,
   key: K,
@@ -138,6 +190,7 @@ export function writeActiveProfileSetting<K extends ProfileBackedKey>(
   const profile = activeId ? profileStore().getProfile(activeId) : findProfileByGameVariant(variant)
   if (profile) {
     ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
+    profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
   }
 
@@ -156,6 +209,7 @@ export function writeProfileSettingByGameVariant<K extends ProfileBackedKey>(
   const profile = findProfileByGameVariant(variant)
   if (profile) {
     ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
+    profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
   }
 
@@ -177,6 +231,7 @@ export function writeRegexPresetsByGameVariant(
   const profile = findProfileByGameVariant(variant)
   if (profile) {
     profile.regexPresets = presets
+    profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
   }
 

--- a/src/main/profile-settings.ts
+++ b/src/main/profile-settings.ts
@@ -7,6 +7,7 @@ import type {
   ProfileSettingKey,
   ProfileSettingValue,
   RegexPreset,
+  RuntimeSettings,
 } from '../shared/types'
 import { getProfileStore, type ProfileStore } from './profiles/store'
 
@@ -73,11 +74,13 @@ export function getProfileBackedSetting<K extends ProfileSettingKey>(
 ): ProfileSettingValue<K> {
   const active = getActiveProfile(store)
   if (active) return active[key]
-  return (active?.[key] ??
-    (key === 'cheatSheets' ? { globalHotkey: '', categories: [], pinned: false } : '')) as ProfileSettingValue<K>
+  if (key === 'cheatSheets')
+    return { globalHotkey: '', categories: [], pinned: false } as unknown as ProfileSettingValue<K>
+  if (key === 'tradePriceOption') return 'chaos_divine' as unknown as ProfileSettingValue<K>
+  return '' as unknown as ProfileSettingValue<K>
 }
 
-export function getEffectiveSettings(store: Store<AppSettings>): AppSettings & { activeProfile: PoeProfile | null } {
+export function getEffectiveSettings(store: Store<AppSettings>): RuntimeSettings {
   const settings = { ...store.store } as AppSettings
   return { ...settings, activeProfile: getActiveProfile(store) }
 }
@@ -148,6 +151,8 @@ export function switchActiveProfileByGameVariant(
   if (!profile) {
     const changed: ProfileChangedSetting[] = []
     rememberChange(store, changed, PROFILE_VERSION_KEY, variant)
+    rememberChange(store, changed, ACTIVE_PROFILE_ID_KEY, '')
+    changed.push({ key: 'activeProfile', value: null, reason: 'activation' })
     return changed
   }
   return hydrateProfileSettings(store, profile)
@@ -179,6 +184,7 @@ export function deleteProfileAndChooseFallback(store: Store<AppSettings>, id: st
   const fallback = deleting ? remaining.find((profile) => profile.gameVariant === deleting.gameVariant) : null
   if (!fallback) {
     rememberChange(store, changed, ACTIVE_PROFILE_ID_KEY, '')
+    changed.push({ key: 'activeProfile', value: null, reason: 'activation' })
     return changed
   }
   for (const change of hydrateProfileSettings(store, fallback)) {

--- a/src/main/profile-settings.ts
+++ b/src/main/profile-settings.ts
@@ -1,47 +1,22 @@
 import Store from 'electron-store'
-import type { AppSettings, CheatSheetsSettings, GameVariant, PoeProfile, PoeProfileSummary, RegexPreset, TradePriceOption } from '../shared/types'
+import type {
+  AppSettings,
+  GameVariant,
+  PoeProfile,
+  PoeProfileSummary,
+  ProfileSettingKey,
+  ProfileSettingValue,
+  RegexPreset,
+} from '../shared/types'
 import { getProfileStore, type ProfileStore } from './profiles/store'
 
-export type ProfileBackedKey = 'league' | 'filterPath' | 'filterDir' | 'tradePriceOption' | 'cheatSheets'
-export type SettingChangeKey = keyof AppSettings | ProfileBackedKey
-
-/** Map a SettingChangeKey to its settable value type. */
-export type SettingValue<K extends SettingChangeKey> =
-  K extends keyof AppSettings ? AppSettings[K]
-  : K extends ProfileBackedKey ? PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]]
-  : never
-
-/** A single setting change with its fully-resolved value type. */
 export type ProfileChangedSetting =
-  | ({ [K in keyof AppSettings]: { key: K; value: AppSettings[K] } })[keyof AppSettings]
-  | ({ [K in ProfileBackedKey]: { key: K; value: PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]] } })[ProfileBackedKey]
+  | { key: 'activeProfile'; value: PoeProfile | null; reason: 'activation' | 'edit' | 'migration' }
+  | { key: keyof AppSettings; value: unknown }
 
-/** The union of all profile-backed value types (useful at IPC boundaries). */
-export type ProfileBackedValue = SettingValue<ProfileBackedKey>
+export type SettingChangeKey = keyof AppSettings | 'activeProfile'
 
-const PROFILE_BACKED_KEYS = [
-  'league',
-  'filterPath',
-  'filterDir',
-  'tradePriceOption',
-  'cheatSheets',
-] as const satisfies readonly ProfileBackedKey[]
-
-const PROFILE_FIELD_BY_KEY = {
-  league: 'league',
-  filterPath: 'filterPath',
-  filterDir: 'filterDir',
-  tradePriceOption: 'tradePriceOption',
-  cheatSheets: 'cheatSheets',
-} as const satisfies Record<ProfileBackedKey, keyof PoeProfile>
-
-const PROFILE_BACKED_DEFAULTS = {
-  league: '',
-  filterPath: '',
-  filterDir: '',
-  tradePriceOption: 'chaos_divine' as TradePriceOption,
-  cheatSheets: { globalHotkey: '', categories: [], pinned: false } as CheatSheetsSettings,
-} satisfies { [K in ProfileBackedKey]: SettingValue<K> }
+export type { ProfileSettingKey, ProfileSettingValue }
 
 export const ACTIVE_PROFILE_ID_KEY = 'activeProfileId' satisfies keyof AppSettings
 export const PROFILE_VERSION_KEY = 'poeVersion' satisfies keyof AppSettings
@@ -76,25 +51,8 @@ function rememberChange<K extends keyof AppSettings>(
 ): void {
   if (store.get(key) === value) return
   store.set(key, value)
-  changed.push({ key, value })
-}
-
-function rememberRuntimeChange<K extends SettingChangeKey>(changed: ProfileChangedSetting[], key: K, value: SettingValue<K>): void {
   changed.push({ key, value } as ProfileChangedSetting)
 }
-
-function rememberActiveProfileChange(
-  store: Store<AppSettings>,
-  changed: ProfileChangedSetting[],
-): void {
-  const profile = getActiveProfile(store)
-  changed.push({ key: 'activeProfile', value: profile })
-}
-
-export function isProfileBackedKey(key: string): key is ProfileBackedKey {
-  return (PROFILE_BACKED_KEYS as readonly string[]).includes(key)
-}
-
 export function findLastUsedProfileByGameVariant(store: Store<AppSettings>, variant: GameVariant): PoeProfile | null {
   const profiles =
     maybeProfileStore()
@@ -109,16 +67,19 @@ export function getActiveProfile(store: Store<AppSettings>): PoeProfile | null {
   return id ? (maybeProfileStore()?.getProfile(id) ?? null) : null
 }
 
-export function getProfileBackedSetting<K extends ProfileBackedKey>(store: Store<AppSettings>, key: K): PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]] {
+export function getProfileBackedSetting<K extends ProfileSettingKey>(
+  store: Store<AppSettings>,
+  key: K,
+): ProfileSettingValue<K> {
   const active = getActiveProfile(store)
-  if (active) return active[PROFILE_FIELD_BY_KEY[key]]
-  return PROFILE_BACKED_DEFAULTS[key]
+  if (active) return active[key]
+  return (active?.[key] ??
+    (key === 'cheatSheets' ? { globalHotkey: '', categories: [], pinned: false } : '')) as ProfileSettingValue<K>
 }
 
-export function getEffectiveSettings(store: Store<AppSettings>): AppSettings {
+export function getEffectiveSettings(store: Store<AppSettings>): AppSettings & { activeProfile: PoeProfile | null } {
   const settings = { ...store.store } as AppSettings
-  settings.activeProfile = getActiveProfile(store)
-  return settings
+  return { ...settings, activeProfile: getActiveProfile(store) }
 }
 
 export function listProfilesByGameVariant(variant: GameVariant): PoeProfile[] {
@@ -152,12 +113,7 @@ export function hydrateProfileSettings(store: Store<AppSettings>, profile: PoePr
   rememberChange(store, changed, ACTIVE_PROFILE_ID_KEY, profile.id)
   rememberChange(store, changed, lastProfileIdKey(profile.gameVariant), profile.id)
   rememberChange(store, changed, PROFILE_VERSION_KEY, profile.gameVariant)
-  rememberRuntimeChange(changed, 'league', profile.league)
-  rememberRuntimeChange(changed, 'filterPath', profile.filterPath)
-  rememberRuntimeChange(changed, 'filterDir', profile.filterDir)
-  rememberRuntimeChange(changed, 'tradePriceOption', profile.tradePriceOption)
-  rememberRuntimeChange(changed, 'cheatSheets', profile.cheatSheets)
-  rememberActiveProfileChange(store, changed)
+  changed.push({ key: 'activeProfile', value: profile, reason: 'activation' })
   rememberChange(store, changed, regexKey(profile.gameVariant), profile.regexPresets)
 
   return changed
@@ -197,12 +153,8 @@ export function switchActiveProfileByGameVariant(
   return hydrateProfileSettings(store, profile)
 }
 
-export function createProfile(
-  store: Store<AppSettings>,
-  input: { name: string; gameVariant: GameVariant; cloneFromId?: string },
-): PoeProfile {
-  const profile = profileStore().createProfile(input)
-  return profile
+export function createProfile(input: { name: string; gameVariant: GameVariant; cloneFromId?: string }): PoeProfile {
+  return profileStore().createProfile(input)
 }
 
 export function renameProfile(id: string, name: string): PoeProfile | null {
@@ -235,54 +187,44 @@ export function deleteProfileAndChooseFallback(store: Store<AppSettings>, id: st
   return changed
 }
 
-export function writeActiveProfileSetting<K extends ProfileBackedKey>(
+export function writeActiveProfileSetting<K extends ProfileSettingKey>(
   store: Store<AppSettings>,
   key: K,
-  value: PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]],
+  value: ProfileSettingValue<K>,
 ): ProfileChangedSetting[] {
-  const changed: ProfileChangedSetting[] = []
-  const variant = store.get(PROFILE_VERSION_KEY) === 2 ? 2 : 1
-
   const activeId = store.get(ACTIVE_PROFILE_ID_KEY)
   const profile = activeId ? profileStore().getProfile(activeId) : null
-  if (profile && profile.gameVariant === variant) {
-    profile[PROFILE_FIELD_BY_KEY[key] as keyof PoeProfile] = value as PoeProfile[keyof PoeProfile]
+  if (profile) {
+    profile[key] = value
     profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
   }
-
-  rememberRuntimeChange(changed, key, value)
-  rememberActiveProfileChange(store, changed)
-
-  return changed
+  return [{ key: 'activeProfile', value: getActiveProfile(store), reason: 'edit' }]
 }
 
-export function writeLastUsedProfileSettingByGameVariant<K extends ProfileBackedKey>(
+export function writeLastUsedProfileSettingByGameVariant<K extends ProfileSettingKey>(
   store: Store<AppSettings>,
   variant: GameVariant,
   key: K,
-  value: PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]],
+  value: ProfileSettingValue<K>,
 ): ProfileChangedSetting[] {
-  const changed: ProfileChangedSetting[] = []
-
   let profile = findLastUsedProfileByGameVariant(store, variant)
   if (!profile) {
     profile = profileStore().createProfile({ name: `Path of Exile ${variant}`, gameVariant: variant })
-    rememberChange(store, changed, lastProfileIdKey(variant), profile.id)
-    if (!store.get(ACTIVE_PROFILE_ID_KEY)) rememberChange(store, changed, ACTIVE_PROFILE_ID_KEY, profile.id)
+    store.set(lastProfileIdKey(variant), profile.id)
+    if (!store.get(ACTIVE_PROFILE_ID_KEY)) store.set(ACTIVE_PROFILE_ID_KEY, profile.id)
   }
   if (profile) {
-    profile[PROFILE_FIELD_BY_KEY[key] as keyof PoeProfile] = value as PoeProfile[keyof PoeProfile]
+    profile[key] = value
     profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
   }
 
-  if (store.get(PROFILE_VERSION_KEY) === variant) {
-    rememberRuntimeChange(changed, key, value)
-    rememberActiveProfileChange(store, changed)
+  const activeId = store.get(ACTIVE_PROFILE_ID_KEY)
+  if (activeId && profile && profile.id === activeId) {
+    return [{ key: 'activeProfile', value: getActiveProfile(store), reason: 'edit' }]
   }
-
-  return changed
+  return []
 }
 
 export function writeActiveRegexPresetsByGameVariant(

--- a/src/main/profile-settings.ts
+++ b/src/main/profile-settings.ts
@@ -150,6 +150,16 @@ export function switchActiveProfileById(store: Store<AppSettings>, id: string): 
   return profile ? hydrateProfileSettings(store, profile) : []
 }
 
+export function getProfileById(id: string): PoeProfile | null {
+  return profileStore().getProfile(id)
+}
+
+export function persistProfileSwitchForRestart(store: Store<AppSettings>, profile: PoeProfile): void {
+  store.set(ACTIVE_PROFILE_ID_KEY, profile.id)
+  store.set(lastProfileIdKey(profile.gameVariant), profile.id)
+  store.set(PROFILE_VERSION_KEY, profile.gameVariant)
+}
+
 export function switchActiveProfileByGameVariant(
   store: Store<AppSettings>,
   variant: GameVariant,

--- a/src/main/profile-settings.ts
+++ b/src/main/profile-settings.ts
@@ -1,0 +1,184 @@
+import Store from 'electron-store'
+import type { AppSettings, GameVariant, PoeProfile, RegexPreset } from '../shared/types'
+import { getProfileStore, type ProfileStore } from './profiles/store'
+
+export type ProfileBackedKey = 'league' | 'filterPath' | 'filterDir' | 'tradePriceOption' | 'cheatSheets'
+export type ProfileChangedSetting = { key: keyof AppSettings; value: AppSettings[keyof AppSettings] }
+
+const PROFILE_BACKED_KEYS = [
+  'league',
+  'filterPath',
+  'filterDir',
+  'tradePriceOption',
+  'cheatSheets',
+] as const satisfies readonly ProfileBackedKey[]
+
+const PROFILE_BACKED_KEY_SET = new Set<keyof AppSettings>(PROFILE_BACKED_KEYS)
+
+const PROFILE_FIELD_BY_KEY = {
+  league: 'league',
+  filterPath: 'filterPath',
+  filterDir: 'filterDir',
+  tradePriceOption: 'tradePriceOption',
+  cheatSheets: 'cheatSheets',
+} as const satisfies Record<ProfileBackedKey, keyof PoeProfile>
+
+const MIRROR_BY_KEY = {
+  league: ['leaguePoe1', 'leaguePoe2'],
+  filterPath: ['filterPathPoe1', 'filterPathPoe2'],
+  filterDir: ['filterDirPoe1', 'filterDirPoe2'],
+  tradePriceOption: ['tradePriceOptionPoe1', 'tradePriceOptionPoe2'],
+  cheatSheets: ['cheatSheetsPoe1', 'cheatSheetsPoe2'],
+} as const satisfies Record<ProfileBackedKey, readonly [keyof AppSettings, keyof AppSettings]>
+
+const profileVersionKey = 'poeVersion'
+function profileStore(): ProfileStore {
+  return getProfileStore()
+}
+
+function maybeProfileStore(): ProfileStore | null {
+  try {
+    return getProfileStore()
+  } catch {
+    return null
+  }
+}
+
+function mirrorKey(key: ProfileBackedKey, variant: GameVariant): keyof AppSettings {
+  return MIRROR_BY_KEY[key][variant === 2 ? 1 : 0]
+}
+
+function regexKey(variant: GameVariant): 'regexPresetsPoe1' | 'regexPresetsPoe2' {
+  return variant === 2 ? 'regexPresetsPoe2' : 'regexPresetsPoe1'
+}
+
+function rememberChange<K extends keyof AppSettings>(
+  store: Store<AppSettings>,
+  changed: ProfileChangedSetting[],
+  key: K,
+  value: AppSettings[K],
+): void {
+  if (store.get(key) === value) return
+  store.set(key, value)
+  changed.push({ key, value })
+}
+
+export function isProfileBackedKey(key: keyof AppSettings): key is ProfileBackedKey {
+  return PROFILE_BACKED_KEY_SET.has(key)
+}
+
+export function findProfileByGameVariant(variant: GameVariant): PoeProfile | null {
+  return (
+    maybeProfileStore()
+      ?.listProfiles()
+      .find((p) => p.gameVariant === variant) ?? null
+  )
+}
+
+export function hydrateProfileSettings(store: Store<AppSettings>, profile: PoeProfile): ProfileChangedSetting[] {
+  const changed: ProfileChangedSetting[] = []
+  rememberChange(store, changed, 'activeProfileId', profile.id)
+  rememberChange(store, changed, profileVersionKey, profile.gameVariant)
+  rememberChange(store, changed, 'league', profile.league)
+  rememberChange(store, changed, 'filterPath', profile.filterPath)
+  rememberChange(store, changed, 'filterDir', profile.filterDir)
+  rememberChange(store, changed, 'tradePriceOption', profile.tradePriceOption)
+  rememberChange(store, changed, 'cheatSheets', profile.cheatSheets)
+
+  for (const key of PROFILE_BACKED_KEYS) {
+    const field = PROFILE_FIELD_BY_KEY[key]
+    rememberChange(
+      store,
+      changed,
+      mirrorKey(key, profile.gameVariant),
+      profile[field] as AppSettings[keyof AppSettings],
+    )
+  }
+  rememberChange(store, changed, regexKey(profile.gameVariant), profile.regexPresets)
+
+  return changed
+}
+
+export function hydrateActiveProfileSettings(store: Store<AppSettings>): ProfileChangedSetting[] {
+  const id = store.get('activeProfileId')
+  const profile = id ? profileStore().getProfile(id) : null
+  return profile ? hydrateProfileSettings(store, profile) : []
+}
+
+export function switchActiveProfileById(store: Store<AppSettings>, id: string): ProfileChangedSetting[] {
+  const profile = profileStore().getProfile(id)
+  return profile ? hydrateProfileSettings(store, profile) : []
+}
+
+export function switchActiveProfileByGameVariant(
+  store: Store<AppSettings>,
+  variant: GameVariant,
+): ProfileChangedSetting[] {
+  const profile = findProfileByGameVariant(variant)
+  if (!profile) {
+    const changed: ProfileChangedSetting[] = []
+    rememberChange(store, changed, profileVersionKey, variant)
+    return changed
+  }
+  return hydrateProfileSettings(store, profile)
+}
+
+export function writeActiveProfileSetting<K extends ProfileBackedKey>(
+  store: Store<AppSettings>,
+  key: K,
+  value: AppSettings[K],
+): ProfileChangedSetting[] {
+  const changed: ProfileChangedSetting[] = []
+  rememberChange(store, changed, key, value)
+
+  const variant = store.get(profileVersionKey) === 2 ? 2 : 1
+  rememberChange(store, changed, mirrorKey(key, variant), value as AppSettings[keyof AppSettings])
+
+  const activeId = store.get('activeProfileId')
+  const profile = activeId ? profileStore().getProfile(activeId) : findProfileByGameVariant(variant)
+  if (profile) {
+    ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
+    profileStore().saveProfile(profile)
+  }
+
+  return changed
+}
+
+export function writeProfileSettingByGameVariant<K extends ProfileBackedKey>(
+  store: Store<AppSettings>,
+  variant: GameVariant,
+  key: K,
+  value: AppSettings[K],
+): ProfileChangedSetting[] {
+  const changed: ProfileChangedSetting[] = []
+  rememberChange(store, changed, mirrorKey(key, variant), value as AppSettings[keyof AppSettings])
+
+  const profile = findProfileByGameVariant(variant)
+  if (profile) {
+    ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
+    profileStore().saveProfile(profile)
+  }
+
+  if (store.get(profileVersionKey) === variant) {
+    rememberChange(store, changed, key, value)
+  }
+
+  return changed
+}
+
+export function writeRegexPresetsByGameVariant(
+  store: Store<AppSettings>,
+  variant: GameVariant,
+  presets: RegexPreset[],
+): ProfileChangedSetting[] {
+  const changed: ProfileChangedSetting[] = []
+  rememberChange(store, changed, regexKey(variant), presets)
+
+  const profile = findProfileByGameVariant(variant)
+  if (profile) {
+    profile.regexPresets = presets
+    profileStore().saveProfile(profile)
+  }
+
+  return changed
+}

--- a/src/main/profile-settings.ts
+++ b/src/main/profile-settings.ts
@@ -23,6 +23,11 @@ const PROFILE_FIELD_BY_KEY = {
   cheatSheets: 'cheatSheets',
 } as const satisfies Record<ProfileBackedKey, keyof PoeProfile>
 
+export const ACTIVE_PROFILE_ID_KEY = 'activeProfileId' satisfies keyof AppSettings
+export const PROFILE_VERSION_KEY = 'poeVersion' satisfies keyof AppSettings
+export const LAST_PROFILE_ID_POE1_KEY = 'lastProfileIdPoe1' satisfies keyof AppSettings
+export const LAST_PROFILE_ID_POE2_KEY = 'lastProfileIdPoe2' satisfies keyof AppSettings
+
 const MIRROR_BY_KEY = {
   league: ['leaguePoe1', 'leaguePoe2'],
   filterPath: ['filterPathPoe1', 'filterPathPoe2'],
@@ -31,7 +36,6 @@ const MIRROR_BY_KEY = {
   cheatSheets: ['cheatSheetsPoe1', 'cheatSheetsPoe2'],
 } as const satisfies Record<ProfileBackedKey, readonly [keyof AppSettings, keyof AppSettings]>
 
-const profileVersionKey = 'poeVersion'
 function profileStore(): ProfileStore {
   return getProfileStore()
 }
@@ -52,6 +56,10 @@ function regexKey(variant: GameVariant): 'regexPresetsPoe1' | 'regexPresetsPoe2'
   return variant === 2 ? 'regexPresetsPoe2' : 'regexPresetsPoe1'
 }
 
+function lastProfileIdKey(variant: GameVariant): 'lastProfileIdPoe1' | 'lastProfileIdPoe2' {
+  return variant === 2 ? LAST_PROFILE_ID_POE2_KEY : LAST_PROFILE_ID_POE1_KEY
+}
+
 function rememberChange<K extends keyof AppSettings>(
   store: Store<AppSettings>,
   changed: ProfileChangedSetting[],
@@ -67,16 +75,17 @@ export function isProfileBackedKey(key: keyof AppSettings): key is ProfileBacked
   return PROFILE_BACKED_KEY_SET.has(key)
 }
 
-export function findProfileByGameVariant(variant: GameVariant): PoeProfile | null {
-  return findLastUsedProfileByGameVariant(variant)
+export function findProfileByGameVariant(store: Store<AppSettings>, variant: GameVariant): PoeProfile | null {
+  return findLastUsedProfileByGameVariant(store, variant)
 }
 
-export function findLastUsedProfileByGameVariant(variant: GameVariant): PoeProfile | null {
-  return (
+export function findLastUsedProfileByGameVariant(store: Store<AppSettings>, variant: GameVariant): PoeProfile | null {
+  const profiles =
     maybeProfileStore()
       ?.listProfiles()
-      .find((p) => p.gameVariant === variant) ?? null
-  )
+      .filter((p) => p.gameVariant === variant) ?? []
+  const lastId = store.get(lastProfileIdKey(variant))
+  return profiles.find((profile) => profile.id === lastId) ?? profiles[0] ?? null
 }
 
 export function listProfilesByGameVariant(variant: GameVariant): PoeProfile[] {
@@ -88,7 +97,7 @@ export function listProfilesByGameVariant(variant: GameVariant): PoeProfile[] {
 }
 
 export function listProfileSummaries(store: Store<AppSettings>): PoeProfileSummary[] {
-  const activeId = store.get('activeProfileId')
+  const activeId = store.get(ACTIVE_PROFILE_ID_KEY)
   return profileStore()
     .listProfiles()
     .map((profile) => ({
@@ -107,8 +116,9 @@ export function listProfileSummaries(store: Store<AppSettings>): PoeProfileSumma
 export function hydrateProfileSettings(store: Store<AppSettings>, profile: PoeProfile): ProfileChangedSetting[] {
   profileStore().touchProfile(profile.id)
   const changed: ProfileChangedSetting[] = []
-  rememberChange(store, changed, 'activeProfileId', profile.id)
-  rememberChange(store, changed, profileVersionKey, profile.gameVariant)
+  rememberChange(store, changed, ACTIVE_PROFILE_ID_KEY, profile.id)
+  rememberChange(store, changed, lastProfileIdKey(profile.gameVariant), profile.id)
+  rememberChange(store, changed, PROFILE_VERSION_KEY, profile.gameVariant)
   rememberChange(store, changed, 'league', profile.league)
   rememberChange(store, changed, 'filterPath', profile.filterPath)
   rememberChange(store, changed, 'filterDir', profile.filterDir)
@@ -130,7 +140,7 @@ export function hydrateProfileSettings(store: Store<AppSettings>, profile: PoePr
 }
 
 export function hydrateActiveProfileSettings(store: Store<AppSettings>): ProfileChangedSetting[] {
-  const id = store.get('activeProfileId')
+  const id = store.get(ACTIVE_PROFILE_ID_KEY)
   const profile = id ? profileStore().getProfile(id) : null
   return profile ? hydrateProfileSettings(store, profile) : []
 }
@@ -144,10 +154,10 @@ export function switchActiveProfileByGameVariant(
   store: Store<AppSettings>,
   variant: GameVariant,
 ): ProfileChangedSetting[] {
-  const profile = findLastUsedProfileByGameVariant(variant)
+  const profile = findLastUsedProfileByGameVariant(store, variant)
   if (!profile) {
     const changed: ProfileChangedSetting[] = []
-    rememberChange(store, changed, profileVersionKey, variant)
+    rememberChange(store, changed, PROFILE_VERSION_KEY, variant)
     return changed
   }
   return hydrateProfileSettings(store, profile)
@@ -167,9 +177,10 @@ export function renameProfile(id: string, name: string): PoeProfile | null {
 }
 
 export function deleteProfileAndChooseFallback(store: Store<AppSettings>, id: string): ProfileChangedSetting[] {
-  const activeId = store.get('activeProfileId')
+  const activeId = store.get(ACTIVE_PROFILE_ID_KEY)
   const deleting = profileStore().getProfile(id)
   profileStore().deleteProfile(id)
+  const changed: ProfileChangedSetting[] = []
 
   let remaining = profileStore().listProfiles()
   if (remaining.length === 0) {
@@ -180,11 +191,19 @@ export function deleteProfileAndChooseFallback(store: Store<AppSettings>, id: st
     remaining = [created]
   }
 
-  if (activeId !== id) return []
+  if (deleting && store.get(lastProfileIdKey(deleting.gameVariant)) === id) {
+    const fallbackLast = remaining.find((profile) => profile.gameVariant === deleting.gameVariant)
+    rememberChange(store, changed, lastProfileIdKey(deleting.gameVariant), fallbackLast?.id ?? '')
+  }
+
+  if (activeId !== id) return changed
 
   const fallback =
     (deleting ? remaining.find((profile) => profile.gameVariant === deleting.gameVariant) : null) ?? remaining[0]
-  return hydrateProfileSettings(store, fallback)
+  for (const change of hydrateProfileSettings(store, fallback)) {
+    if (!changed.some((existing) => existing.key === change.key)) changed.push(change)
+  }
+  return changed
 }
 
 export function writeActiveProfileSetting<K extends ProfileBackedKey>(
@@ -195,10 +214,10 @@ export function writeActiveProfileSetting<K extends ProfileBackedKey>(
   const changed: ProfileChangedSetting[] = []
   rememberChange(store, changed, key, value)
 
-  const variant = store.get(profileVersionKey) === 2 ? 2 : 1
+  const variant = store.get(PROFILE_VERSION_KEY) === 2 ? 2 : 1
   rememberChange(store, changed, mirrorKey(key, variant), value as AppSettings[keyof AppSettings])
 
-  const activeId = store.get('activeProfileId')
+  const activeId = store.get(ACTIVE_PROFILE_ID_KEY)
   const profile = activeId ? profileStore().getProfile(activeId) : null
   if (profile && profile.gameVariant === variant) {
     ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
@@ -218,14 +237,14 @@ export function writeLastUsedProfileSettingByGameVariant<K extends ProfileBacked
   const changed: ProfileChangedSetting[] = []
   rememberChange(store, changed, mirrorKey(key, variant), value as AppSettings[keyof AppSettings])
 
-  const profile = findLastUsedProfileByGameVariant(variant)
+  const profile = findLastUsedProfileByGameVariant(store, variant)
   if (profile) {
     ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
     profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
   }
 
-  if (store.get(profileVersionKey) === variant) {
+  if (store.get(PROFILE_VERSION_KEY) === variant) {
     rememberChange(store, changed, key, value)
   }
 
@@ -240,7 +259,7 @@ export function writeActiveRegexPresetsByGameVariant(
   const changed: ProfileChangedSetting[] = []
   rememberChange(store, changed, regexKey(variant), presets)
 
-  const activeId = store.get('activeProfileId')
+  const activeId = store.get(ACTIVE_PROFILE_ID_KEY)
   const profile = activeId ? profileStore().getProfile(activeId) : null
   if (profile && profile.gameVariant === variant) {
     profile.regexPresets = presets

--- a/src/main/profile-settings.ts
+++ b/src/main/profile-settings.ts
@@ -1,9 +1,23 @@
 import Store from 'electron-store'
-import type { AppSettings, GameVariant, PoeProfile, PoeProfileSummary, RegexPreset } from '../shared/types'
+import type { AppSettings, CheatSheetsSettings, GameVariant, PoeProfile, PoeProfileSummary, RegexPreset, TradePriceOption } from '../shared/types'
 import { getProfileStore, type ProfileStore } from './profiles/store'
 
 export type ProfileBackedKey = 'league' | 'filterPath' | 'filterDir' | 'tradePriceOption' | 'cheatSheets'
-export type ProfileChangedSetting = { key: keyof AppSettings; value: AppSettings[keyof AppSettings] }
+export type SettingChangeKey = keyof AppSettings | ProfileBackedKey
+
+/** Map a SettingChangeKey to its settable value type. */
+export type SettingValue<K extends SettingChangeKey> =
+  K extends keyof AppSettings ? AppSettings[K]
+  : K extends ProfileBackedKey ? PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]]
+  : never
+
+/** A single setting change with its fully-resolved value type. */
+export type ProfileChangedSetting =
+  | ({ [K in keyof AppSettings]: { key: K; value: AppSettings[K] } })[keyof AppSettings]
+  | ({ [K in ProfileBackedKey]: { key: K; value: PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]] } })[ProfileBackedKey]
+
+/** The union of all profile-backed value types (useful at IPC boundaries). */
+export type ProfileBackedValue = SettingValue<ProfileBackedKey>
 
 const PROFILE_BACKED_KEYS = [
   'league',
@@ -13,8 +27,6 @@ const PROFILE_BACKED_KEYS = [
   'cheatSheets',
 ] as const satisfies readonly ProfileBackedKey[]
 
-const PROFILE_BACKED_KEY_SET = new Set<keyof AppSettings>(PROFILE_BACKED_KEYS)
-
 const PROFILE_FIELD_BY_KEY = {
   league: 'league',
   filterPath: 'filterPath',
@@ -23,18 +35,18 @@ const PROFILE_FIELD_BY_KEY = {
   cheatSheets: 'cheatSheets',
 } as const satisfies Record<ProfileBackedKey, keyof PoeProfile>
 
+const PROFILE_BACKED_DEFAULTS = {
+  league: '',
+  filterPath: '',
+  filterDir: '',
+  tradePriceOption: 'chaos_divine' as TradePriceOption,
+  cheatSheets: { globalHotkey: '', categories: [], pinned: false } as CheatSheetsSettings,
+} satisfies { [K in ProfileBackedKey]: SettingValue<K> }
+
 export const ACTIVE_PROFILE_ID_KEY = 'activeProfileId' satisfies keyof AppSettings
 export const PROFILE_VERSION_KEY = 'poeVersion' satisfies keyof AppSettings
 export const LAST_PROFILE_ID_POE1_KEY = 'lastProfileIdPoe1' satisfies keyof AppSettings
 export const LAST_PROFILE_ID_POE2_KEY = 'lastProfileIdPoe2' satisfies keyof AppSettings
-
-const MIRROR_BY_KEY = {
-  league: ['leaguePoe1', 'leaguePoe2'],
-  filterPath: ['filterPathPoe1', 'filterPathPoe2'],
-  filterDir: ['filterDirPoe1', 'filterDirPoe2'],
-  tradePriceOption: ['tradePriceOptionPoe1', 'tradePriceOptionPoe2'],
-  cheatSheets: ['cheatSheetsPoe1', 'cheatSheetsPoe2'],
-} as const satisfies Record<ProfileBackedKey, readonly [keyof AppSettings, keyof AppSettings]>
 
 function profileStore(): ProfileStore {
   return getProfileStore()
@@ -46,10 +58,6 @@ function maybeProfileStore(): ProfileStore | null {
   } catch {
     return null
   }
-}
-
-function mirrorKey(key: ProfileBackedKey, variant: GameVariant): keyof AppSettings {
-  return MIRROR_BY_KEY[key][variant === 2 ? 1 : 0]
 }
 
 function regexKey(variant: GameVariant): 'regexPresetsPoe1' | 'regexPresetsPoe2' {
@@ -71,12 +79,20 @@ function rememberChange<K extends keyof AppSettings>(
   changed.push({ key, value })
 }
 
-export function isProfileBackedKey(key: keyof AppSettings): key is ProfileBackedKey {
-  return PROFILE_BACKED_KEY_SET.has(key)
+function rememberRuntimeChange<K extends SettingChangeKey>(changed: ProfileChangedSetting[], key: K, value: SettingValue<K>): void {
+  changed.push({ key, value } as ProfileChangedSetting)
 }
 
-export function findProfileByGameVariant(store: Store<AppSettings>, variant: GameVariant): PoeProfile | null {
-  return findLastUsedProfileByGameVariant(store, variant)
+function rememberActiveProfileChange(
+  store: Store<AppSettings>,
+  changed: ProfileChangedSetting[],
+): void {
+  const profile = getActiveProfile(store)
+  changed.push({ key: 'activeProfile', value: profile })
+}
+
+export function isProfileBackedKey(key: string): key is ProfileBackedKey {
+  return (PROFILE_BACKED_KEYS as readonly string[]).includes(key)
 }
 
 export function findLastUsedProfileByGameVariant(store: Store<AppSettings>, variant: GameVariant): PoeProfile | null {
@@ -86,6 +102,23 @@ export function findLastUsedProfileByGameVariant(store: Store<AppSettings>, vari
       .filter((p) => p.gameVariant === variant) ?? []
   const lastId = store.get(lastProfileIdKey(variant))
   return profiles.find((profile) => profile.id === lastId) ?? profiles[0] ?? null
+}
+
+export function getActiveProfile(store: Store<AppSettings>): PoeProfile | null {
+  const id = store.get(ACTIVE_PROFILE_ID_KEY)
+  return id ? (maybeProfileStore()?.getProfile(id) ?? null) : null
+}
+
+export function getProfileBackedSetting<K extends ProfileBackedKey>(store: Store<AppSettings>, key: K): PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]] {
+  const active = getActiveProfile(store)
+  if (active) return active[PROFILE_FIELD_BY_KEY[key]]
+  return PROFILE_BACKED_DEFAULTS[key]
+}
+
+export function getEffectiveSettings(store: Store<AppSettings>): AppSettings {
+  const settings = { ...store.store } as AppSettings
+  settings.activeProfile = getActiveProfile(store)
+  return settings
 }
 
 export function listProfilesByGameVariant(variant: GameVariant): PoeProfile[] {
@@ -119,21 +152,12 @@ export function hydrateProfileSettings(store: Store<AppSettings>, profile: PoePr
   rememberChange(store, changed, ACTIVE_PROFILE_ID_KEY, profile.id)
   rememberChange(store, changed, lastProfileIdKey(profile.gameVariant), profile.id)
   rememberChange(store, changed, PROFILE_VERSION_KEY, profile.gameVariant)
-  rememberChange(store, changed, 'league', profile.league)
-  rememberChange(store, changed, 'filterPath', profile.filterPath)
-  rememberChange(store, changed, 'filterDir', profile.filterDir)
-  rememberChange(store, changed, 'tradePriceOption', profile.tradePriceOption)
-  rememberChange(store, changed, 'cheatSheets', profile.cheatSheets)
-
-  for (const key of PROFILE_BACKED_KEYS) {
-    const field = PROFILE_FIELD_BY_KEY[key]
-    rememberChange(
-      store,
-      changed,
-      mirrorKey(key, profile.gameVariant),
-      profile[field] as AppSettings[keyof AppSettings],
-    )
-  }
+  rememberRuntimeChange(changed, 'league', profile.league)
+  rememberRuntimeChange(changed, 'filterPath', profile.filterPath)
+  rememberRuntimeChange(changed, 'filterDir', profile.filterDir)
+  rememberRuntimeChange(changed, 'tradePriceOption', profile.tradePriceOption)
+  rememberRuntimeChange(changed, 'cheatSheets', profile.cheatSheets)
+  rememberActiveProfileChange(store, changed)
   rememberChange(store, changed, regexKey(profile.gameVariant), profile.regexPresets)
 
   return changed
@@ -178,7 +202,6 @@ export function createProfile(
   input: { name: string; gameVariant: GameVariant; cloneFromId?: string },
 ): PoeProfile {
   const profile = profileStore().createProfile(input)
-  if (profileStore().listProfiles().length === 1) hydrateProfileSettings(store, profile)
   return profile
 }
 
@@ -192,14 +215,7 @@ export function deleteProfileAndChooseFallback(store: Store<AppSettings>, id: st
   profileStore().deleteProfile(id)
   const changed: ProfileChangedSetting[] = []
 
-  let remaining = profileStore().listProfiles()
-  if (remaining.length === 0) {
-    const created = profileStore().createProfile({
-      name: 'Path of Exile 1',
-      gameVariant: 1,
-    })
-    remaining = [created]
-  }
+  const remaining = profileStore().listProfiles()
 
   if (deleting && store.get(lastProfileIdKey(deleting.gameVariant)) === id) {
     const fallbackLast = remaining.find((profile) => profile.gameVariant === deleting.gameVariant)
@@ -208,8 +224,11 @@ export function deleteProfileAndChooseFallback(store: Store<AppSettings>, id: st
 
   if (activeId !== id) return changed
 
-  const fallback =
-    (deleting ? remaining.find((profile) => profile.gameVariant === deleting.gameVariant) : null) ?? remaining[0]
+  const fallback = deleting ? remaining.find((profile) => profile.gameVariant === deleting.gameVariant) : null
+  if (!fallback) {
+    rememberChange(store, changed, ACTIVE_PROFILE_ID_KEY, '')
+    return changed
+  }
   for (const change of hydrateProfileSettings(store, fallback)) {
     if (!changed.some((existing) => existing.key === change.key)) changed.push(change)
   }
@@ -219,21 +238,21 @@ export function deleteProfileAndChooseFallback(store: Store<AppSettings>, id: st
 export function writeActiveProfileSetting<K extends ProfileBackedKey>(
   store: Store<AppSettings>,
   key: K,
-  value: AppSettings[K],
+  value: PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]],
 ): ProfileChangedSetting[] {
   const changed: ProfileChangedSetting[] = []
-  rememberChange(store, changed, key, value)
-
   const variant = store.get(PROFILE_VERSION_KEY) === 2 ? 2 : 1
-  rememberChange(store, changed, mirrorKey(key, variant), value as AppSettings[keyof AppSettings])
 
   const activeId = store.get(ACTIVE_PROFILE_ID_KEY)
   const profile = activeId ? profileStore().getProfile(activeId) : null
   if (profile && profile.gameVariant === variant) {
-    ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
+    profile[PROFILE_FIELD_BY_KEY[key] as keyof PoeProfile] = value as PoeProfile[keyof PoeProfile]
     profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
   }
+
+  rememberRuntimeChange(changed, key, value)
+  rememberActiveProfileChange(store, changed)
 
   return changed
 }
@@ -242,20 +261,25 @@ export function writeLastUsedProfileSettingByGameVariant<K extends ProfileBacked
   store: Store<AppSettings>,
   variant: GameVariant,
   key: K,
-  value: AppSettings[K],
+  value: PoeProfile[typeof PROFILE_FIELD_BY_KEY[K]],
 ): ProfileChangedSetting[] {
   const changed: ProfileChangedSetting[] = []
-  rememberChange(store, changed, mirrorKey(key, variant), value as AppSettings[keyof AppSettings])
 
-  const profile = findLastUsedProfileByGameVariant(store, variant)
+  let profile = findLastUsedProfileByGameVariant(store, variant)
+  if (!profile) {
+    profile = profileStore().createProfile({ name: `Path of Exile ${variant}`, gameVariant: variant })
+    rememberChange(store, changed, lastProfileIdKey(variant), profile.id)
+    if (!store.get(ACTIVE_PROFILE_ID_KEY)) rememberChange(store, changed, ACTIVE_PROFILE_ID_KEY, profile.id)
+  }
   if (profile) {
-    ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
+    profile[PROFILE_FIELD_BY_KEY[key] as keyof PoeProfile] = value as PoeProfile[keyof PoeProfile]
     profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
   }
 
   if (store.get(PROFILE_VERSION_KEY) === variant) {
-    rememberChange(store, changed, key, value)
+    rememberRuntimeChange(changed, key, value)
+    rememberActiveProfileChange(store, changed)
   }
 
   return changed

--- a/src/main/profile-settings.ts
+++ b/src/main/profile-settings.ts
@@ -68,10 +68,22 @@ export function isProfileBackedKey(key: keyof AppSettings): key is ProfileBacked
 }
 
 export function findProfileByGameVariant(variant: GameVariant): PoeProfile | null {
+  return findLastUsedProfileByGameVariant(variant)
+}
+
+export function findLastUsedProfileByGameVariant(variant: GameVariant): PoeProfile | null {
   return (
     maybeProfileStore()
       ?.listProfiles()
       .find((p) => p.gameVariant === variant) ?? null
+  )
+}
+
+export function listProfilesByGameVariant(variant: GameVariant): PoeProfile[] {
+  return (
+    maybeProfileStore()
+      ?.listProfiles()
+      .filter((profile) => profile.gameVariant === variant) ?? []
   )
 }
 
@@ -132,7 +144,7 @@ export function switchActiveProfileByGameVariant(
   store: Store<AppSettings>,
   variant: GameVariant,
 ): ProfileChangedSetting[] {
-  const profile = findProfileByGameVariant(variant)
+  const profile = findLastUsedProfileByGameVariant(variant)
   if (!profile) {
     const changed: ProfileChangedSetting[] = []
     rememberChange(store, changed, profileVersionKey, variant)
@@ -187,8 +199,8 @@ export function writeActiveProfileSetting<K extends ProfileBackedKey>(
   rememberChange(store, changed, mirrorKey(key, variant), value as AppSettings[keyof AppSettings])
 
   const activeId = store.get('activeProfileId')
-  const profile = activeId ? profileStore().getProfile(activeId) : findProfileByGameVariant(variant)
-  if (profile) {
+  const profile = activeId ? profileStore().getProfile(activeId) : null
+  if (profile && profile.gameVariant === variant) {
     ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
     profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
@@ -197,7 +209,7 @@ export function writeActiveProfileSetting<K extends ProfileBackedKey>(
   return changed
 }
 
-export function writeProfileSettingByGameVariant<K extends ProfileBackedKey>(
+export function writeLastUsedProfileSettingByGameVariant<K extends ProfileBackedKey>(
   store: Store<AppSettings>,
   variant: GameVariant,
   key: K,
@@ -206,7 +218,7 @@ export function writeProfileSettingByGameVariant<K extends ProfileBackedKey>(
   const changed: ProfileChangedSetting[] = []
   rememberChange(store, changed, mirrorKey(key, variant), value as AppSettings[keyof AppSettings])
 
-  const profile = findProfileByGameVariant(variant)
+  const profile = findLastUsedProfileByGameVariant(variant)
   if (profile) {
     ;(profile as unknown as Record<string, unknown>)[PROFILE_FIELD_BY_KEY[key]] = value
     profile.updatedAt = new Date().toISOString()
@@ -220,7 +232,7 @@ export function writeProfileSettingByGameVariant<K extends ProfileBackedKey>(
   return changed
 }
 
-export function writeRegexPresetsByGameVariant(
+export function writeActiveRegexPresetsByGameVariant(
   store: Store<AppSettings>,
   variant: GameVariant,
   presets: RegexPreset[],
@@ -228,8 +240,9 @@ export function writeRegexPresetsByGameVariant(
   const changed: ProfileChangedSetting[] = []
   rememberChange(store, changed, regexKey(variant), presets)
 
-  const profile = findProfileByGameVariant(variant)
-  if (profile) {
+  const activeId = store.get('activeProfileId')
+  const profile = activeId ? profileStore().getProfile(activeId) : null
+  if (profile && profile.gameVariant === variant) {
     profile.regexPresets = presets
     profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)

--- a/src/main/profiles/profile-settings.test.ts
+++ b/src/main/profiles/profile-settings.test.ts
@@ -3,8 +3,8 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { describe, expect, it } from 'vitest'
 import type Store from 'electron-store'
-import type { AppSettings } from '../shared/types'
-import { initProfileStore } from './profiles/store'
+import type { AppSettings } from '../../shared/types'
+import { initProfileStore } from './store'
 import {
   ACTIVE_PROFILE_ID_KEY,
   LAST_PROFILE_ID_POE1_KEY,

--- a/src/main/profiles/profile-settings.ts
+++ b/src/main/profiles/profile-settings.ts
@@ -8,8 +8,8 @@ import type {
   ProfileSettingValue,
   RegexPreset,
   RuntimeSettings,
-} from '../shared/types'
-import { getProfileStore, type ProfileStore } from './profiles/store'
+} from '../../shared/types'
+import { getProfileStore, type ProfileStore } from './store'
 
 export type ProfileChangedSetting =
   | { key: 'activeProfile'; value: PoeProfile | null; reason: 'activation' | 'edit' | 'migration' }

--- a/src/main/profiles/store.ts
+++ b/src/main/profiles/store.ts
@@ -2,7 +2,7 @@ import { writeFileSync, readFileSync, existsSync, mkdirSync, readdirSync, unlink
 import { join } from 'path'
 import { randomUUID } from 'crypto'
 import type Store from 'electron-store'
-import type { AppSettings, PoeProfile, GameVariant } from '../../shared/types'
+import type { AppSettings, PoeProfile, GameVariant, LegacyAppSettings } from '../../shared/types'
 
 let _instance: ProfileStore | null = null
 
@@ -172,26 +172,38 @@ export class ProfileStore {
   /** Seed profiles from the legacy per-version mirror keys stored in electron-store.
    *  Returns the created profiles so the caller can pick the active one. */
   migrateFromLegacy(appStore: Store<AppSettings>): PoeProfile[] {
-    const poe1 = this.createDefault(1)
-    const poe2 = this.createDefault(2)
+    const store = appStore as unknown as Store<AppSettings & LegacyAppSettings>
+    const created: PoeProfile[] = []
+    const hasPoe1Data =
+      Boolean(store.get('filterPathPoe1') || store.get('filterDirPoe1')) || Boolean(store.get('filterPath'))
+    const hasPoe2Data = Boolean(store.get('filterPathPoe2') || store.get('filterDirPoe2'))
 
-    poe1.filterPath = appStore.get('filterPathPoe1') ?? ''
-    poe1.filterDir = appStore.get('filterDirPoe1') ?? ''
-    poe1.league = appStore.get('leaguePoe1') ?? poe1.league
-    poe1.tradePriceOption = appStore.get('tradePriceOptionPoe1') ?? poe1.tradePriceOption
-    poe1.cheatSheets = appStore.get('cheatSheetsPoe1') ?? poe1.cheatSheets
-    poe1.regexPresets = appStore.get('regexPresetsPoe1') ?? []
+    if (hasPoe1Data) {
+      const poe1 = this.createDefault(1)
 
-    poe2.filterPath = appStore.get('filterPathPoe2') ?? ''
-    poe2.filterDir = appStore.get('filterDirPoe2') ?? ''
-    poe2.league = appStore.get('leaguePoe2') ?? poe2.league
-    poe2.tradePriceOption = appStore.get('tradePriceOptionPoe2') ?? poe2.tradePriceOption
-    poe2.cheatSheets = appStore.get('cheatSheetsPoe2') ?? poe2.cheatSheets
-    poe2.regexPresets = appStore.get('regexPresetsPoe2') ?? []
+      poe1.filterPath = store.get('filterPathPoe1') || store.get('filterPath') || ''
+      poe1.filterDir = store.get('filterDirPoe1') || store.get('filterDir') || ''
+      poe1.league = store.get('leaguePoe1') ?? poe1.league
+      poe1.tradePriceOption = store.get('tradePriceOptionPoe1') ?? poe1.tradePriceOption
+      poe1.cheatSheets = store.get('cheatSheetsPoe1') ?? poe1.cheatSheets
+      poe1.regexPresets = store.get('regexPresetsPoe1') ?? []
+      this.saveProfile(poe1)
+      created.push(poe1)
+    }
 
-    this.saveProfile(poe1)
-    this.saveProfile(poe2)
+    if (hasPoe2Data) {
+      const poe2 = this.createDefault(2)
 
-    return [poe1, poe2]
+      poe2.filterPath = store.get('filterPathPoe2') ?? ''
+      poe2.filterDir = store.get('filterDirPoe2') ?? ''
+      poe2.league = store.get('leaguePoe2') ?? poe2.league
+      poe2.tradePriceOption = store.get('tradePriceOptionPoe2') ?? poe2.tradePriceOption
+      poe2.cheatSheets = store.get('cheatSheetsPoe2') ?? poe2.cheatSheets
+      poe2.regexPresets = store.get('regexPresetsPoe2') ?? []
+      this.saveProfile(poe2)
+      created.push(poe2)
+    }
+
+    return created
   }
 }

--- a/src/main/profiles/store.ts
+++ b/src/main/profiles/store.ts
@@ -1,0 +1,113 @@
+import { writeFileSync, readFileSync, existsSync, mkdirSync, readdirSync } from 'fs'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import type Store from 'electron-store'
+import type { AppSettings, PoeProfile, GameVariant } from '../../shared/types'
+
+let _instance: ProfileStore | null = null
+
+export function getProfileStore(): ProfileStore {
+  if (!_instance) throw new Error('ProfileStore not initialized')
+  return _instance
+}
+
+export function initProfileStore(userDataPath: string): ProfileStore {
+  _instance = new ProfileStore(userDataPath)
+  return _instance
+}
+
+export class ProfileStore {
+  private dir: string
+
+  constructor(userDataPath: string) {
+    this.dir = join(userDataPath, 'profiles')
+  }
+
+  ensureDir(): void {
+    if (!existsSync(this.dir)) {
+      mkdirSync(this.dir, { recursive: true })
+    }
+  }
+
+  private filePath(id: string): string {
+    return join(this.dir, `${id}.json`)
+  }
+
+  listProfiles(): PoeProfile[] {
+    this.ensureDir()
+    const profiles: PoeProfile[] = []
+    try {
+      for (const f of readdirSync(this.dir)) {
+        if (!f.endsWith('.json')) continue
+        try {
+          const data = readFileSync(join(this.dir, f), 'utf-8')
+          const profile = JSON.parse(data) as PoeProfile
+          if (profile.id && profile.gameVariant !== undefined) {
+            profiles.push(profile)
+          }
+        } catch {
+          /* skip invalid files */
+        }
+      }
+    } catch {
+      /* dir may not exist yet */
+    }
+    return profiles
+  }
+
+  getProfile(id: string): PoeProfile | null {
+    const path = this.filePath(id)
+    try {
+      if (!existsSync(path)) return null
+      return JSON.parse(readFileSync(path, 'utf-8')) as PoeProfile
+    } catch {
+      return null
+    }
+  }
+
+  saveProfile(profile: PoeProfile): void {
+    this.ensureDir()
+    writeFileSync(this.filePath(profile.id), JSON.stringify(profile, null, 2), 'utf-8')
+  }
+
+  createDefault(variant: GameVariant): PoeProfile {
+    const isPoe2 = variant === 2
+    return {
+      id: randomUUID(),
+      name: `Path of Exile ${isPoe2 ? '2' : '1'}`,
+      gameVariant: variant,
+      filterDir: '',
+      filterPath: '',
+      league: isPoe2 ? 'Fate of the Vaal' : 'Mirage',
+      tradePriceOption: isPoe2 ? 'exalted_divine' : 'chaos_divine',
+      cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+      regexPresets: [],
+    }
+  }
+
+  /** Seed profiles from the legacy per-version mirror keys stored in electron-store.
+   *  Returns the created profiles so the caller can pick the active one. */
+  migrateFromLegacy(appStore: Store<AppSettings>): PoeProfile[] {
+    const poe1 = this.createDefault(1)
+    const poe2 = this.createDefault(2)
+
+    poe1.filterPath = appStore.get('filterPathPoe1') ?? ''
+    poe1.filterDir = appStore.get('filterDirPoe1') ?? ''
+    poe1.league = appStore.get('leaguePoe1') ?? poe1.league
+    poe1.tradePriceOption = appStore.get('tradePriceOptionPoe1') ?? poe1.tradePriceOption
+    poe1.cheatSheets = appStore.get('cheatSheetsPoe1') ?? poe1.cheatSheets
+    poe1.regexPresets = appStore.get('regexPresetsPoe1') ?? []
+
+    poe2.filterPath = appStore.get('filterPathPoe2') ?? ''
+    poe2.filterDir = appStore.get('filterDirPoe2') ?? ''
+    poe2.league = appStore.get('leaguePoe2') ?? poe2.league
+    poe2.tradePriceOption = appStore.get('tradePriceOptionPoe2') ?? poe2.tradePriceOption
+    poe2.cheatSheets = appStore.get('cheatSheetsPoe2') ?? poe2.cheatSheets
+    poe2.regexPresets = appStore.get('regexPresetsPoe2') ?? []
+
+    this.saveProfile(poe1)
+    this.saveProfile(poe2)
+
+    return [poe1, poe2]
+  }
+}

--- a/src/main/profiles/store.ts
+++ b/src/main/profiles/store.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, readFileSync, existsSync, mkdirSync, readdirSync } from 'fs'
+import { writeFileSync, readFileSync, existsSync, mkdirSync, readdirSync, unlinkSync } from 'fs'
 import { join } from 'path'
 import { randomUUID } from 'crypto'
 import type Store from 'electron-store'
@@ -30,7 +30,40 @@ export class ProfileStore {
   }
 
   private filePath(id: string): string {
-    return join(this.dir, `${id}.json`)
+    return join(this.dir, `${id.replace(/[\\/]/g, '_')}.json`)
+  }
+
+  private normalize(raw: Partial<PoeProfile>): PoeProfile | null {
+    const variant = raw.gameVariant === 2 ? 2 : raw.gameVariant === 1 ? 1 : null
+    if (!raw.id || !variant) return null
+    const fallback = this.defaultValues(variant)
+    const now = new Date().toISOString()
+    return {
+      schemaVersion: 1,
+      id: raw.id,
+      name: typeof raw.name === 'string' && raw.name.trim() ? raw.name.trim() : fallback.name,
+      gameVariant: variant,
+      createdAt: typeof raw.createdAt === 'string' && raw.createdAt ? raw.createdAt : now,
+      updatedAt: typeof raw.updatedAt === 'string' && raw.updatedAt ? raw.updatedAt : now,
+      filterDir: typeof raw.filterDir === 'string' ? raw.filterDir : '',
+      filterPath: typeof raw.filterPath === 'string' ? raw.filterPath : '',
+      league: typeof raw.league === 'string' && raw.league ? raw.league : fallback.league,
+      tradePriceOption: raw.tradePriceOption ?? fallback.tradePriceOption,
+      cheatSheets: raw.cheatSheets ?? fallback.cheatSheets,
+      regexPresets: Array.isArray(raw.regexPresets) ? raw.regexPresets : [],
+    }
+  }
+
+  private defaultValues(
+    variant: GameVariant,
+  ): Pick<PoeProfile, 'name' | 'league' | 'tradePriceOption' | 'cheatSheets'> {
+    const isPoe2 = variant === 2
+    return {
+      name: `Path of Exile ${isPoe2 ? '2' : '1'}`,
+      league: isPoe2 ? 'Fate of the Vaal' : 'Mirage',
+      tradePriceOption: isPoe2 ? 'exalted_divine' : 'chaos_divine',
+      cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+    }
   }
 
   listProfiles(): PoeProfile[] {
@@ -41,8 +74,8 @@ export class ProfileStore {
         if (!f.endsWith('.json')) continue
         try {
           const data = readFileSync(join(this.dir, f), 'utf-8')
-          const profile = JSON.parse(data) as PoeProfile
-          if (profile.id && profile.gameVariant !== undefined) {
+          const profile = this.normalize(JSON.parse(data) as Partial<PoeProfile>)
+          if (profile) {
             profiles.push(profile)
           }
         } catch {
@@ -52,14 +85,14 @@ export class ProfileStore {
     } catch {
       /* dir may not exist yet */
     }
-    return profiles
+    return profiles.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
   }
 
   getProfile(id: string): PoeProfile | null {
     const path = this.filePath(id)
     try {
       if (!existsSync(path)) return null
-      return JSON.parse(readFileSync(path, 'utf-8')) as PoeProfile
+      return this.normalize(JSON.parse(readFileSync(path, 'utf-8')) as Partial<PoeProfile>)
     } catch {
       return null
     }
@@ -67,22 +100,73 @@ export class ProfileStore {
 
   saveProfile(profile: PoeProfile): void {
     this.ensureDir()
-    writeFileSync(this.filePath(profile.id), JSON.stringify(profile, null, 2), 'utf-8')
+    const normalized = this.normalize(profile)
+    if (!normalized) return
+    writeFileSync(this.filePath(normalized.id), JSON.stringify(normalized, null, 2), 'utf-8')
+  }
+
+  deleteProfile(id: string): void {
+    try {
+      unlinkSync(this.filePath(id))
+    } catch {
+      /* already gone */
+    }
   }
 
   createDefault(variant: GameVariant): PoeProfile {
-    const isPoe2 = variant === 2
+    const defaults = this.defaultValues(variant)
+    const now = new Date().toISOString()
     return {
+      schemaVersion: 1,
       id: randomUUID(),
-      name: `Path of Exile ${isPoe2 ? '2' : '1'}`,
+      name: defaults.name,
       gameVariant: variant,
+      createdAt: now,
+      updatedAt: now,
       filterDir: '',
       filterPath: '',
-      league: isPoe2 ? 'Fate of the Vaal' : 'Mirage',
-      tradePriceOption: isPoe2 ? 'exalted_divine' : 'chaos_divine',
-      cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+      league: defaults.league,
+      tradePriceOption: defaults.tradePriceOption,
+      cheatSheets: defaults.cheatSheets,
       regexPresets: [],
     }
+  }
+
+  createProfile(input: { name: string; gameVariant: GameVariant; cloneFromId?: string }): PoeProfile {
+    const source = input.cloneFromId ? this.getProfile(input.cloneFromId) : null
+    if (input.cloneFromId && !source) throw new Error('Profile not found')
+    const now = new Date().toISOString()
+    const base = source ? (JSON.parse(JSON.stringify(source)) as PoeProfile) : this.createDefault(input.gameVariant)
+    const profile: PoeProfile = {
+      ...base,
+      id: randomUUID(),
+      name: input.name.trim() || (source ? `${source.name} copy` : base.name),
+      createdAt: now,
+      updatedAt: now,
+    }
+    profile.schemaVersion = 1
+    profile.gameVariant = source?.gameVariant ?? input.gameVariant
+    profile.createdAt = now
+    profile.updatedAt = now
+    this.saveProfile(profile)
+    return profile
+  }
+
+  renameProfile(id: string, name: string): PoeProfile | null {
+    const profile = this.getProfile(id)
+    if (!profile) return null
+    profile.name = name.trim() || profile.name
+    profile.updatedAt = new Date().toISOString()
+    this.saveProfile(profile)
+    return profile
+  }
+
+  touchProfile(id: string): PoeProfile | null {
+    const profile = this.getProfile(id)
+    if (!profile) return null
+    profile.updatedAt = new Date().toISOString()
+    this.saveProfile(profile)
+    return profile
   }
 
   /** Seed profiles from the legacy per-version mirror keys stored in electron-store.

--- a/src/main/settings-write.test.ts
+++ b/src/main/settings-write.test.ts
@@ -38,6 +38,10 @@ vi.mock('./hotkeys', () => ({
   setStashScrollEnabled: vi.fn(),
 }))
 
+vi.mock('./online-sync', () => ({
+  updateOnlineSyncDir: vi.fn(),
+}))
+
 vi.mock('./pinned-zone', () => ({
   applyPinnedZoneEnabled: vi.fn(),
   getPinnedZoneOverlay: vi.fn(() => null),
@@ -70,5 +74,14 @@ describe('settings-write side effects', () => {
     applyProfileHydrationSideEffects(changes, { [PROFILE_VERSION_KEY]: 2, league: 'Fate of the Vaal' })
 
     expect(observedVersions).toEqual([1])
+  })
+
+  it('updates online sync directory when filterDir changes', async () => {
+    const { updateOnlineSyncDir } = await import('./online-sync')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    applyProfileHydrationSideEffects([{ key: 'filterDir', value: 'C:\\filters' }], { filterDir: 'C:\\old' })
+
+    expect(updateOnlineSyncDir).toHaveBeenCalledWith('C:\\filters')
   })
 })

--- a/src/main/settings-write.test.ts
+++ b/src/main/settings-write.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { getPoeVersion, setPoeVersion } from './game-state'
-import { PROFILE_VERSION_KEY, type ProfileChangedSetting } from './profile-settings'
+import { PROFILE_VERSION_KEY, type ProfileChangedSetting } from './profiles/profile-settings'
 import type { AppSettings, PoeProfile } from '../shared/types'
 
 vi.mock('./filter-state', () => ({

--- a/src/main/settings-write.test.ts
+++ b/src/main/settings-write.test.ts
@@ -1,7 +1,33 @@
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type Store from 'electron-store'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { getPoeVersion, setPoeVersion } from './game-state'
-import { PROFILE_VERSION_KEY, type ProfileChangedSetting } from './profiles/profile-settings'
+import {
+  ACTIVE_PROFILE_ID_KEY,
+  LAST_PROFILE_ID_POE1_KEY,
+  LAST_PROFILE_ID_POE2_KEY,
+  PROFILE_VERSION_KEY,
+  type ProfileChangedSetting,
+} from './profiles/profile-settings'
+import { initProfileStore } from './profiles/store'
 import type { AppSettings, PoeProfile } from '../shared/types'
+
+function makeStore(initial: Record<string, unknown>): Store<AppSettings> {
+  const data: Record<string, unknown> = { ...initial }
+  return {
+    get: (key: string) => data[key],
+    set: (key: string, value: unknown) => {
+      data[key] = value
+    },
+    store: data,
+  } as unknown as Store<AppSettings>
+}
+
+function setupProfiles(): ReturnType<typeof initProfileStore> {
+  return initProfileStore(mkdtempSync(join(tmpdir(), 'scalpel-edit-fx-')))
+}
 
 vi.mock('./filter-state', () => ({
   clearFilterState: vi.fn(),
@@ -352,5 +378,107 @@ describe('settings-write side effects', () => {
       filterPath: 'a.filter',
     })
     expect(send).not.toHaveBeenCalledWith('league-updated', expect.any(String))
+  })
+})
+
+describe('applyProfileSettingForGame edit side effects', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reloads the in-memory filter when the active profile filterPath is edited', async () => {
+    const { loadFilter } = await import('./filter-state')
+    const { applyProfileSettingForGame } = await import('./settings-write')
+    const profiles = setupProfiles()
+    const poe1 = { ...profiles.createDefault(1), filterPath: 'C:\\old.filter' }
+    profiles.saveProfile(poe1)
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
+    })
+
+    applyProfileSettingForGame(store, 1, 'filterPath', 'C:\\new.filter', null)
+
+    expect(loadFilter).toHaveBeenCalledWith('C:\\new.filter', 'Switched Filters')
+    expect(profiles.getProfile(poe1.id)?.filterPath).toBe('C:\\new.filter')
+  })
+
+  it('clears filter state when the active profile filterPath is edited to empty', async () => {
+    const { loadFilter, clearFilterState } = await import('./filter-state')
+    const { applyProfileSettingForGame } = await import('./settings-write')
+    const profiles = setupProfiles()
+    const poe1 = { ...profiles.createDefault(1), filterPath: 'C:\\old.filter' }
+    profiles.saveProfile(poe1)
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
+    })
+
+    applyProfileSettingForGame(store, 1, 'filterPath', '', null)
+
+    expect(loadFilter).not.toHaveBeenCalled()
+    expect(clearFilterState).toHaveBeenCalled()
+  })
+
+  it('re-points online sync when the active profile filterDir is edited', async () => {
+    const { updateOnlineSyncDir } = await import('./online-sync')
+    const { applyProfileSettingForGame } = await import('./settings-write')
+    const profiles = setupProfiles()
+    const poe1 = profiles.createDefault(1)
+    profiles.saveProfile(poe1)
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
+    })
+
+    applyProfileSettingForGame(store, 1, 'filterDir', 'C:\\filters', null)
+
+    expect(updateOnlineSyncDir).toHaveBeenCalledWith('C:\\filters')
+  })
+
+  it('re-registers cheat-sheet hotkeys and pinned zone when the active profile cheatSheets is edited', async () => {
+    const { applyCheatSheetHotkeys } = await import('./cheat-sheets')
+    const { applyPinnedZoneEnabled } = await import('./pinned-zone')
+    const { applyProfileSettingForGame } = await import('./settings-write')
+    const profiles = setupProfiles()
+    const poe1 = profiles.createDefault(1)
+    profiles.saveProfile(poe1)
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
+    })
+    const cheatSheets = { globalHotkey: 'Ctrl+X', categories: [], pinned: true }
+
+    applyProfileSettingForGame(store, 1, 'cheatSheets', cheatSheets, null)
+
+    expect(applyCheatSheetHotkeys).toHaveBeenCalledWith(cheatSheets)
+    expect(applyPinnedZoneEnabled).toHaveBeenCalledWith(true)
+  })
+
+  it('does not run side effects when editing the inactive game profile', async () => {
+    const { loadFilter } = await import('./filter-state')
+    const { updateOnlineSyncDir } = await import('./online-sync')
+    const { applyProfileSettingForGame } = await import('./settings-write')
+    const profiles = setupProfiles()
+    const poe1 = profiles.createDefault(1)
+    const poe2 = profiles.createDefault(2)
+    profiles.saveProfile(poe1)
+    profiles.saveProfile(poe2)
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE2_KEY]: poe2.id,
+    })
+
+    applyProfileSettingForGame(store, 2, 'filterPath', 'C:\\poe2.filter', null)
+
+    expect(loadFilter).not.toHaveBeenCalled()
+    expect(updateOnlineSyncDir).not.toHaveBeenCalled()
+    expect(profiles.getProfile(poe2.id)?.filterPath).toBe('C:\\poe2.filter')
   })
 })

--- a/src/main/settings-write.test.ts
+++ b/src/main/settings-write.test.ts
@@ -13,6 +13,10 @@ vi.mock('./overlay', () => ({
   setCloseOnClickOutside: vi.fn(),
 }))
 
+vi.mock('./whiteboard', () => ({
+  getWhiteboardOverlay: vi.fn(() => null),
+}))
+
 vi.mock('./app-macros', () => ({
   withPluginHotkeys: vi.fn((value) => value),
 }))
@@ -250,5 +254,103 @@ describe('settings-write side effects', () => {
     applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
 
     expect(setCloseOnClickOutside).toHaveBeenCalledWith(true)
+  })
+
+  it('clears filter state when activation profile has no filterPath', async () => {
+    const { clearFilterState } = await import('./filter-state')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: {
+          league: '',
+          filterDir: '',
+          filterPath: '',
+          cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+        } as unknown as PoeProfile,
+        reason: 'activation',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(clearFilterState).toHaveBeenCalled()
+  })
+
+  it('clears filter state and online sync when activation profile is null', async () => {
+    const { clearFilterState } = await import('./filter-state')
+    const { updateOnlineSyncDir } = await import('./online-sync')
+    const { applyPinnedZoneEnabled } = await import('./pinned-zone')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: null,
+        reason: 'activation',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(clearFilterState).toHaveBeenCalled()
+    expect(updateOnlineSyncDir).toHaveBeenCalledWith('')
+    expect(applyPinnedZoneEnabled).toHaveBeenCalledWith(false)
+  })
+
+  it('updates online sync dir even when filterDir is empty string on activation', async () => {
+    const { updateOnlineSyncDir } = await import('./online-sync')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: {
+          league: '',
+          filterDir: '',
+          cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+        } as unknown as PoeProfile,
+        reason: 'activation',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(updateOnlineSyncDir).toHaveBeenCalledWith('')
+  })
+
+  it('broadcasts league-updated when active profile league changes', async () => {
+    const { getOverlayWindow } = await import('./overlay')
+    const { broadcastSettingUpdates } = await import('./settings-write')
+    const send = vi.fn()
+    vi.mocked(getOverlayWindow).mockReturnValue({ webContents: { send } } as never)
+
+    broadcastSettingUpdates(
+      null,
+      [{ key: 'activeProfile', value: { league: 'Mercenaries' } as PoeProfile, reason: 'edit' }],
+      { activeProfile: { league: 'Standard' } as PoeProfile } as never,
+      { activeProfile: { league: 'Mercenaries' } as PoeProfile } as never,
+    )
+
+    expect(send).toHaveBeenCalledWith('setting-updated', 'activeProfile', { league: 'Mercenaries' })
+    expect(send).toHaveBeenCalledWith('league-updated', 'Mercenaries')
+  })
+
+  it('does not broadcast league-updated for unrelated active profile edits', async () => {
+    const { getOverlayWindow } = await import('./overlay')
+    const { broadcastSettingUpdates } = await import('./settings-write')
+    const send = vi.fn()
+    vi.mocked(getOverlayWindow).mockReturnValue({ webContents: { send } } as never)
+
+    broadcastSettingUpdates(
+      null,
+      [{ key: 'activeProfile', value: { league: 'Standard', filterPath: 'a.filter' } as PoeProfile, reason: 'edit' }],
+      { activeProfile: { league: 'Standard', filterPath: '' } as PoeProfile } as never,
+      { activeProfile: { league: 'Standard', filterPath: 'a.filter' } as PoeProfile } as never,
+    )
+
+    expect(send).toHaveBeenCalledWith('setting-updated', 'activeProfile', {
+      league: 'Standard',
+      filterPath: 'a.filter',
+    })
+    expect(send).not.toHaveBeenCalledWith('league-updated', expect.any(String))
   })
 })

--- a/src/main/settings-write.test.ts
+++ b/src/main/settings-write.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { getPoeVersion, setPoeVersion } from './game-state'
 import { PROFILE_VERSION_KEY, type ProfileChangedSetting } from './profile-settings'
+import type { AppSettings, PoeProfile } from '../shared/types'
 
 vi.mock('./filter-state', () => ({
   clearFilterState: vi.fn(),
@@ -56,7 +57,11 @@ vi.mock('./update/updater', () => ({
 }))
 
 describe('settings-write side effects', () => {
-  it('updates process game state before refreshing prices during profile hydration', async () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+  })
+
+  it('updates process game state before refreshing prices during profile activation', async () => {
     const { refreshPrices } = await import('./trade/prices')
     const { applyProfileHydrationSideEffects } = await import('./settings-write')
     const observedVersions: number[] = []
@@ -69,19 +74,181 @@ describe('settings-write side effects', () => {
 
     const changes: ProfileChangedSetting[] = [
       { key: PROFILE_VERSION_KEY, value: 1 },
-      { key: 'league', value: 'Mirage' },
+      {
+        key: 'activeProfile',
+        value: {
+          league: 'Mirage',
+          cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+        } as unknown as PoeProfile,
+        reason: 'activation',
+      },
     ]
-    applyProfileHydrationSideEffects(changes, { [PROFILE_VERSION_KEY]: 2, league: 'Fate of the Vaal' })
+    applyProfileHydrationSideEffects(changes, { [PROFILE_VERSION_KEY]: 2 } as unknown as AppSettings)
 
     expect(observedVersions).toEqual([1])
   })
 
-  it('updates online sync directory when filterDir changes', async () => {
+  it('refreshes prices on profile activation', async () => {
+    const { refreshPrices } = await import('./trade/prices')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: {
+          league: 'Mirage',
+          filterDir: '',
+          cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+        } as unknown as PoeProfile,
+        reason: 'activation',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(refreshPrices).toHaveBeenCalledWith('Mirage')
+  })
+
+  it('updates online sync directory on profile activation', async () => {
     const { updateOnlineSyncDir } = await import('./online-sync')
     const { applyProfileHydrationSideEffects } = await import('./settings-write')
 
-    applyProfileHydrationSideEffects([{ key: 'filterDir', value: 'C:\\filters' }], { filterDir: 'C:\\old' })
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: {
+          league: '',
+          filterDir: 'C:\\filters',
+          cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+        } as unknown as PoeProfile,
+        reason: 'activation',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
 
     expect(updateOnlineSyncDir).toHaveBeenCalledWith('C:\\filters')
+  })
+
+  it('applies cheat sheet hotkeys on profile activation', async () => {
+    const { applyCheatSheetHotkeys } = await import('./cheat-sheets')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const cheatSheets = { globalHotkey: 'Ctrl+X', categories: [], pinned: false }
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: { league: '', filterDir: '', cheatSheets } as unknown as PoeProfile,
+        reason: 'activation',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(applyCheatSheetHotkeys).toHaveBeenCalledWith(cheatSheets)
+  })
+
+  it('applies pinned zone enabled state on profile activation', async () => {
+    const { applyPinnedZoneEnabled } = await import('./pinned-zone')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: {
+          league: '',
+          filterDir: '',
+          cheatSheets: { globalHotkey: '', categories: [], pinned: true },
+        } as unknown as PoeProfile,
+        reason: 'activation',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(applyPinnedZoneEnabled).toHaveBeenCalledWith(true)
+  })
+
+  it('loads filter state on profile activation', async () => {
+    const { loadFilter } = await import('./filter-state')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: {
+          league: '',
+          filterDir: '',
+          filterPath: 'C:\\filters\\test.filter',
+          cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+        } as unknown as PoeProfile,
+        reason: 'activation',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(loadFilter).toHaveBeenCalledWith('C:\\filters\\test.filter', 'Profile Activation')
+  })
+
+  it('does NOT run profile-backed side effects for edit reason', async () => {
+    const { refreshPrices } = await import('./trade/prices')
+    const { updateOnlineSyncDir } = await import('./online-sync')
+    const { applyCheatSheetHotkeys } = await import('./cheat-sheets')
+    const { applyPinnedZoneEnabled } = await import('./pinned-zone')
+    const { loadFilter } = await import('./filter-state')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: {
+          league: 'Mirage',
+          filterDir: 'C:\\filters',
+          filterPath: 'C:\\filters\\test.filter',
+          cheatSheets: { globalHotkey: 'Ctrl+X', categories: [], pinned: true },
+        } as unknown as PoeProfile,
+        reason: 'edit',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(refreshPrices).not.toHaveBeenCalled()
+    expect(updateOnlineSyncDir).not.toHaveBeenCalled()
+    expect(applyCheatSheetHotkeys).not.toHaveBeenCalled()
+    expect(applyPinnedZoneEnabled).not.toHaveBeenCalled()
+    expect(loadFilter).not.toHaveBeenCalled()
+  })
+
+  it('does NOT run profile-backed side effects for migration reason', async () => {
+    const { refreshPrices } = await import('./trade/prices')
+    const { updateOnlineSyncDir } = await import('./online-sync')
+    const { applyCheatSheetHotkeys } = await import('./cheat-sheets')
+    const { applyPinnedZoneEnabled } = await import('./pinned-zone')
+    const { loadFilter } = await import('./filter-state')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const changes: ProfileChangedSetting[] = [
+      {
+        key: 'activeProfile',
+        value: {
+          league: 'Mirage',
+          cheatSheets: { globalHotkey: '', categories: [], pinned: false },
+        } as unknown as PoeProfile,
+        reason: 'migration',
+      },
+    ]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(refreshPrices).not.toHaveBeenCalled()
+    expect(updateOnlineSyncDir).not.toHaveBeenCalled()
+    expect(applyCheatSheetHotkeys).not.toHaveBeenCalled()
+    expect(applyPinnedZoneEnabled).not.toHaveBeenCalled()
+    expect(loadFilter).not.toHaveBeenCalled()
+  })
+
+  it('still runs flat-setting side effects regardless of activeProfile reason', async () => {
+    const { setCloseOnClickOutside } = await import('./overlay')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+
+    const changes: ProfileChangedSetting[] = [{ key: 'closeOnClickOutside', value: true }]
+    applyProfileHydrationSideEffects(changes, {} as unknown as AppSettings)
+
+    expect(setCloseOnClickOutside).toHaveBeenCalledWith(true)
   })
 })

--- a/src/main/settings-write.test.ts
+++ b/src/main/settings-write.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getPoeVersion, setPoeVersion } from './game-state'
+import { PROFILE_VERSION_KEY, type ProfileChangedSetting } from './profile-settings'
+
+vi.mock('./filter-state', () => ({
+  clearFilterState: vi.fn(),
+  loadFilter: vi.fn(),
+}))
+
+vi.mock('./overlay', () => ({
+  getOverlayWindow: vi.fn(() => null),
+  setCloseOnClickOutside: vi.fn(),
+}))
+
+vi.mock('./app-macros', () => ({
+  withPluginHotkeys: vi.fn((value) => value),
+}))
+
+vi.mock('./app-window', () => ({
+  getAppWindow: vi.fn(() => null),
+}))
+
+vi.mock('./cheat-sheets', () => ({
+  applyCheatSheetHotkeys: vi.fn(),
+  getCheatSheetsOverlay: vi.fn(() => null),
+}))
+
+vi.mock('./evaluation', () => ({
+  reEvaluateLastItem: vi.fn(),
+  setOpenSide: vi.fn(),
+}))
+
+vi.mock('./hotkeys', () => ({
+  setAppMacros: vi.fn(),
+  setChatCommands: vi.fn(),
+  setHotkey: vi.fn(),
+  setPriceCheckHotkey: vi.fn(),
+  setStashScrollEnabled: vi.fn(),
+}))
+
+vi.mock('./pinned-zone', () => ({
+  applyPinnedZoneEnabled: vi.fn(),
+  getPinnedZoneOverlay: vi.fn(() => null),
+}))
+
+vi.mock('./trade/prices', () => ({
+  refreshPrices: vi.fn(),
+}))
+
+vi.mock('./update/updater', () => ({
+  setUpdateChannel: vi.fn(),
+}))
+
+describe('settings-write side effects', () => {
+  it('updates process game state before refreshing prices during profile hydration', async () => {
+    const { refreshPrices } = await import('./trade/prices')
+    const { applyProfileHydrationSideEffects } = await import('./settings-write')
+    const observedVersions: number[] = []
+    vi.mocked(refreshPrices).mockImplementation(() => {
+      observedVersions.push(getPoeVersion())
+      return Promise.resolve()
+    })
+
+    setPoeVersion(2)
+
+    const changes: ProfileChangedSetting[] = [
+      { key: PROFILE_VERSION_KEY, value: 1 },
+      { key: 'league', value: 'Mirage' },
+    ]
+    applyProfileHydrationSideEffects(changes, { [PROFILE_VERSION_KEY]: 2, league: 'Fate of the Vaal' })
+
+    expect(observedVersions).toEqual([1])
+  })
+})

--- a/src/main/settings-write.ts
+++ b/src/main/settings-write.ts
@@ -7,22 +7,22 @@
  *  table and broadcast targets stay in lockstep. */
 
 import type { WebContents } from 'electron'
-import Store from 'electron-store'
+import type Store from 'electron-store'
 import { clearFilterState, loadFilter } from './filter-state'
 import { getOverlayWindow, setCloseOnClickOutside } from './overlay'
-import type Store from 'electron-store'
 import { withPluginHotkeys } from './app-macros'
 import { getAppWindow } from './app-window'
 import { applyCheatSheetHotkeys, getCheatSheetsOverlay } from './cheat-sheets'
 import { reEvaluateLastItem, setOpenSide } from './evaluation'
-import { loadFilter } from './filter-state'
+import { setPoeVersion } from './game-state'
 import { setAppMacros, setChatCommands, setHotkey, setPriceCheckHotkey, setStashScrollEnabled } from './hotkeys'
-import { getOverlayWindow, setCloseOnClickOutside } from './overlay'
 import { applyPinnedZoneEnabled, getPinnedZoneOverlay } from './pinned-zone'
 import { refreshPrices } from './trade/prices'
 import { setUpdateChannel } from './update/updater'
 import type { AppSettings, GameVariant } from '../shared/types'
 import {
+  ACTIVE_PROFILE_ID_KEY,
+  PROFILE_VERSION_KEY,
   hydrateActiveProfileSettings,
   isProfileBackedKey,
   switchActiveProfileByGameVariant,
@@ -57,6 +57,7 @@ function sideEffect<K extends keyof AppSettings>(
   value: AppSettings[K],
   prev: AppSettings[K] | undefined,
 ): void {
+  if (key === PROFILE_VERSION_KEY) setPoeVersion(value as GameVariant)
   if (key === 'filterPath' && value !== prev) {
     const path = value as string
     if (path) loadFilter(path, 'Switched Filters')
@@ -119,9 +120,9 @@ export function applySetting<K extends keyof AppSettings>(
   const previous = capturePreviousSettings(store, key)
   let changes: ProfileChangedSetting[]
 
-  if (key === 'activeProfileId' && value) {
+  if (key === ACTIVE_PROFILE_ID_KEY && value) {
     changes = switchActiveProfileById(store, value as string)
-  } else if (key === 'poeVersion') {
+  } else if (key === PROFILE_VERSION_KEY) {
     changes = switchActiveProfileByGameVariant(store, value as GameVariant)
   } else if (isProfileBackedKey(key)) {
     changes = writeActiveProfileSetting(store, key, value as AppSettings[typeof key])
@@ -130,7 +131,7 @@ export function applySetting<K extends keyof AppSettings>(
     changes = [{ key, value }]
   }
 
-  if (key === 'activeProfileId' && changes.length === 0) {
+  if (key === ACTIVE_PROFILE_ID_KEY && changes.length === 0) {
     changes = hydrateActiveProfileSettings(store)
   }
 

--- a/src/main/settings-write.ts
+++ b/src/main/settings-write.ts
@@ -7,6 +7,9 @@
  *  table and broadcast targets stay in lockstep. */
 
 import type { WebContents } from 'electron'
+import Store from 'electron-store'
+import { clearFilterState, loadFilter } from './filter-state'
+import { getOverlayWindow, setCloseOnClickOutside } from './overlay'
 import type Store from 'electron-store'
 import { withPluginHotkeys } from './app-macros'
 import { getAppWindow } from './app-window'
@@ -54,7 +57,11 @@ function sideEffect<K extends keyof AppSettings>(
   value: AppSettings[K],
   prev: AppSettings[K] | undefined,
 ): void {
-  if (key === 'filterPath' && value && value !== prev) loadFilter(value as string, 'Switched Filters')
+  if (key === 'filterPath' && value !== prev) {
+    const path = value as string
+    if (path) loadFilter(path, 'Switched Filters')
+    else clearFilterState()
+  }
   if (key === 'hotkey') setHotkey(value as string)
   if (key === 'priceCheckHotkey') setPriceCheckHotkey(value as string)
   if (key === 'closeOnClickOutside') setCloseOnClickOutside(value as boolean)

--- a/src/main/settings-write.ts
+++ b/src/main/settings-write.ts
@@ -1,8 +1,3 @@
-/** Single source of truth for "what happens when a setting is written":
- *  side effects and broadcast to other windows. Profile-backed fields
- *  (filterPath, league, etc.) are handled directly by profile management
- *  code; this module only deals with global AppSettings keys. */
-
 import type { WebContents } from 'electron'
 import type Store from 'electron-store'
 import { getOverlayWindow, setCloseOnClickOutside } from './overlay'
@@ -10,29 +5,28 @@ import { withPluginHotkeys } from './app-macros'
 import { getAppWindow } from './app-window'
 import { applyCheatSheetHotkeys, getCheatSheetsOverlay } from './cheat-sheets'
 import { reEvaluateLastItem, setOpenSide } from './evaluation'
+import { loadFilter } from './filter-state'
 import { setPoeVersion } from './game-state'
 import { setAppMacros, setChatCommands, setHotkey, setPriceCheckHotkey, setStashScrollEnabled } from './hotkeys'
 import { applyPinnedZoneEnabled, getPinnedZoneOverlay } from './pinned-zone'
+import { updateOnlineSyncDir } from './online-sync'
 import { refreshPrices } from './trade/prices'
 import { setUpdateChannel } from './update/updater'
-import type { AppSettings } from '../shared/types'
+import type { AppSettings, GameVariant, PoeProfile } from '../shared/types'
 import {
   ACTIVE_PROFILE_ID_KEY,
   PROFILE_VERSION_KEY,
   getEffectiveSettings,
   hydrateActiveProfileSettings,
-  isProfileBackedKey,
   switchActiveProfileByGameVariant,
   switchActiveProfileById,
   writeActiveProfileSetting,
-  type ProfileBackedKey,
   type ProfileChangedSetting,
+  type ProfileSettingKey,
   type SettingChangeKey,
-  type SettingValue,
 } from './profile-settings'
 
-/** Send `setting-updated` to every window except the sender. */
-export function broadcastSettingUpdate(sender: WebContents | null, key: SettingChangeKey, value: SettingValue<SettingChangeKey>): void {
+export function broadcastSettingUpdate(sender: WebContents | null, key: SettingChangeKey, value: unknown): void {
   const csWin = getCheatSheetsOverlay()?.getWindow() ?? null
   const pinnedWin = getPinnedZoneOverlay()?.getWindow() ?? null
   for (const win of [getOverlayWindow(), getAppWindow(), csWin, pinnedWin]) {
@@ -47,64 +41,60 @@ export function broadcastSettingUpdate(sender: WebContents | null, key: SettingC
         wbWin.webContents.send('setting-updated', key, value)
       }
     })
-    .catch(() => {
-      // whiteboard module unavailable; nothing to notify.
-    })
+    .catch(() => {})
 }
+
 function sideEffect(setting: ProfileChangedSetting, prevAppSettings?: AppSettings): void {
   const { key, value } = setting
 
-  switch (key) {
-    case PROFILE_VERSION_KEY:
-      setPoeVersion(value)
-      break
-    case 'hotkey':
-      setHotkey(value)
-      break
-    case 'priceCheckHotkey':
-      setPriceCheckHotkey(value)
-      break
-    case 'closeOnClickOutside':
-      setCloseOnClickOutside(value)
-      break
-    case 'league':
-      refreshPrices(value)
-      break
-    case 'chatCommands':
-      setChatCommands(value)
-      break
-    case 'appMacros':
-      setAppMacros(withPluginHotkeys(value))
-      break
-    case 'stashScrollEnabled':
-      setStashScrollEnabled(value)
-      break
-    case 'openSide':
-      setOpenSide(value)
-      break
-    case 'updateChannel':
-      setUpdateChannel(value)
-      break
-    case 'useCurrentZoneAreaLevel':
-      if (prevAppSettings && value !== prevAppSettings.useCurrentZoneAreaLevel) {
-        reEvaluateLastItem()
+  if (key === 'activeProfile') {
+    if (setting.reason === 'activation') {
+      const profile = value as PoeProfile | null
+      if (profile) {
+        if (profile.league) refreshPrices(profile.league)
+        if (profile.filterDir) updateOnlineSyncDir(profile.filterDir)
+        if (profile.cheatSheets) applyCheatSheetHotkeys(profile.cheatSheets)
+        if (profile.filterPath) loadFilter(profile.filterPath, 'Profile Activation')
       }
-      break
+      applyPinnedZoneEnabled(profile?.cheatSheets?.pinned === true)
+    }
+    return
+  }
+
+  if (key === PROFILE_VERSION_KEY) {
+    setPoeVersion(value as GameVariant)
+  } else if (key === 'hotkey') {
+    setHotkey(value as string)
+  } else if (key === 'priceCheckHotkey') {
+    setPriceCheckHotkey(value as string)
+  } else if (key === 'closeOnClickOutside') {
+    setCloseOnClickOutside(value as boolean)
+  } else if (key === 'chatCommands') {
+    setChatCommands(value as AppSettings['chatCommands'])
+  } else if (key === 'appMacros') {
+    setAppMacros(withPluginHotkeys(value as AppSettings['appMacros']))
+  } else if (key === 'stashScrollEnabled') {
+    setStashScrollEnabled(value as boolean)
+  } else if (key === 'openSide') {
+    setOpenSide(value as AppSettings['openSide'])
+  } else if (key === 'updateChannel') {
+    setUpdateChannel(value as string)
+  } else if (key === 'useCurrentZoneAreaLevel') {
+    if (prevAppSettings && value !== prevAppSettings.useCurrentZoneAreaLevel) {
+      reEvaluateLastItem()
+    }
   }
 }
 
-export function applyProfileHydrationSideEffects(
-  changes: ProfileChangedSetting[],
-  previous: AppSettings,
-): void {
+export function applyProfileHydrationSideEffects(changes: ProfileChangedSetting[], previous: AppSettings): void {
   for (const change of changes) {
     sideEffect(change, previous)
   }
 }
 
 export function broadcastSettingUpdates(sender: WebContents | null, changes: ProfileChangedSetting[]): void {
-  for (const { key, value } of changes) {
-    broadcastSettingUpdate(sender, key, value)
+  for (const change of changes) {
+    broadcastSettingUpdate(sender, change.key, change.value)
   }
 }
 
@@ -112,10 +102,6 @@ function capturePreviousSettings(store: Store<AppSettings>): AppSettings {
   return getEffectiveSettings(store)
 }
 
-/** Persist a setting + dispatch any side effects + broadcast.
- *  Pass `sender` from the IPC event so the originating window doesn't echo
- *  its own write. Pass `null` when the write didn't originate from a window
- *  (e.g. main-side migrations). */
 export function applySetting<K extends keyof AppSettings>(
   store: Store<AppSettings>,
   key: K,
@@ -126,12 +112,12 @@ export function applySetting<K extends keyof AppSettings>(
   let changes: ProfileChangedSetting[]
 
   if (key === ACTIVE_PROFILE_ID_KEY && value) {
-    changes = switchActiveProfileById(store, value)
+    changes = switchActiveProfileById(store, value as string)
   } else if (key === PROFILE_VERSION_KEY) {
-    changes = switchActiveProfileByGameVariant(store, value)
+    changes = switchActiveProfileByGameVariant(store, value as GameVariant)
   } else {
     store.set(key, value)
-    changes = [{ key, value }]
+    changes = [{ key, value } as ProfileChangedSetting]
   }
 
   if (key === ACTIVE_PROFILE_ID_KEY && changes.length === 0) {
@@ -142,30 +128,12 @@ export function applySetting<K extends keyof AppSettings>(
   broadcastSettingUpdates(sender, changes)
 }
 
-/** Write a profile-backed setting to the active profile, dispatch side
- *  effects, and broadcast changes to windows. Used when the write originates
- *  from a main-process handler (e.g. file picker, cheat sheet overlay). */
-export function applyProfileBackedSetting<K extends ProfileBackedKey>(
+export function applyProfileBackedSetting<K extends ProfileSettingKey>(
   store: Store<AppSettings>,
   key: K,
   value: Parameters<typeof writeActiveProfileSetting<K>>[2],
   sender: WebContents | null,
-  loadFilterFn?: (path: string) => void,
-  updateOnlineSyncDirFn?: (dir: string) => void,
 ): void {
-  const previous = getEffectiveSettings(store)
   const changes = writeActiveProfileSetting(store, key, value)
-
-  if (key === 'filterPath' && loadFilterFn) {
-    if (value) loadFilterFn(value)
-  }
-  if (key === 'filterDir' && updateOnlineSyncDirFn) {
-    updateOnlineSyncDirFn(value)
-  }
-  if (key === 'league') {
-    refreshPrices(value)
-  }
-
-  applyProfileHydrationSideEffects(changes, previous)
   broadcastSettingUpdates(sender, changes)
 }

--- a/src/main/settings-write.ts
+++ b/src/main/settings-write.ts
@@ -1,14 +1,10 @@
 /** Single source of truth for "what happens when a setting is written":
- *  per-version mirror, side effects, and broadcast to other windows.
- *
- *  The set-setting IPC handler is the canonical caller, but we also write
- *  filterPath/filterDir from the file-pick handlers and broadcast league
- *  changes after refreshLeagues -- everyone goes through here so the mirror
- *  table and broadcast targets stay in lockstep. */
+ *  side effects and broadcast to other windows. Profile-backed fields
+ *  (filterPath, league, etc.) are handled directly by profile management
+ *  code; this module only deals with global AppSettings keys. */
 
 import type { WebContents } from 'electron'
 import type Store from 'electron-store'
-import { clearFilterState, loadFilter } from './filter-state'
 import { getOverlayWindow, setCloseOnClickOutside } from './overlay'
 import { withPluginHotkeys } from './app-macros'
 import { getAppWindow } from './app-window'
@@ -19,20 +15,24 @@ import { setAppMacros, setChatCommands, setHotkey, setPriceCheckHotkey, setStash
 import { applyPinnedZoneEnabled, getPinnedZoneOverlay } from './pinned-zone'
 import { refreshPrices } from './trade/prices'
 import { setUpdateChannel } from './update/updater'
-import type { AppSettings, GameVariant } from '../shared/types'
+import type { AppSettings } from '../shared/types'
 import {
   ACTIVE_PROFILE_ID_KEY,
   PROFILE_VERSION_KEY,
+  getEffectiveSettings,
   hydrateActiveProfileSettings,
   isProfileBackedKey,
   switchActiveProfileByGameVariant,
   switchActiveProfileById,
   writeActiveProfileSetting,
+  type ProfileBackedKey,
   type ProfileChangedSetting,
+  type SettingChangeKey,
+  type SettingValue,
 } from './profile-settings'
 
 /** Send `setting-updated` to every window except the sender. */
-export function broadcastSettingUpdate(sender: WebContents | null, key: keyof AppSettings, value: unknown): void {
+export function broadcastSettingUpdate(sender: WebContents | null, key: SettingChangeKey, value: SettingValue<SettingChangeKey>): void {
   const csWin = getCheatSheetsOverlay()?.getWindow() ?? null
   const pinnedWin = getPinnedZoneOverlay()?.getWindow() ?? null
   for (const win of [getOverlayWindow(), getAppWindow(), csWin, pinnedWin]) {
@@ -51,44 +51,54 @@ export function broadcastSettingUpdate(sender: WebContents | null, key: keyof Ap
       // whiteboard module unavailable; nothing to notify.
     })
 }
+function sideEffect(setting: ProfileChangedSetting, prevAppSettings?: AppSettings): void {
+  const { key, value } = setting
 
-function sideEffect<K extends keyof AppSettings>(
-  key: K,
-  value: AppSettings[K],
-  prev: AppSettings[K] | undefined,
-): void {
-  if (key === PROFILE_VERSION_KEY) setPoeVersion(value as GameVariant)
-  if (key === 'filterPath' && value !== prev) {
-    const path = value as string
-    if (path) loadFilter(path, 'Switched Filters')
-    else clearFilterState()
-  }
-  if (key === 'hotkey') setHotkey(value as string)
-  if (key === 'priceCheckHotkey') setPriceCheckHotkey(value as string)
-  if (key === 'closeOnClickOutside') setCloseOnClickOutside(value as boolean)
-  if (key === 'league') refreshPrices(value as string)
-  if (key === 'chatCommands') setChatCommands(value as AppSettings['chatCommands'])
-  if (key === 'appMacros') setAppMacros(withPluginHotkeys(value as AppSettings['appMacros']))
-  if (key === 'stashScrollEnabled') setStashScrollEnabled(value as boolean)
-  if (key === 'openSide') setOpenSide(value as AppSettings['openSide'])
-  if (key === 'updateChannel') setUpdateChannel(value as string)
-  if (key === 'useCurrentZoneAreaLevel' && value !== prev) reEvaluateLastItem()
-  if (key === 'cheatSheets') {
-    const next = value as AppSettings['cheatSheets']
-    applyCheatSheetHotkeys(next)
-    const prevCs = prev as AppSettings['cheatSheets'] | undefined
-    if ((next?.pinned ?? false) !== (prevCs?.pinned ?? false)) {
-      applyPinnedZoneEnabled(next?.pinned === true)
-    }
+  switch (key) {
+    case PROFILE_VERSION_KEY:
+      setPoeVersion(value)
+      break
+    case 'hotkey':
+      setHotkey(value)
+      break
+    case 'priceCheckHotkey':
+      setPriceCheckHotkey(value)
+      break
+    case 'closeOnClickOutside':
+      setCloseOnClickOutside(value)
+      break
+    case 'league':
+      refreshPrices(value)
+      break
+    case 'chatCommands':
+      setChatCommands(value)
+      break
+    case 'appMacros':
+      setAppMacros(withPluginHotkeys(value))
+      break
+    case 'stashScrollEnabled':
+      setStashScrollEnabled(value)
+      break
+    case 'openSide':
+      setOpenSide(value)
+      break
+    case 'updateChannel':
+      setUpdateChannel(value)
+      break
+    case 'useCurrentZoneAreaLevel':
+      if (prevAppSettings && value !== prevAppSettings.useCurrentZoneAreaLevel) {
+        reEvaluateLastItem()
+      }
+      break
   }
 }
 
 export function applyProfileHydrationSideEffects(
   changes: ProfileChangedSetting[],
-  previous: Partial<AppSettings>,
+  previous: AppSettings,
 ): void {
-  for (const { key, value } of changes) {
-    sideEffect(key, value, previous[key])
+  for (const change of changes) {
+    sideEffect(change, previous)
   }
 }
 
@@ -98,16 +108,11 @@ export function broadcastSettingUpdates(sender: WebContents | null, changes: Pro
   }
 }
 
-function capturePreviousSettings(store: Store<AppSettings>, key: keyof AppSettings): Partial<AppSettings> {
-  return {
-    [key]: store.get(key),
-    filterPath: store.get('filterPath'),
-    league: store.get('league'),
-    cheatSheets: store.get('cheatSheets'),
-  }
+function capturePreviousSettings(store: Store<AppSettings>): AppSettings {
+  return getEffectiveSettings(store)
 }
 
-/** Persist a setting + mirror it + dispatch any side effects + broadcast.
+/** Persist a setting + dispatch any side effects + broadcast.
  *  Pass `sender` from the IPC event so the originating window doesn't echo
  *  its own write. Pass `null` when the write didn't originate from a window
  *  (e.g. main-side migrations). */
@@ -117,15 +122,13 @@ export function applySetting<K extends keyof AppSettings>(
   value: AppSettings[K],
   sender: WebContents | null,
 ): void {
-  const previous = capturePreviousSettings(store, key)
+  const previous = capturePreviousSettings(store)
   let changes: ProfileChangedSetting[]
 
   if (key === ACTIVE_PROFILE_ID_KEY && value) {
-    changes = switchActiveProfileById(store, value as string)
+    changes = switchActiveProfileById(store, value)
   } else if (key === PROFILE_VERSION_KEY) {
-    changes = switchActiveProfileByGameVariant(store, value as GameVariant)
-  } else if (isProfileBackedKey(key)) {
-    changes = writeActiveProfileSetting(store, key, value as AppSettings[typeof key])
+    changes = switchActiveProfileByGameVariant(store, value)
   } else {
     store.set(key, value)
     changes = [{ key, value }]
@@ -133,6 +136,34 @@ export function applySetting<K extends keyof AppSettings>(
 
   if (key === ACTIVE_PROFILE_ID_KEY && changes.length === 0) {
     changes = hydrateActiveProfileSettings(store)
+  }
+
+  applyProfileHydrationSideEffects(changes, previous)
+  broadcastSettingUpdates(sender, changes)
+}
+
+/** Write a profile-backed setting to the active profile, dispatch side
+ *  effects, and broadcast changes to windows. Used when the write originates
+ *  from a main-process handler (e.g. file picker, cheat sheet overlay). */
+export function applyProfileBackedSetting<K extends ProfileBackedKey>(
+  store: Store<AppSettings>,
+  key: K,
+  value: Parameters<typeof writeActiveProfileSetting<K>>[2],
+  sender: WebContents | null,
+  loadFilterFn?: (path: string) => void,
+  updateOnlineSyncDirFn?: (dir: string) => void,
+): void {
+  const previous = getEffectiveSettings(store)
+  const changes = writeActiveProfileSetting(store, key, value)
+
+  if (key === 'filterPath' && loadFilterFn) {
+    if (value) loadFilterFn(value)
+  }
+  if (key === 'filterDir' && updateOnlineSyncDirFn) {
+    updateOnlineSyncDirFn(value)
+  }
+  if (key === 'league') {
+    refreshPrices(value)
   }
 
   applyProfileHydrationSideEffects(changes, previous)

--- a/src/main/settings-write.ts
+++ b/src/main/settings-write.ts
@@ -8,7 +8,6 @@
 
 import type { WebContents } from 'electron'
 import type Store from 'electron-store'
-import type { AppSettings } from '../shared/types'
 import { withPluginHotkeys } from './app-macros'
 import { getAppWindow } from './app-window'
 import { applyCheatSheetHotkeys, getCheatSheetsOverlay } from './cheat-sheets'
@@ -19,18 +18,15 @@ import { getOverlayWindow, setCloseOnClickOutside } from './overlay'
 import { applyPinnedZoneEnabled, getPinnedZoneOverlay } from './pinned-zone'
 import { refreshPrices } from './trade/prices'
 import { setUpdateChannel } from './update/updater'
-
-/** Flat active key -> per-version mirror keys (PoE1, PoE2). When a flat key is
- *  written we also write to the mirror entry matching the current `poeVersion`,
- *  so consumers can keep reading the flat field while the per-version data
- *  stays current for the eventual game switch. */
-const MIRROR_KEYS = {
-  league: ['leaguePoe1', 'leaguePoe2'],
-  filterPath: ['filterPathPoe1', 'filterPathPoe2'],
-  filterDir: ['filterDirPoe1', 'filterDirPoe2'],
-  tradePriceOption: ['tradePriceOptionPoe1', 'tradePriceOptionPoe2'],
-  cheatSheets: ['cheatSheetsPoe1', 'cheatSheetsPoe2'],
-} as const satisfies Partial<Record<keyof AppSettings, readonly [keyof AppSettings, keyof AppSettings]>>
+import type { AppSettings, GameVariant } from '../shared/types'
+import {
+  hydrateActiveProfileSettings,
+  isProfileBackedKey,
+  switchActiveProfileByGameVariant,
+  switchActiveProfileById,
+  writeActiveProfileSetting,
+  type ProfileChangedSetting,
+} from './profile-settings'
 
 /** Send `setting-updated` to every window except the sender. */
 export function broadcastSettingUpdate(sender: WebContents | null, key: keyof AppSettings, value: unknown): void {
@@ -53,24 +49,12 @@ export function broadcastSettingUpdate(sender: WebContents | null, key: keyof Ap
     })
 }
 
-/** Persist a setting + mirror it + dispatch any side effects + broadcast.
- *  Pass `sender` from the IPC event so the originating window doesn't echo
- *  its own write. Pass `null` when the write didn't originate from a window
- *  (e.g. main-side migrations). */
-export function applySetting<K extends keyof AppSettings>(
-  store: Store<AppSettings>,
+function sideEffect<K extends keyof AppSettings>(
   key: K,
   value: AppSettings[K],
-  sender: WebContents | null,
+  prev: AppSettings[K] | undefined,
 ): void {
-  const prev = store.get(key)
-  store.set(key, value)
-  const mirror = MIRROR_KEYS[key as keyof typeof MIRROR_KEYS]
-  if (mirror) {
-    const v = store.get('poeVersion')
-    store.set(mirror[v === 2 ? 1 : 0], value as AppSettings[(typeof mirror)[number]])
-  }
-  if (key === 'filterPath' && value !== prev) loadFilter(value as string, 'Switched Filters')
+  if (key === 'filterPath' && value && value !== prev) loadFilter(value as string, 'Switched Filters')
   if (key === 'hotkey') setHotkey(value as string)
   if (key === 'priceCheckHotkey') setPriceCheckHotkey(value as string)
   if (key === 'closeOnClickOutside') setCloseOnClickOutside(value as boolean)
@@ -89,6 +73,60 @@ export function applySetting<K extends keyof AppSettings>(
       applyPinnedZoneEnabled(next?.pinned === true)
     }
   }
+}
 
-  broadcastSettingUpdate(sender, key, value)
+export function applyProfileHydrationSideEffects(
+  changes: ProfileChangedSetting[],
+  previous: Partial<AppSettings>,
+): void {
+  for (const { key, value } of changes) {
+    sideEffect(key, value, previous[key])
+  }
+}
+
+export function broadcastSettingUpdates(sender: WebContents | null, changes: ProfileChangedSetting[]): void {
+  for (const { key, value } of changes) {
+    broadcastSettingUpdate(sender, key, value)
+  }
+}
+
+function capturePreviousSettings(store: Store<AppSettings>, key: keyof AppSettings): Partial<AppSettings> {
+  return {
+    [key]: store.get(key),
+    filterPath: store.get('filterPath'),
+    league: store.get('league'),
+    cheatSheets: store.get('cheatSheets'),
+  }
+}
+
+/** Persist a setting + mirror it + dispatch any side effects + broadcast.
+ *  Pass `sender` from the IPC event so the originating window doesn't echo
+ *  its own write. Pass `null` when the write didn't originate from a window
+ *  (e.g. main-side migrations). */
+export function applySetting<K extends keyof AppSettings>(
+  store: Store<AppSettings>,
+  key: K,
+  value: AppSettings[K],
+  sender: WebContents | null,
+): void {
+  const previous = capturePreviousSettings(store, key)
+  let changes: ProfileChangedSetting[]
+
+  if (key === 'activeProfileId' && value) {
+    changes = switchActiveProfileById(store, value as string)
+  } else if (key === 'poeVersion') {
+    changes = switchActiveProfileByGameVariant(store, value as GameVariant)
+  } else if (isProfileBackedKey(key)) {
+    changes = writeActiveProfileSetting(store, key, value as AppSettings[typeof key])
+  } else {
+    store.set(key, value)
+    changes = [{ key, value }]
+  }
+
+  if (key === 'activeProfileId' && changes.length === 0) {
+    changes = hydrateActiveProfileSettings(store)
+  }
+
+  applyProfileHydrationSideEffects(changes, previous)
+  broadcastSettingUpdates(sender, changes)
 }

--- a/src/main/settings-write.ts
+++ b/src/main/settings-write.ts
@@ -12,7 +12,7 @@ import { applyPinnedZoneEnabled, getPinnedZoneOverlay } from './pinned-zone'
 import { updateOnlineSyncDir } from './online-sync'
 import { refreshPrices } from './trade/prices'
 import { setUpdateChannel } from './update/updater'
-import type { AppSettings, GameVariant, PoeProfile, RuntimeSettings } from '../shared/types'
+import type { AppSettings, CheatSheetsSettings, GameVariant, PoeProfile, RuntimeSettings } from '../shared/types'
 import {
   ACTIVE_PROFILE_ID_KEY,
   PROFILE_VERSION_KEY,
@@ -20,9 +20,10 @@ import {
   hydrateActiveProfileSettings,
   switchActiveProfileByGameVariant,
   switchActiveProfileById,
-  writeActiveProfileSetting,
+  writeLastUsedProfileSettingByGameVariant,
   type ProfileChangedSetting,
   type ProfileSettingKey,
+  type ProfileSettingValue,
   type SettingChangeKey,
 } from './profiles/profile-settings'
 
@@ -167,13 +168,45 @@ export function applySetting<K extends keyof AppSettings>(
   broadcastSettingUpdates(sender, changes, previous, getEffectiveSettings(store))
 }
 
-export function applyProfileBackedSetting<K extends ProfileSettingKey>(
+/** Dispatch the imperative main-process side effect for a single profile-backed
+ *  field edit. This is what applySetting() used to do for the old flat keys:
+ *  a filter pick reloads the in-memory filter, a folder change re-points online
+ *  sync, and cheat-sheet edits re-register hotkeys + the pinned-zone overlay.
+ *  league/tradePriceOption need no eager effect (consumers read them lazily). */
+export function applyProfileEditSideEffect<K extends ProfileSettingKey>(key: K, value: ProfileSettingValue<K>): void {
+  if (key === 'filterPath') {
+    const path = value as string
+    if (path) loadFilter(path, 'Switched Filters')
+    else clearFilterState()
+  } else if (key === 'filterDir') {
+    updateOnlineSyncDir(value as string)
+  } else if (key === 'cheatSheets') {
+    const cs = value as CheatSheetsSettings
+    applyCheatSheetHotkeys(cs)
+    applyPinnedZoneEnabled(cs?.pinned === true)
+  } else if (key === 'league') {
+    refreshPrices(value as string)
+  }
+}
+
+/** Write a profile-backed setting to the given game's last-used profile, then --
+ *  only when that edit targeted the *active* profile -- run the field side effect
+ *  and broadcast. The set-profile-setting-for-game IPC handler delegates here so
+ *  a filter/dir/cheat-sheet change takes effect immediately rather than waiting
+ *  for the next profile activation. Editing the inactive game's profile (the
+ *  onboarding "both games" league step) writes silently with no side effect. */
+export function applyProfileSettingForGame<K extends ProfileSettingKey>(
   store: Store<AppSettings>,
+  variant: GameVariant,
   key: K,
-  value: Parameters<typeof writeActiveProfileSetting<K>>[2],
+  value: ProfileSettingValue<K>,
   sender: WebContents | null,
-): void {
+): RuntimeSettings {
   const previous = capturePreviousSettings(store)
-  const changes = writeActiveProfileSetting(store, key, value)
-  broadcastSettingUpdates(sender, changes, previous, getEffectiveSettings(store))
+  const changes = writeLastUsedProfileSettingByGameVariant(store, variant, key, value)
+  if (changes.length > 0) {
+    applyProfileEditSideEffect(key, value)
+    broadcastSettingUpdates(sender, changes, previous, getEffectiveSettings(store))
+  }
+  return getEffectiveSettings(store)
 }

--- a/src/main/settings-write.ts
+++ b/src/main/settings-write.ts
@@ -5,14 +5,14 @@ import { withPluginHotkeys } from './app-macros'
 import { getAppWindow } from './app-window'
 import { applyCheatSheetHotkeys, getCheatSheetsOverlay } from './cheat-sheets'
 import { reEvaluateLastItem, setOpenSide } from './evaluation'
-import { loadFilter } from './filter-state'
+import { clearFilterState, loadFilter } from './filter-state'
 import { setPoeVersion } from './game-state'
 import { setAppMacros, setChatCommands, setHotkey, setPriceCheckHotkey, setStashScrollEnabled } from './hotkeys'
 import { applyPinnedZoneEnabled, getPinnedZoneOverlay } from './pinned-zone'
 import { updateOnlineSyncDir } from './online-sync'
 import { refreshPrices } from './trade/prices'
 import { setUpdateChannel } from './update/updater'
-import type { AppSettings, GameVariant, PoeProfile } from '../shared/types'
+import type { AppSettings, GameVariant, PoeProfile, RuntimeSettings } from '../shared/types'
 import {
   ACTIVE_PROFILE_ID_KEY,
   PROFILE_VERSION_KEY,
@@ -52,11 +52,17 @@ function sideEffect(setting: ProfileChangedSetting, prevAppSettings?: AppSetting
       const profile = value as PoeProfile | null
       if (profile) {
         if (profile.league) refreshPrices(profile.league)
-        if (profile.filterDir) updateOnlineSyncDir(profile.filterDir)
+        updateOnlineSyncDir(profile.filterDir)
         if (profile.cheatSheets) applyCheatSheetHotkeys(profile.cheatSheets)
         if (profile.filterPath) loadFilter(profile.filterPath, 'Profile Activation')
+        else clearFilterState()
+        applyPinnedZoneEnabled(profile.cheatSheets?.pinned === true)
+      } else {
+        clearFilterState()
+        updateOnlineSyncDir('')
+        applyPinnedZoneEnabled(false)
       }
-      applyPinnedZoneEnabled(profile?.cheatSheets?.pinned === true)
+      return
     }
     return
   }
@@ -92,13 +98,46 @@ export function applyProfileHydrationSideEffects(changes: ProfileChangedSetting[
   }
 }
 
-export function broadcastSettingUpdates(sender: WebContents | null, changes: ProfileChangedSetting[]): void {
+export function broadcastSettingUpdates(
+  sender: WebContents | null,
+  changes: ProfileChangedSetting[],
+  previous?: RuntimeSettings,
+  current?: RuntimeSettings,
+): void {
   for (const change of changes) {
     broadcastSettingUpdate(sender, change.key, change.value)
   }
+
+  if (changes.some((change) => change.key === 'activeProfile')) {
+    const previousLeague = previous?.activeProfile?.league ?? ''
+    const changedProfile = changes.find((change) => change.key === 'activeProfile')?.value as
+      | PoeProfile
+      | null
+      | undefined
+    const currentLeague = current?.activeProfile?.league ?? changedProfile?.league ?? ''
+    if (!previous || previousLeague !== currentLeague) broadcastLeagueUpdate(sender, currentLeague)
+  }
 }
 
-function capturePreviousSettings(store: Store<AppSettings>): AppSettings {
+export function broadcastLeagueUpdate(sender: WebContents | null, league: string): void {
+  const csWin = getCheatSheetsOverlay()?.getWindow() ?? null
+  const pinnedWin = getPinnedZoneOverlay()?.getWindow() ?? null
+  for (const win of [getOverlayWindow(), getAppWindow(), csWin, pinnedWin]) {
+    if (win && win.webContents !== sender) {
+      win.webContents.send('league-updated', league)
+    }
+  }
+  void import('./whiteboard')
+    .then(({ getWhiteboardOverlay }) => {
+      const wbWin = getWhiteboardOverlay()?.getWindow() ?? null
+      if (wbWin && wbWin.webContents !== sender) {
+        wbWin.webContents.send('league-updated', league)
+      }
+    })
+    .catch(() => {})
+}
+
+function capturePreviousSettings(store: Store<AppSettings>): RuntimeSettings {
   return getEffectiveSettings(store)
 }
 
@@ -125,7 +164,7 @@ export function applySetting<K extends keyof AppSettings>(
   }
 
   applyProfileHydrationSideEffects(changes, previous)
-  broadcastSettingUpdates(sender, changes)
+  broadcastSettingUpdates(sender, changes, previous, getEffectiveSettings(store))
 }
 
 export function applyProfileBackedSetting<K extends ProfileSettingKey>(
@@ -134,6 +173,7 @@ export function applyProfileBackedSetting<K extends ProfileSettingKey>(
   value: Parameters<typeof writeActiveProfileSetting<K>>[2],
   sender: WebContents | null,
 ): void {
+  const previous = capturePreviousSettings(store)
   const changes = writeActiveProfileSetting(store, key, value)
-  broadcastSettingUpdates(sender, changes)
+  broadcastSettingUpdates(sender, changes, previous, getEffectiveSettings(store))
 }

--- a/src/main/settings-write.ts
+++ b/src/main/settings-write.ts
@@ -24,7 +24,7 @@ import {
   type ProfileChangedSetting,
   type ProfileSettingKey,
   type SettingChangeKey,
-} from './profile-settings'
+} from './profiles/profile-settings'
 
 export function broadcastSettingUpdate(sender: WebContents | null, key: SettingChangeKey, value: unknown): void {
   const csWin = getCheatSheetsOverlay()?.getWindow() ?? null

--- a/src/main/trade/clipboard.ts
+++ b/src/main/trade/clipboard.ts
@@ -8,12 +8,20 @@ import { getPoeVersion } from '../game-state'
 // class sheet -- getPoeVersion() isn't reliable at module load (game-state
 // hasn't been set yet), so we resolve on first access. registerFilterBaseTypes()
 // then adds filter-discovered bases on top.
-let _knownBaseTypes: Set<string> | null = null
-function getKnownBaseTypes(): Set<string> {
-  if (_knownBaseTypes === null) {
-    _knownBaseTypes = new Set(Object.values(getItemClasses(getPoeVersion())).flatMap((c) => c.bases.map((b) => b.name)))
+let _staticBaseTypes: Set<string> | null = null
+let _filterBaseTypes = new Set<string>()
+
+function getStaticBaseTypes(): Set<string> {
+  if (_staticBaseTypes === null) {
+    _staticBaseTypes = new Set(
+      Object.values(getItemClasses(getPoeVersion())).flatMap((c) => c.bases.map((b) => b.name)),
+    )
   }
-  return _knownBaseTypes
+  return _staticBaseTypes
+}
+
+function getKnownBaseTypes(): Set<string> {
+  return new Set([...getStaticBaseTypes(), ..._filterBaseTypes])
 }
 
 let _itemSizes: Record<string, [number, number]> | null = null
@@ -26,8 +34,15 @@ function getItemSizes(): Record<string, [number, number]> {
 
 /** Add base types extracted from the loaded filter */
 export function registerFilterBaseTypes(baseTypes: string[]): void {
-  const set = getKnownBaseTypes()
-  for (const bt of baseTypes) set.add(bt)
+  _filterBaseTypes = new Set(baseTypes)
+}
+
+export function clearFilterBaseTypes(): void {
+  _filterBaseTypes = new Set()
+}
+
+export function __hasKnownBaseTypeForTest(baseType: string): boolean {
+  return getKnownBaseTypes().has(baseType)
 }
 
 /** Try to find a known base type within a magic item name */

--- a/src/main/trade/leagues.test.ts
+++ b/src/main/trade/leagues.test.ts
@@ -36,8 +36,6 @@ describe('migrateLeague', () => {
   })
 
   it('migrates Mirage -> Return of the Settlers (multi-word challenge name)', () => {
-    // Real-world scenario: PoE1 launches a multi-word league name; the SC
-    // challenge entry is the first item in the trade API response.
     const fresh = [
       'Return of the Settlers',
       'Hardcore Return of the Settlers',
@@ -71,19 +69,17 @@ describe('migrateLeague', () => {
   })
 })
 
-// ─── refreshLeagues integration ─────────────────────────────────────────────
+// ---------------------------------------------------------------------------
+// refreshLeagues integration
+// ---------------------------------------------------------------------------
 
-/** Minimal in-memory implementation of the subset of electron-store's API that
- *  refreshLeagues touches. Lets us assert what got persisted without booting
- *  electron. */
-function makeFakeStore(initial: Partial<AppSettings>): Store<AppSettings> {
+function makeFakeStore(initial: Record<string, unknown>): Store<AppSettings> {
   const data: Record<string, unknown> = { ...initial }
   return {
     get: (key: string) => data[key],
     set: (key: string, value: unknown) => {
       data[key] = value
     },
-    // expose for assertions
     _data: data,
   } as unknown as Store<AppSettings> & { _data: Record<string, unknown> }
 }
@@ -97,9 +93,6 @@ describe('refreshLeagues', () => {
       [ACTIVE_PROFILE_ID_KEY]: poe1.id,
       [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
       poeVersion: 1,
-      league: 'Mirage',
-      leaguePoe1: 'Mirage',
-      leaguePoe2: 'Fate of the Vaal',
       leaguesPoe1: [],
       leaguesPoe2: [],
     })
@@ -119,11 +112,8 @@ describe('refreshLeagues', () => {
     expect(store.get('leaguesPoe1')).toEqual(fresh1)
     expect(store.get('leaguesPoe2')).toEqual(fresh2)
     expect(profiles.getProfile(poe1.id)?.league).toBe('Return of the Settlers')
-    expect(store.get('leaguePoe1')).toBe('Mirage')
-    expect(store.get('league')).toBe('Mirage')
-    expect(store.get('leaguePoe2')).toBe('Fate of the Vaal') // unchanged
     expect(changed).toContain('leaguesPoe1')
-    expect(changed).toContain('league')
+    expect(changed).toContain('activeProfile')
   })
 
   it('migrates Hardcore Mirage -> Hardcore Return of the Settlers', async () => {
@@ -134,9 +124,6 @@ describe('refreshLeagues', () => {
       [ACTIVE_PROFILE_ID_KEY]: poe1.id,
       [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
       poeVersion: 1,
-      league: 'Hardcore Mirage',
-      leaguePoe1: 'Hardcore Mirage',
-      leaguePoe2: 'Fate of the Vaal',
       leaguesPoe1: [],
       leaguesPoe2: [],
     })
@@ -147,11 +134,9 @@ describe('refreshLeagues', () => {
     await refreshLeagues(store, fetcher)
 
     expect(profiles.getProfile(poe1.id)?.league).toBe('Hardcore Return of the Settlers')
-    expect(store.get('leaguePoe1')).toBe('Hardcore Mirage')
-    expect(store.get('league')).toBe('Hardcore Mirage')
   })
 
-  it('does not touch flat league when the inactive version migrates', async () => {
+  it('does not return activeProfile when the inactive version migrates', async () => {
     const profiles = initProfileStore(mkdtempSync(join(tmpdir(), 'scalpel-league-profiles-')))
     const poe1 = { ...profiles.createDefault(1), league: 'Mirage' }
     const poe2 = { ...profiles.createDefault(2), league: 'Fate of the Vaal' }
@@ -161,9 +146,6 @@ describe('refreshLeagues', () => {
       [ACTIVE_PROFILE_ID_KEY]: poe2.id,
       [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
       poeVersion: 2,
-      league: 'Fate of the Vaal',
-      leaguePoe1: 'Mirage',
-      leaguePoe2: 'Fate of the Vaal',
       leaguesPoe1: [],
       leaguesPoe2: [],
     })
@@ -175,17 +157,17 @@ describe('refreshLeagues', () => {
     const changed = await refreshLeagues(store, fetcher)
 
     expect(profiles.getProfile(poe1.id)?.league).toBe('Return of the Settlers')
-    expect(store.get('leaguePoe1')).toBe('Mirage')
-    expect(store.get('league')).toBe('Fate of the Vaal') // active game (poe2) untouched
-    expect(changed).not.toContain('league')
+    expect(profiles.getProfile(poe2.id)?.league).toBe('Fate of the Vaal')
+    expect(changed).not.toContain('activeProfile')
   })
 
   it('makes no migrations when the user is on Standard (persists across leagues)', async () => {
+    const profiles = initProfileStore(mkdtempSync(join(tmpdir(), 'scalpel-league-profiles-')))
+    const poe1 = { ...profiles.createDefault(1), league: 'Standard' }
+    profiles.saveProfile(poe1)
     const store = makeFakeStore({
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
       poeVersion: 1,
-      league: 'Standard',
-      leaguePoe1: 'Standard',
-      leaguePoe2: 'Standard',
       leaguesPoe1: [],
       leaguesPoe2: [],
     })
@@ -194,18 +176,13 @@ describe('refreshLeagues', () => {
 
     const changed = await refreshLeagues(store, fetcher)
 
-    expect(store.get('leaguePoe1')).toBe('Standard')
-    expect(store.get('league')).toBe('Standard')
-    expect(changed).not.toContain('leaguePoe1')
-    expect(changed).not.toContain('league')
+    expect(profiles.getProfile(poe1.id)?.league).toBe('Standard')
+    expect(changed).not.toContain('activeProfile')
   })
 
   it('uses the hardcoded fallback list when the API returns null', async () => {
     const store = makeFakeStore({
       poeVersion: 1,
-      league: 'Mirage',
-      leaguePoe1: 'Mirage',
-      leaguePoe2: 'Fate of the Vaal',
       leaguesPoe1: [],
       leaguesPoe2: [],
     })
@@ -213,19 +190,18 @@ describe('refreshLeagues', () => {
 
     await refreshLeagues(store, fetcher)
 
-    // Fallback uses shared/game-features.ts -- 'Mirage' is in there so no migration.
-    expect(store.get('leaguePoe1')).toBe('Mirage')
     const list = store.get('leaguesPoe1') as string[]
     expect(list.length).toBeGreaterThan(0)
   })
 
   it('does not re-persist the list or rewrite the league when nothing changed', async () => {
+    const profiles = initProfileStore(mkdtempSync(join(tmpdir(), 'scalpel-league-profiles-')))
+    const poe1 = { ...profiles.createDefault(1), league: 'Mirage' }
+    profiles.saveProfile(poe1)
     const fresh1 = ['Mirage', 'Hardcore Mirage', 'Standard', 'Hardcore']
     const store = makeFakeStore({
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
       poeVersion: 1,
-      league: 'Mirage',
-      leaguePoe1: 'Mirage',
-      leaguePoe2: 'Fate of the Vaal',
       leaguesPoe1: fresh1,
       leaguesPoe2: ['Fate of the Vaal', 'HC Fate of the Vaal', 'Standard', 'Hardcore'],
     })
@@ -260,9 +236,6 @@ describe('refreshLeagues', () => {
       [PROFILE_VERSION_KEY]: 2,
       [ACTIVE_PROFILE_ID_KEY]: poe2Active.id,
       [LAST_PROFILE_ID_POE1_KEY]: poe1Hc.id,
-      league: 'Fate of the Vaal',
-      leaguePoe1: 'Mirage',
-      leaguePoe2: 'Fate of the Vaal',
       leaguesPoe1: [],
       leaguesPoe2: [],
     })
@@ -275,8 +248,6 @@ describe('refreshLeagues', () => {
     expect(profiles.getProfile(poe1Trade.id)?.league).toBe('Return of the Settlers')
     expect(profiles.getProfile(poe1Hc.id)?.league).toBe('Hardcore Return of the Settlers')
     expect(profiles.getProfile(poe2Active.id)?.league).toBe('Fate of the Vaal')
-    expect(store.get('league')).toBe('Fate of the Vaal')
-    expect(store.get('leaguePoe1')).toBe('Mirage')
-    expect(changed).not.toContain('league')
+    expect(changed).not.toContain('activeProfile')
   })
 })

--- a/src/main/trade/leagues.test.ts
+++ b/src/main/trade/leagues.test.ts
@@ -89,8 +89,13 @@ function makeFakeStore(initial: Partial<AppSettings>): Store<AppSettings> {
 }
 
 describe('refreshLeagues', () => {
-  it('persists fetched lists and migrates leaguePoe1 + flat league when poe1 is active', async () => {
+  it('persists fetched lists and migrates active profile league when poe1 is active', async () => {
+    const profiles = initProfileStore(mkdtempSync(join(tmpdir(), 'scalpel-league-profiles-')))
+    const poe1 = { ...profiles.createDefault(1), league: 'Mirage' }
+    profiles.saveProfile(poe1)
     const store = makeFakeStore({
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
       poeVersion: 1,
       league: 'Mirage',
       leaguePoe1: 'Mirage',
@@ -113,16 +118,21 @@ describe('refreshLeagues', () => {
 
     expect(store.get('leaguesPoe1')).toEqual(fresh1)
     expect(store.get('leaguesPoe2')).toEqual(fresh2)
-    expect(store.get('leaguePoe1')).toBe('Return of the Settlers')
-    expect(store.get('league')).toBe('Return of the Settlers') // poe1 is active so flat mirrors
+    expect(profiles.getProfile(poe1.id)?.league).toBe('Return of the Settlers')
+    expect(store.get('leaguePoe1')).toBe('Mirage')
+    expect(store.get('league')).toBe('Mirage')
     expect(store.get('leaguePoe2')).toBe('Fate of the Vaal') // unchanged
     expect(changed).toContain('leaguesPoe1')
-    expect(changed).toContain('leaguePoe1')
     expect(changed).toContain('league')
   })
 
   it('migrates Hardcore Mirage -> Hardcore Return of the Settlers', async () => {
+    const profiles = initProfileStore(mkdtempSync(join(tmpdir(), 'scalpel-league-profiles-')))
+    const poe1 = { ...profiles.createDefault(1), league: 'Hardcore Mirage' }
+    profiles.saveProfile(poe1)
     const store = makeFakeStore({
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
       poeVersion: 1,
       league: 'Hardcore Mirage',
       leaguePoe1: 'Hardcore Mirage',
@@ -136,14 +146,20 @@ describe('refreshLeagues', () => {
 
     await refreshLeagues(store, fetcher)
 
-    expect(store.get('leaguePoe1')).toBe('Hardcore Return of the Settlers')
-    expect(store.get('league')).toBe('Hardcore Return of the Settlers')
+    expect(profiles.getProfile(poe1.id)?.league).toBe('Hardcore Return of the Settlers')
+    expect(store.get('leaguePoe1')).toBe('Hardcore Mirage')
+    expect(store.get('league')).toBe('Hardcore Mirage')
   })
 
   it('does not touch flat league when the inactive version migrates', async () => {
-    // poe2 is active, but leaguePoe1 (PoE1, inactive) needs migration. The flat
-    // 'league' field reflects the active game (poe2) so it must not be rewritten.
+    const profiles = initProfileStore(mkdtempSync(join(tmpdir(), 'scalpel-league-profiles-')))
+    const poe1 = { ...profiles.createDefault(1), league: 'Mirage' }
+    const poe2 = { ...profiles.createDefault(2), league: 'Fate of the Vaal' }
+    profiles.saveProfile(poe1)
+    profiles.saveProfile(poe2)
     const store = makeFakeStore({
+      [ACTIVE_PROFILE_ID_KEY]: poe2.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
       poeVersion: 2,
       league: 'Fate of the Vaal',
       leaguePoe1: 'Mirage',
@@ -158,7 +174,8 @@ describe('refreshLeagues', () => {
 
     const changed = await refreshLeagues(store, fetcher)
 
-    expect(store.get('leaguePoe1')).toBe('Return of the Settlers')
+    expect(profiles.getProfile(poe1.id)?.league).toBe('Return of the Settlers')
+    expect(store.get('leaguePoe1')).toBe('Mirage')
     expect(store.get('league')).toBe('Fate of the Vaal') // active game (poe2) untouched
     expect(changed).not.toContain('league')
   })
@@ -259,7 +276,7 @@ describe('refreshLeagues', () => {
     expect(profiles.getProfile(poe1Hc.id)?.league).toBe('Hardcore Return of the Settlers')
     expect(profiles.getProfile(poe2Active.id)?.league).toBe('Fate of the Vaal')
     expect(store.get('league')).toBe('Fate of the Vaal')
-    expect(store.get('leaguePoe1')).toBe('Hardcore Return of the Settlers')
+    expect(store.get('leaguePoe1')).toBe('Mirage')
     expect(changed).not.toContain('league')
   })
 })

--- a/src/main/trade/leagues.test.ts
+++ b/src/main/trade/leagues.test.ts
@@ -4,7 +4,7 @@ import { join } from 'path'
 import type Store from 'electron-store'
 import { describe, expect, it } from 'vitest'
 import type { AppSettings } from '../../shared/types'
-import { ACTIVE_PROFILE_ID_KEY, LAST_PROFILE_ID_POE1_KEY, PROFILE_VERSION_KEY } from '../profile-settings'
+import { ACTIVE_PROFILE_ID_KEY, LAST_PROFILE_ID_POE1_KEY, PROFILE_VERSION_KEY } from '../profiles/profile-settings'
 import { initProfileStore } from '../profiles/store'
 import { migrateLeague, refreshLeagues } from './leagues'
 

--- a/src/main/trade/leagues.test.ts
+++ b/src/main/trade/leagues.test.ts
@@ -1,10 +1,10 @@
 import { mkdtempSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { describe, it, expect } from 'vitest'
 import type Store from 'electron-store'
 import { describe, expect, it } from 'vitest'
 import type { AppSettings } from '../../shared/types'
+import { ACTIVE_PROFILE_ID_KEY, LAST_PROFILE_ID_POE1_KEY, PROFILE_VERSION_KEY } from '../profile-settings'
 import { initProfileStore } from '../profiles/store'
 import { migrateLeague, refreshLeagues } from './leagues'
 
@@ -240,8 +240,9 @@ describe('refreshLeagues', () => {
     profiles.saveProfile(poe2Active)
 
     const store = makeFakeStore({
-      poeVersion: 2,
-      activeProfileId: poe2Active.id,
+      [PROFILE_VERSION_KEY]: 2,
+      [ACTIVE_PROFILE_ID_KEY]: poe2Active.id,
+      [LAST_PROFILE_ID_POE1_KEY]: poe1Hc.id,
       league: 'Fate of the Vaal',
       leaguePoe1: 'Mirage',
       leaguePoe2: 'Fate of the Vaal',
@@ -258,7 +259,7 @@ describe('refreshLeagues', () => {
     expect(profiles.getProfile(poe1Hc.id)?.league).toBe('Hardcore Return of the Settlers')
     expect(profiles.getProfile(poe2Active.id)?.league).toBe('Fate of the Vaal')
     expect(store.get('league')).toBe('Fate of the Vaal')
-    expect(store.get('leaguePoe1')).toBe('Return of the Settlers')
+    expect(store.get('leaguePoe1')).toBe('Hardcore Return of the Settlers')
     expect(changed).not.toContain('league')
   })
 })

--- a/src/main/trade/leagues.test.ts
+++ b/src/main/trade/leagues.test.ts
@@ -1,6 +1,11 @@
+import { mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { describe, it, expect } from 'vitest'
 import type Store from 'electron-store'
 import { describe, expect, it } from 'vitest'
 import type { AppSettings } from '../../shared/types'
+import { initProfileStore } from '../profiles/store'
 import { migrateLeague, refreshLeagues } from './leagues'
 
 describe('migrateLeague', () => {
@@ -213,5 +218,47 @@ describe('refreshLeagues', () => {
     const changed = await refreshLeagues(store, fetcher)
 
     expect(changed).toEqual([])
+  })
+
+  it('migrates every stale profile for a game without rewriting the active profile for another game', async () => {
+    const profiles = initProfileStore(mkdtempSync(join(tmpdir(), 'scalpel-league-profiles-')))
+    const poe1Trade = {
+      ...profiles.createDefault(1),
+      name: 'Trade',
+      league: 'Mirage',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    }
+    const poe1Hc = {
+      ...profiles.createDefault(1),
+      name: 'HC',
+      league: 'Hardcore Mirage',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }
+    const poe2Active = { ...profiles.createDefault(2), name: 'PoE2 active', league: 'Fate of the Vaal' }
+    profiles.saveProfile(poe1Trade)
+    profiles.saveProfile(poe1Hc)
+    profiles.saveProfile(poe2Active)
+
+    const store = makeFakeStore({
+      poeVersion: 2,
+      activeProfileId: poe2Active.id,
+      league: 'Fate of the Vaal',
+      leaguePoe1: 'Mirage',
+      leaguePoe2: 'Fate of the Vaal',
+      leaguesPoe1: [],
+      leaguesPoe2: [],
+    })
+    const fresh1 = ['Return of the Settlers', 'Hardcore Return of the Settlers', 'Standard', 'Hardcore']
+    const fresh2 = ['Fate of the Vaal', 'HC Fate of the Vaal', 'Standard', 'Hardcore']
+    const fetcher = async (v: 1 | 2): Promise<string[] | null> => (v === 1 ? fresh1 : fresh2)
+
+    const changed = await refreshLeagues(store, fetcher)
+
+    expect(profiles.getProfile(poe1Trade.id)?.league).toBe('Return of the Settlers')
+    expect(profiles.getProfile(poe1Hc.id)?.league).toBe('Hardcore Return of the Settlers')
+    expect(profiles.getProfile(poe2Active.id)?.league).toBe('Fate of the Vaal')
+    expect(store.get('league')).toBe('Fate of the Vaal')
+    expect(store.get('leaguePoe1')).toBe('Return of the Settlers')
+    expect(changed).not.toContain('league')
   })
 })

--- a/src/main/trade/leagues.ts
+++ b/src/main/trade/leagues.ts
@@ -1,22 +1,8 @@
-/** Fetch + cache league lists from the official trade APIs and migrate the
- *  user's selected league when their challenge league rotates out.
- *
- *  Endpoints live in `src/shared/endpoints.ts` (`getTradeUrls(v).leagues`).
- *  Both versions return `{ result: [{ id, text }, ...] }`. The trade UI uses
- *  `id` as the league key in queries, which is what we persist + render in the
- *  dropdown. They're static-data endpoints with very generous quotas so this
- *  module deliberately doesn't share the search/fetch/exchange rate buckets. */
-
 import { net } from 'electron'
 import type Store from 'electron-store'
 import { getTradeUrls } from '../../shared/endpoints'
 import { getProfileStore } from '../profiles/store'
-import {
-  hydrateProfileSettings,
-  listProfilesByGameVariant,
-  type ProfileChangedSetting,
-  type SettingChangeKey,
-} from '../profile-settings'
+import { listProfilesByGameVariant, type ProfileChangedSetting } from '../profile-settings'
 import { getGameFeatures } from '../../shared/game-features'
 import type { AppSettings } from '../../shared/types'
 
@@ -60,12 +46,8 @@ function fetchJson(url: string, timeoutMs = 10000): Promise<unknown> {
 export async function fetchLeagueList(version: 1 | 2): Promise<string[] | null> {
   try {
     const json = (await fetchJson(getTradeUrls(version).leagues)) as LeaguesResponse
-    // PoE trade API returns leagues per realm (pc, xbox, sony) -- we only
-    // support PC. Older entries without a realm field are treated as pc.
     const entries = (json.result ?? []).filter((l) => !l.realm || l.realm.toLowerCase() === 'pc')
     const rawIds = entries.map((l) => l.id).filter((s): s is string => typeof s === 'string' && s.length > 0)
-    // Dedupe defensively while preserving insertion order so the active SC
-    // challenge stays first (which migrateLeague depends on).
     const seen = new Set<string>()
     const ids: string[] = []
     for (const id of rawIds) {
@@ -84,16 +66,10 @@ function isHardcore(name: string): boolean {
   return name.startsWith('Hardcore ') || name.startsWith('HC ') || name === 'Hardcore'
 }
 
-/** "Standard" / "Hardcore" -- the never-rotating leagues every league cycle keeps. */
 function isPermanentLeague(name: string): boolean {
   return name === 'Standard' || name === 'Hardcore'
 }
 
-/** Decide what `leagueX` should become when the previously-stored league no
- *  longer appears in the freshly-fetched list. Returns null if the current
- *  league is still valid. Preserves softcore/hardcore preference, and falls
- *  back to the equivalent permanent league (Standard/Hardcore) if the new
- *  list has no challenge entry of the matching type. */
 export function migrateLeague(current: string, fresh: readonly string[]): string | null {
   if (!current || fresh.includes(current)) return null
   const wantsHC = isHardcore(current)
@@ -102,20 +78,7 @@ export function migrateLeague(current: string, fresh: readonly string[]): string
   return challenge ?? permanent ?? fresh[0] ?? current
 }
 
-/** Test seam: refreshLeagues calls this to obtain each version's league list,
- *  defaulting to the live trade API. Tests inject a stub. */
 export type LeagueFetcher = (version: 1 | 2) => Promise<string[] | null>
-
-function rememberChange<K extends keyof AppSettings>(
-  store: Store<AppSettings>,
-  changed: ProfileChangedSetting[],
-  key: K,
-  value: AppSettings[K],
-): void {
-  if (store.get(key) === value) return
-  store.set(key, value)
-  changed.push({ key, value })
-}
 
 function migrateProfileLeagues(
   store: Store<AppSettings>,
@@ -146,34 +109,23 @@ function migrateProfileLeagues(
   if (activeProfileChanged && activeId) {
     const activeProfile = profileStore.getProfile(activeId)
     if (activeProfile) {
-      for (const change of hydrateProfileSettings(store, activeProfile)) {
-        if (!changed.some((existing) => existing.key === change.key)) changed.push(change)
-      }
+      changed.push({ key: 'activeProfile', value: activeProfile, reason: 'migration' })
     }
   }
 
   return changed
 }
 
-/** Fetch both PoE1 and PoE2 league lists, persist them, and migrate the user's
- *  selected leagues if their challenge league rotated out. Returns the set of
- *  setting keys that were actually changed so callers can broadcast updates.
- *
- *  Pass `force: false` (the default) to skip the network round-trip when the
- *  last successful refresh was within the cooldown window -- callers like the
- *  app-window mount fire on every reopen and don't need fresh data more than
- *  hourly. The launch-time call uses `force: true` so a long-running app
- *  picks up new leagues on next open even past cooldown. */
 export async function refreshLeagues(
   store: Store<AppSettings>,
   fetcher: LeagueFetcher = fetchLeagueList,
   options: { force?: boolean } = {},
-): Promise<SettingChangeKey[]> {
-  const COOLDOWN_MS = 60 * 60 * 1000 // 1h
+): Promise<Array<keyof AppSettings | 'activeProfile'>> {
+  const COOLDOWN_MS = 60 * 60 * 1000
   const lastFetched = store.get('leaguesFetchedAt') ?? 0
   if (!options.force && Date.now() - lastFetched < COOLDOWN_MS) return []
 
-  const changed: SettingChangeKey[] = []
+  const changed: Array<keyof AppSettings | 'activeProfile'> = []
 
   const [poe1, poe2] = await Promise.all([fetcher(1), fetcher(2)])
 
@@ -198,9 +150,6 @@ export async function refreshLeagues(
   apply(poe1, 'leaguesPoe1', getGameFeatures(1).leagues, 1)
   apply(poe2, 'leaguesPoe2', getGameFeatures(2).leagues, 2)
 
-  // Mark a successful round so the cooldown gate above can short-circuit
-  // future calls. Only mark if at least one fetcher returned data, otherwise
-  // we'd cement a permanent failure.
   if (poe1 || poe2) store.set('leaguesFetchedAt', Date.now())
 
   return changed

--- a/src/main/trade/leagues.ts
+++ b/src/main/trade/leagues.ts
@@ -12,10 +12,10 @@ import type Store from 'electron-store'
 import { getTradeUrls } from '../../shared/endpoints'
 import { getProfileStore } from '../profiles/store'
 import {
-  findLastUsedProfileByGameVariant,
   hydrateProfileSettings,
   listProfilesByGameVariant,
   type ProfileChangedSetting,
+  type SettingChangeKey,
 } from '../profile-settings'
 import { getGameFeatures } from '../../shared/game-features'
 import type { AppSettings } from '../../shared/types'
@@ -123,22 +123,11 @@ function migrateProfileLeagues(
   list: readonly string[],
 ): ProfileChangedSetting[] {
   const changed: ProfileChangedSetting[] = []
-  const mirrorKey = version === 2 ? 'leaguePoe2' : 'leaguePoe1'
   const activeId = store.get('activeProfileId')
   const profiles = listProfilesByGameVariant(version)
 
-  if (profiles.length === 0) {
-    const currentLeague = store.get(mirrorKey)
-    const next = migrateLeague(currentLeague, list)
-    if (next && next !== currentLeague) {
-      rememberChange(store, changed, mirrorKey, next)
-      if (store.get('poeVersion') === version) rememberChange(store, changed, 'league', next)
-    }
-    return changed
-  }
+  if (profiles.length === 0) return changed
 
-  const lastUsedProfile = findLastUsedProfileByGameVariant(store, version)
-  let lastUsedNext: string | null = null
   let activeProfileChanged = false
   const profileStore = getProfileStore()
 
@@ -151,11 +140,8 @@ function migrateProfileLeagues(
     profile.updatedAt = new Date().toISOString()
     profileStore.saveProfile(profile)
 
-    if (profile.id === lastUsedProfile?.id) lastUsedNext = next
     if (profile.id === activeId) activeProfileChanged = true
   }
-
-  if (lastUsedNext) rememberChange(store, changed, mirrorKey, lastUsedNext)
 
   if (activeProfileChanged && activeId) {
     const activeProfile = profileStore.getProfile(activeId)
@@ -182,19 +168,18 @@ export async function refreshLeagues(
   store: Store<AppSettings>,
   fetcher: LeagueFetcher = fetchLeagueList,
   options: { force?: boolean } = {},
-): Promise<Array<keyof AppSettings>> {
+): Promise<SettingChangeKey[]> {
   const COOLDOWN_MS = 60 * 60 * 1000 // 1h
   const lastFetched = store.get('leaguesFetchedAt') ?? 0
   if (!options.force && Date.now() - lastFetched < COOLDOWN_MS) return []
 
-  const changed: Array<keyof AppSettings> = []
+  const changed: SettingChangeKey[] = []
 
   const [poe1, poe2] = await Promise.all([fetcher(1), fetcher(2)])
 
   const apply = (
     fetched: string[] | null,
     listKey: 'leaguesPoe1' | 'leaguesPoe2',
-    _leagueKey: 'leaguePoe1' | 'leaguePoe2',
     fallback: readonly string[],
     version: 1 | 2,
   ): void => {
@@ -210,8 +195,8 @@ export async function refreshLeagues(
     }
   }
 
-  apply(poe1, 'leaguesPoe1', 'leaguePoe1', getGameFeatures(1).leagues, 1)
-  apply(poe2, 'leaguesPoe2', 'leaguePoe2', getGameFeatures(2).leagues, 2)
+  apply(poe1, 'leaguesPoe1', getGameFeatures(1).leagues, 1)
+  apply(poe2, 'leaguesPoe2', getGameFeatures(2).leagues, 2)
 
   // Mark a successful round so the cooldown gate above can short-circuit
   // future calls. Only mark if at least one fetcher returned data, otherwise

--- a/src/main/trade/leagues.ts
+++ b/src/main/trade/leagues.ts
@@ -10,6 +10,7 @@
 import { net } from 'electron'
 import type Store from 'electron-store'
 import { getTradeUrls } from '../../shared/endpoints'
+import { writeProfileSettingByGameVariant } from '../profile-settings'
 import { getGameFeatures } from '../../shared/game-features'
 import type { AppSettings } from '../../shared/types'
 
@@ -138,12 +139,9 @@ export async function refreshLeagues(
     const next = migrateLeague(currentLeague, list)
     if (next && next !== currentLeague) {
       console.warn(`[leagues] migrating ${leagueKey}: ${currentLeague} -> ${next}`)
-      store.set(leagueKey, next)
-      changed.push(leagueKey)
-      // Mirror to the flat 'league' if this is the active version
-      if (store.get('poeVersion') === version && store.get('league') === currentLeague) {
-        store.set('league', next)
-        changed.push('league')
+      const profileChanges = writeProfileSettingByGameVariant(store, version, 'league', next)
+      for (const change of profileChanges) {
+        if (!changed.includes(change.key)) changed.push(change.key)
       }
     }
   }

--- a/src/main/trade/leagues.ts
+++ b/src/main/trade/leagues.ts
@@ -2,7 +2,7 @@ import { net } from 'electron'
 import type Store from 'electron-store'
 import { getTradeUrls } from '../../shared/endpoints'
 import { getProfileStore } from '../profiles/store'
-import { listProfilesByGameVariant, type ProfileChangedSetting } from '../profile-settings'
+import { listProfilesByGameVariant, type ProfileChangedSetting } from '../profiles/profile-settings'
 import { getGameFeatures } from '../../shared/game-features'
 import type { AppSettings } from '../../shared/types'
 

--- a/src/main/trade/leagues.ts
+++ b/src/main/trade/leagues.ts
@@ -11,7 +11,12 @@ import { net } from 'electron'
 import type Store from 'electron-store'
 import { getTradeUrls } from '../../shared/endpoints'
 import { getProfileStore } from '../profiles/store'
-import { hydrateProfileSettings, listProfilesByGameVariant, type ProfileChangedSetting } from '../profile-settings'
+import {
+  findLastUsedProfileByGameVariant,
+  hydrateProfileSettings,
+  listProfilesByGameVariant,
+  type ProfileChangedSetting,
+} from '../profile-settings'
 import { getGameFeatures } from '../../shared/game-features'
 import type { AppSettings } from '../../shared/types'
 
@@ -132,7 +137,7 @@ function migrateProfileLeagues(
     return changed
   }
 
-  const lastUsedProfile = profiles[0]
+  const lastUsedProfile = findLastUsedProfileByGameVariant(store, version)
   let lastUsedNext: string | null = null
   let activeProfileChanged = false
   const profileStore = getProfileStore()
@@ -146,7 +151,7 @@ function migrateProfileLeagues(
     profile.updatedAt = new Date().toISOString()
     profileStore.saveProfile(profile)
 
-    if (profile.id === lastUsedProfile.id) lastUsedNext = next
+    if (profile.id === lastUsedProfile?.id) lastUsedNext = next
     if (profile.id === activeId) activeProfileChanged = true
   }
 

--- a/src/main/trade/leagues.ts
+++ b/src/main/trade/leagues.ts
@@ -10,7 +10,8 @@
 import { net } from 'electron'
 import type Store from 'electron-store'
 import { getTradeUrls } from '../../shared/endpoints'
-import { writeProfileSettingByGameVariant } from '../profile-settings'
+import { getProfileStore } from '../profiles/store'
+import { hydrateProfileSettings, listProfilesByGameVariant, type ProfileChangedSetting } from '../profile-settings'
 import { getGameFeatures } from '../../shared/game-features'
 import type { AppSettings } from '../../shared/types'
 
@@ -100,6 +101,69 @@ export function migrateLeague(current: string, fresh: readonly string[]): string
  *  defaulting to the live trade API. Tests inject a stub. */
 export type LeagueFetcher = (version: 1 | 2) => Promise<string[] | null>
 
+function rememberChange<K extends keyof AppSettings>(
+  store: Store<AppSettings>,
+  changed: ProfileChangedSetting[],
+  key: K,
+  value: AppSettings[K],
+): void {
+  if (store.get(key) === value) return
+  store.set(key, value)
+  changed.push({ key, value })
+}
+
+function migrateProfileLeagues(
+  store: Store<AppSettings>,
+  version: 1 | 2,
+  list: readonly string[],
+): ProfileChangedSetting[] {
+  const changed: ProfileChangedSetting[] = []
+  const mirrorKey = version === 2 ? 'leaguePoe2' : 'leaguePoe1'
+  const activeId = store.get('activeProfileId')
+  const profiles = listProfilesByGameVariant(version)
+
+  if (profiles.length === 0) {
+    const currentLeague = store.get(mirrorKey)
+    const next = migrateLeague(currentLeague, list)
+    if (next && next !== currentLeague) {
+      rememberChange(store, changed, mirrorKey, next)
+      if (store.get('poeVersion') === version) rememberChange(store, changed, 'league', next)
+    }
+    return changed
+  }
+
+  const lastUsedProfile = profiles[0]
+  let lastUsedNext: string | null = null
+  let activeProfileChanged = false
+  const profileStore = getProfileStore()
+
+  for (const profile of profiles) {
+    const next = migrateLeague(profile.league, list)
+    if (!next || next === profile.league) continue
+
+    console.warn(`[leagues] migrating profile ${profile.id}: ${profile.league} -> ${next}`)
+    profile.league = next
+    profile.updatedAt = new Date().toISOString()
+    profileStore.saveProfile(profile)
+
+    if (profile.id === lastUsedProfile.id) lastUsedNext = next
+    if (profile.id === activeId) activeProfileChanged = true
+  }
+
+  if (lastUsedNext) rememberChange(store, changed, mirrorKey, lastUsedNext)
+
+  if (activeProfileChanged && activeId) {
+    const activeProfile = profileStore.getProfile(activeId)
+    if (activeProfile) {
+      for (const change of hydrateProfileSettings(store, activeProfile)) {
+        if (!changed.some((existing) => existing.key === change.key)) changed.push(change)
+      }
+    }
+  }
+
+  return changed
+}
+
 /** Fetch both PoE1 and PoE2 league lists, persist them, and migrate the user's
  *  selected leagues if their challenge league rotated out. Returns the set of
  *  setting keys that were actually changed so callers can broadcast updates.
@@ -125,7 +189,7 @@ export async function refreshLeagues(
   const apply = (
     fetched: string[] | null,
     listKey: 'leaguesPoe1' | 'leaguesPoe2',
-    leagueKey: 'leaguePoe1' | 'leaguePoe2',
+    _leagueKey: 'leaguePoe1' | 'leaguePoe2',
     fallback: readonly string[],
     version: 1 | 2,
   ): void => {
@@ -135,14 +199,9 @@ export async function refreshLeagues(
       store.set(listKey, list)
       changed.push(listKey)
     }
-    const currentLeague = store.get(leagueKey)
-    const next = migrateLeague(currentLeague, list)
-    if (next && next !== currentLeague) {
-      console.warn(`[leagues] migrating ${leagueKey}: ${currentLeague} -> ${next}`)
-      const profileChanges = writeProfileSettingByGameVariant(store, version, 'league', next)
-      for (const change of profileChanges) {
-        if (!changed.includes(change.key)) changed.push(change.key)
-      }
+    const profileChanges = migrateProfileLeagues(store, version, list)
+    for (const change of profileChanges) {
+      if (!changed.includes(change.key)) changed.push(change.key)
     }
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,7 +4,6 @@ import type { ExternalLinkTarget } from '../shared/external-link'
 import type {
   AppSettings,
   AuthResult,
-  CheatSheetsSettings,
   FilterBlock,
   FilterListEntry,
   FilterVersion,
@@ -13,27 +12,26 @@ import type {
   Manifest,
   OverlayData,
   PoeProfileSummary,
-  TradePriceOption,
+  ProfileSettingKey,
+  ProfileSettingValue,
+  RuntimeSettings,
   Zone,
 } from '../shared/types'
 import type { BoardLibrary, BoardSnapshot, BoardState } from '../shared/whiteboard-types'
-
-type ProfileBackedSettingKey = 'league' | 'filterPath' | 'filterDir' | 'tradePriceOption' | 'cheatSheets'
-type ProfileBackedValue = string | TradePriceOption | CheatSheetsSettings
 
 export const api = {
   // Manifest
   getManifest: (): Promise<Manifest> => ipcRenderer.invoke('get-manifest'),
 
   // Settings
-  getSettings: (): Promise<AppSettings> => ipcRenderer.invoke('get-settings'),
+  getSettings: (): Promise<RuntimeSettings> => ipcRenderer.invoke('get-settings'),
   setSetting: <K extends keyof AppSettings>(key: K, value: AppSettings[K]): Promise<void> =>
     ipcRenderer.invoke('set-setting', key, value),
   setProfileSettingForGame: (
     variant: GameVariant,
-    key: ProfileBackedSettingKey,
-    value: ProfileBackedValue,
-  ): Promise<AppSettings> => ipcRenderer.invoke('set-profile-setting-for-game', variant, key, value),
+    key: ProfileSettingKey,
+    value: ProfileSettingValue<typeof key>,
+  ): Promise<RuntimeSettings> => ipcRenderer.invoke('set-profile-setting-for-game', variant, key, value),
   listProfiles: (): Promise<PoeProfileSummary[]> => ipcRenderer.invoke('list-profiles'),
   createProfile: (input: {
     name: string
@@ -49,7 +47,7 @@ export const api = {
     id: string,
     restartIfNeeded = false,
   ): Promise<
-    | { ok: true; settings: AppSettings }
+    | { ok: true; settings: RuntimeSettings }
     | { ok: true; restarting: true; devRestartRequired?: true }
     | { ok: false; requiresRestart: true; targetGame: GameVariant }
     | { ok: false; error: string }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -47,7 +47,7 @@ export const api = {
     id: string,
     restartIfNeeded = false,
   ): Promise<
-    | { ok: true; settings: RuntimeSettings }
+    | { ok: true; settings: RuntimeSettings; devRestartRequired?: true }
     | { ok: true; restarting: true; devRestartRequired?: true }
     | { ok: false; requiresRestart: true; targetGame: GameVariant }
     | { ok: false; error: string }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -35,7 +35,15 @@ export const api = {
   duplicateProfile: (id: string, name: string): Promise<PoeProfileSummary> =>
     ipcRenderer.invoke('duplicate-profile', id, name),
   deleteProfile: (id: string): Promise<void> => ipcRenderer.invoke('delete-profile', id),
-  setActiveProfile: (id: string): Promise<AppSettings> => ipcRenderer.invoke('set-active-profile', id),
+  setActiveProfile: (
+    id: string,
+    restartIfNeeded = false,
+  ): Promise<
+    | { ok: true; settings: AppSettings }
+    | { ok: true; restarting: true; devRestartRequired?: true }
+    | { ok: false; requiresRestart: true; targetGame: GameVariant }
+    | { ok: false; error: string }
+  > => ipcRenderer.invoke('set-active-profile', id, restartIfNeeded),
   refreshLeagues: (): Promise<{
     leaguesPoe1: string[]
     leaguesPoe2: string[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,9 +7,11 @@ import type {
   FilterBlock,
   FilterListEntry,
   FilterVersion,
+  GameVariant,
   HistoryEntry,
   Manifest,
   OverlayData,
+  PoeProfileSummary,
   Zone,
 } from '../shared/types'
 import type { BoardLibrary, BoardSnapshot, BoardState } from '../shared/whiteboard-types'
@@ -22,6 +24,18 @@ export const api = {
   getSettings: (): Promise<AppSettings> => ipcRenderer.invoke('get-settings'),
   setSetting: <K extends keyof AppSettings>(key: K, value: AppSettings[K]): Promise<void> =>
     ipcRenderer.invoke('set-setting', key, value),
+  listProfiles: (): Promise<PoeProfileSummary[]> => ipcRenderer.invoke('list-profiles'),
+  createProfile: (input: {
+    name: string
+    gameVariant: GameVariant
+    cloneFromId?: string
+  }): Promise<PoeProfileSummary> => ipcRenderer.invoke('create-profile', input),
+  renameProfile: (id: string, name: string): Promise<PoeProfileSummary | null> =>
+    ipcRenderer.invoke('rename-profile', id, name),
+  duplicateProfile: (id: string, name: string): Promise<PoeProfileSummary> =>
+    ipcRenderer.invoke('duplicate-profile', id, name),
+  deleteProfile: (id: string): Promise<void> => ipcRenderer.invoke('delete-profile', id),
+  setActiveProfile: (id: string): Promise<AppSettings> => ipcRenderer.invoke('set-active-profile', id),
   refreshLeagues: (): Promise<{
     leaguesPoe1: string[]
     leaguesPoe2: string[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -323,6 +323,11 @@ export const api = {
     ipcRenderer.on('setting-updated', handler)
     return () => ipcRenderer.removeListener('setting-updated', handler)
   },
+  onLeagueUpdated: (cb: (league: string) => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, league: string): void => cb(league)
+    ipcRenderer.on('league-updated', handler)
+    return () => ipcRenderer.removeListener('league-updated', handler)
+  },
   onSkipAnimation: (cb: () => void): (() => void) => {
     const handler = (): void => cb()
     ipcRenderer.on('skip-animation', handler)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -598,6 +598,11 @@ export const api = {
     ipcRenderer.on('online-filter-changed', handler)
     return () => ipcRenderer.removeListener('online-filter-changed', handler)
   },
+  onFilterChanged: (cb: () => void): (() => void) => {
+    const handler = (): void => cb()
+    ipcRenderer.on('filter-changed', handler)
+    return () => ipcRenderer.removeListener('filter-changed', handler)
+  },
 
   // Auto-update
   downloadUpdate: (): Promise<void> => ipcRenderer.invoke('download-update'),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import type { ExternalLinkTarget } from '../shared/external-link'
 import type {
   AppSettings,
   AuthResult,
+  CheatSheetsSettings,
   FilterBlock,
   FilterListEntry,
   FilterVersion,
@@ -12,9 +13,13 @@ import type {
   Manifest,
   OverlayData,
   PoeProfileSummary,
+  TradePriceOption,
   Zone,
 } from '../shared/types'
 import type { BoardLibrary, BoardSnapshot, BoardState } from '../shared/whiteboard-types'
+
+type ProfileBackedSettingKey = 'league' | 'filterPath' | 'filterDir' | 'tradePriceOption' | 'cheatSheets'
+type ProfileBackedValue = string | TradePriceOption | CheatSheetsSettings
 
 export const api = {
   // Manifest
@@ -24,6 +29,11 @@ export const api = {
   getSettings: (): Promise<AppSettings> => ipcRenderer.invoke('get-settings'),
   setSetting: <K extends keyof AppSettings>(key: K, value: AppSettings[K]): Promise<void> =>
     ipcRenderer.invoke('set-setting', key, value),
+  setProfileSettingForGame: (
+    variant: GameVariant,
+    key: ProfileBackedSettingKey,
+    value: ProfileBackedValue,
+  ): Promise<AppSettings> => ipcRenderer.invoke('set-profile-setting-for-game', variant, key, value),
   listProfiles: (): Promise<PoeProfileSummary[]> => ipcRenderer.invoke('list-profiles'),
   createProfile: (input: {
     name: string
@@ -47,9 +57,6 @@ export const api = {
   refreshLeagues: (): Promise<{
     leaguesPoe1: string[]
     leaguesPoe2: string[]
-    leaguePoe1: string
-    leaguePoe2: string
-    league: string
   }> => ipcRenderer.invoke('refresh-leagues'),
   pickFilterFile: (): Promise<string | null> => ipcRenderer.invoke('pick-filter-file'),
   pickFilterDir: (): Promise<string | null> => ipcRenderer.invoke('pick-filter-dir'),
@@ -163,7 +170,6 @@ export const api = {
     ipcRenderer.invoke('delete-version', filename),
 
   // App window
-  finishOnboarding: (): Promise<void> => ipcRenderer.invoke('finish-onboarding'),
   setAppWindowMode: (mode: 'onboarding' | 'settings'): void => ipcRenderer.send('app-window-mode', mode),
 
   // Dev tools

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -39,6 +39,7 @@ export function AppWindow(): JSX.Element {
   const [importedOnline, setImportedOnline] = useState<ImportedOnline>({ poe1: null, poe2: null })
   const [gameSwitchTarget, setGameSwitchTarget] = useState<1 | 2 | null>(null)
   const [selectedGames, setSelectedGames] = useState<SelectedGames>({ poe1: false, poe2: false })
+  const [settingsTabRequest, setSettingsTabRequest] = useState<{ tab: string; n: number } | null>(null)
   // Set when the user opens Manage Profiles from settings so the focus-bounce
   // effect below doesn't yank them back to settings on every focus event.
   const [revisitingOnboarding, setRevisitingOnboarding] = useState(false)
@@ -131,20 +132,24 @@ export function AppWindow(): JSX.Element {
   }
 
   const editProfile = async (profile: PoeProfileSummary): Promise<void> => {
-    const nextGames = { poe1: profile.gameVariant === 1, poe2: profile.gameVariant === 2 }
     const result = await window.api.setActiveProfile(profile.id)
     if (!result.ok && 'requiresRestart' in result) {
       const confirmed = window.confirm(
         `Editing this PoE${profile.gameVariant} profile requires restarting Scalpel so the overlay can attach to the correct game. Restart now?`,
       )
-      if (confirmed) await window.api.setActiveProfile(profile.id, true)
+      if (!confirmed) return
+      const restartResult = await window.api.setActiveProfile(profile.id, true)
+      if (!restartResult.ok || !('settings' in restartResult)) return
+      setSettings(restartResult.settings)
+      setSettingsTabRequest((prev) => ({ tab: 'filter', n: (prev?.n ?? 0) + 1 }))
+      goTo('settings')
       return
     }
     if (!result.ok) return
     if ('restarting' in result) return
     setSettings(result.settings)
-    setSelectedGames(nextGames)
-    goTo(filterFolderStepFor(profile.gameVariant), nextGames)
+    setSettingsTabRequest((prev) => ({ tab: 'filter', n: (prev?.n ?? 0) + 1 }))
+    goTo('settings')
   }
 
   const startFilterFlowFor = async (game: 1 | 2): Promise<void> => {
@@ -353,6 +358,7 @@ export function AppWindow(): JSX.Element {
             <AppSettingsWrapper
               settings={settings}
               onSettingsChange={setSettings}
+              tabRequest={settingsTabRequest}
               onManageProfiles={() => {
                 setRevisitingOnboarding(true)
                 goTo('profiles')

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -27,22 +27,18 @@ import {
 } from './app-window/onboarding-steps'
 import { AppSettingsWrapper } from './app-window/AppSettingsWrapper'
 import { AppUpdateBanner } from './app-window/AppUpdateBanner'
-import { ProfileManagerStep } from './app-window/ProfileManagerStep'
 import { GameSwitchModal } from './components/GameSwitchModal'
 
 type ImportedOnline = { poe1: string | null; poe2: string | null }
 
 export function AppWindow(): JSX.Element {
   const [settings, setSettings] = useState<RuntimeSettings | null>(null)
-  const [step, setStep] = useState<Step>('profiles')
+  const [step, setStep] = useState<Step>('welcome')
   const [direction, setDirection] = useState<'forward' | 'back'>('forward')
   const [importedOnline, setImportedOnline] = useState<ImportedOnline>({ poe1: null, poe2: null })
   const [gameSwitchTarget, setGameSwitchTarget] = useState<1 | 2 | null>(null)
   const [selectedGames, setSelectedGames] = useState<SelectedGames>({ poe1: false, poe2: false })
   const [settingsTabRequest, setSettingsTabRequest] = useState<{ tab: string; n: number } | null>(null)
-  // Set when the user opens Manage Profiles from settings so the focus-bounce
-  // effect below doesn't yank them back to settings on every focus event.
-  const [revisitingOnboarding, setRevisitingOnboarding] = useState(false)
 
   const goTo = (next: Step, resumeGames = selectedGames): void => {
     const curIdx = STEP_ORDER.indexOf(step)
@@ -72,7 +68,7 @@ export function AppWindow(): JSX.Element {
       if (s.onboardingCompleted) {
         goTo('settings')
       } else if (s.onboardingStep) {
-        setStep((s.onboardingStep === 'welcome' ? 'profiles' : s.onboardingStep) as Step)
+        setStep((s.onboardingStep === 'profiles' ? 'welcome' : s.onboardingStep) as Step)
         if (s.onboardingSelectedGames) setSelectedGames(s.onboardingSelectedGames)
         if (s.onboardingImportedOnline) setImportedOnline(s.onboardingImportedOnline)
       }
@@ -95,11 +91,11 @@ export function AppWindow(): JSX.Element {
 
   useEffect(() => {
     const onFocus = (): void => {
-      if (settings?.onboardingCompleted && step !== 'settings' && !revisitingOnboarding) goTo('settings')
+      if (settings?.onboardingCompleted && step !== 'settings') goTo('settings')
     }
     window.addEventListener('focus', onFocus)
     return () => window.removeEventListener('focus', onFocus)
-  }, [settings, step, revisitingOnboarding])
+  }, [settings, step])
 
   const updateSetting = <K extends keyof AppSettings>(key: K, value: AppSettings[K]): void => {
     if (!settings) return
@@ -113,23 +109,10 @@ export function AppWindow(): JSX.Element {
 
   if (!settings) return <div />
 
-  const showBackToSettings = revisitingOnboarding
-  const onBackToSettings = (): void => {
-    setRevisitingOnboarding(false)
-    goTo('settings')
-  }
-
   const total = totalOnboardingSteps(selectedGames)
   const sharedBase = sharedStepBase(selectedGames)
   const orderedGames = selectedGameOrder(selectedGames)
   const showGameLabel = orderedGames.length === 2
-
-  const finishProfileManager = (): void => {
-    window.api.setSetting('onboardingCompleted', true)
-    window.api.setSetting('onboardingStep', '')
-    setRevisitingOnboarding(false)
-    goTo('settings')
-  }
 
   const editProfile = async (profile: PoeProfileSummary): Promise<void> => {
     const result = await window.api.setActiveProfile(profile.id)
@@ -181,23 +164,11 @@ export function AppWindow(): JSX.Element {
       <div
         className="flex-1 overflow-y-auto overflow-x-hidden flex justify-center"
         style={{
-          alignItems: step !== 'settings' && step !== 'profiles' ? 'center' : undefined,
-          marginTop: step !== 'settings' && step !== 'profiles' ? -10 : undefined,
+          alignItems: step !== 'settings' ? 'center' : undefined,
+          marginTop: step !== 'settings' ? -10 : undefined,
         }}
       >
         <div className={`w-full max-w-[480px] px-6 py-8 ${step !== 'settings' ? 'select-none' : ''}`}>
-          {step === 'profiles' && (
-            <SlideIn stepKey="profiles" direction={direction}>
-              <ProfileManagerStep
-                settings={settings}
-                onSettingsChange={setSettings}
-                onEditProfile={(profile) => {
-                  void editProfile(profile)
-                }}
-                onFinish={finishProfileManager}
-              />
-            </SlideIn>
-          )}
           {step === 'welcome' && (
             <SlideIn stepKey="welcome" direction={direction}>
               <WelcomeStep
@@ -206,7 +177,6 @@ export function AppWindow(): JSX.Element {
                 onNext={() => {
                   void startFilterFlowFor(orderedGames[0] ?? 1)
                 }}
-                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -238,7 +208,6 @@ export function AppWindow(): JSX.Element {
                       game={showGameLabel ? game : null}
                       stepNum={filterStepNum(selectedGames, game, 'folder')}
                       totalSteps={total}
-                      onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
                     />
                   </SlideIn>
                 )}
@@ -260,7 +229,6 @@ export function AppWindow(): JSX.Element {
                       game={showGameLabel ? game : null}
                       stepNum={filterStepNum(selectedGames, game, 'filter')}
                       totalSteps={total}
-                      onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
                     />
                   </SlideIn>
                 )}
@@ -282,7 +250,6 @@ export function AppWindow(): JSX.Element {
                       }}
                       stepNum={filterStepNum(selectedGames, game, 'filter') + 1}
                       totalSteps={total + 1}
-                      onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
                     />
                   </SlideIn>
                 )}
@@ -299,7 +266,6 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo(backStepFromHotkey(selectedGames, importedOnline))}
                 stepNum={sharedBase + 1}
                 totalSteps={total}
-                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -312,7 +278,6 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo('hotkey')}
                 stepNum={sharedBase + 2}
                 totalSteps={total}
-                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -323,7 +288,6 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo('pricecheck-hotkey')}
                 stepNum={sharedBase + 3}
                 totalSteps={total}
-                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -338,7 +302,6 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo('trade-login')}
                 stepNum={sharedBase + 4}
                 totalSteps={total}
-                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -348,7 +311,6 @@ export function AppWindow(): JSX.Element {
                 onFinish={() => {
                   window.api.setSetting('onboardingCompleted', true)
                   window.api.setSetting('onboardingStep', '')
-                  setRevisitingOnboarding(false)
                   goTo('settings')
                 }}
               />
@@ -359,9 +321,8 @@ export function AppWindow(): JSX.Element {
               settings={settings}
               onSettingsChange={setSettings}
               tabRequest={settingsTabRequest}
-              onManageProfiles={() => {
-                setRevisitingOnboarding(true)
-                goTo('profiles')
+              onEditProfile={(profile) => {
+                void editProfile(profile)
               }}
             />
           )}

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useEffect, useState } from 'react'
-import type { AppSettings } from '../../shared/types'
+import type { AppSettings, PoeProfileSummary } from '../../shared/types'
 import { type Step, STEP_ORDER, type SelectedGames, totalOnboardingSteps } from './app-window/constants'
 import {
   backStepFromFilterFolder,
@@ -27,29 +27,30 @@ import {
 } from './app-window/onboarding-steps'
 import { AppSettingsWrapper } from './app-window/AppSettingsWrapper'
 import { AppUpdateBanner } from './app-window/AppUpdateBanner'
+import { ProfileManagerStep } from './app-window/ProfileManagerStep'
 import { GameSwitchModal } from './components/GameSwitchModal'
 
 type ImportedOnline = { poe1: string | null; poe2: string | null }
 
 export function AppWindow(): JSX.Element {
   const [settings, setSettings] = useState<AppSettings | null>(null)
-  const [step, setStep] = useState<Step>('welcome')
+  const [step, setStep] = useState<Step>('profiles')
   const [direction, setDirection] = useState<'forward' | 'back'>('forward')
   const [importedOnline, setImportedOnline] = useState<ImportedOnline>({ poe1: null, poe2: null })
   const [gameSwitchTarget, setGameSwitchTarget] = useState<1 | 2 | null>(null)
   const [selectedGames, setSelectedGames] = useState<SelectedGames>({ poe1: false, poe2: false })
-  // Set when the user clicks "Show Onboarding" from settings so the focus-bounce
+  // Set when the user opens Manage Profiles from settings so the focus-bounce
   // effect below doesn't yank them back to settings on every focus event.
   const [revisitingOnboarding, setRevisitingOnboarding] = useState(false)
 
-  const goTo = (next: Step): void => {
+  const goTo = (next: Step, resumeGames = selectedGames): void => {
     const curIdx = STEP_ORDER.indexOf(step)
     const nextIdx = STEP_ORDER.indexOf(next)
     setDirection(nextIdx >= curIdx ? 'forward' : 'back')
     setStep(next)
     if (next !== 'settings' && next !== 'done') {
       window.api.setSetting('onboardingStep', next)
-      window.api.setSetting('onboardingSelectedGames', selectedGames)
+      window.api.setSetting('onboardingSelectedGames', resumeGames)
       window.api.setSetting('onboardingImportedOnline', importedOnline)
     }
   }
@@ -70,7 +71,7 @@ export function AppWindow(): JSX.Element {
       if (s.onboardingCompleted) {
         goTo('settings')
       } else if (s.onboardingStep) {
-        setStep(s.onboardingStep as Step)
+        setStep((s.onboardingStep === 'welcome' ? 'profiles' : s.onboardingStep) as Step)
         if (s.onboardingSelectedGames) setSelectedGames(s.onboardingSelectedGames)
         if (s.onboardingImportedOnline) setImportedOnline(s.onboardingImportedOnline)
       }
@@ -118,6 +119,20 @@ export function AppWindow(): JSX.Element {
   const orderedGames = selectedGameOrder(selectedGames)
   const showGameLabel = orderedGames.length === 2
 
+  const finishProfileManager = (): void => {
+    window.api.setSetting('onboardingCompleted', true)
+    window.api.setSetting('onboardingStep', '')
+    setRevisitingOnboarding(false)
+    goTo('settings')
+  }
+
+  const editProfile = async (profile: PoeProfileSummary): Promise<void> => {
+    const nextGames = { poe1: profile.gameVariant === 1, poe2: profile.gameVariant === 2 }
+    setSettings(await window.api.setActiveProfile(profile.id))
+    setSelectedGames(nextGames)
+    goTo(filterFolderStepFor(profile.gameVariant), nextGames)
+  }
+
   const startFilterFlowFor = async (game: 1 | 2): Promise<void> => {
     await switchOnboardingGame(game)
     goTo(filterFolderStepFor(game))
@@ -152,6 +167,18 @@ export function AppWindow(): JSX.Element {
         }}
       >
         <div className={`w-full max-w-[480px] px-6 py-8 ${step !== 'settings' ? 'select-none' : ''}`}>
+          {step === 'profiles' && (
+            <SlideIn stepKey="profiles" direction={direction}>
+              <ProfileManagerStep
+                settings={settings}
+                onSettingsChange={setSettings}
+                onEditProfile={(profile) => {
+                  void editProfile(profile)
+                }}
+                onFinish={finishProfileManager}
+              />
+            </SlideIn>
+          )}
           {step === 'welcome' && (
             <SlideIn stepKey="welcome" direction={direction}>
               <WelcomeStep
@@ -311,9 +338,9 @@ export function AppWindow(): JSX.Element {
             <AppSettingsWrapper
               settings={settings}
               onSettingsChange={setSettings}
-              onShowOnboarding={() => {
+              onManageProfiles={() => {
                 setRevisitingOnboarding(true)
-                goTo('welcome')
+                goTo('profiles')
               }}
             />
           )}

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useEffect, useState } from 'react'
-import type { AppSettings, PoeProfileSummary } from '../../shared/types'
+import type { AppSettings, PoeProfileSummary, RuntimeSettings } from '../../shared/types'
 import { type Step, STEP_ORDER, type SelectedGames, totalOnboardingSteps } from './app-window/constants'
 import {
   backStepFromFilterFolder,
@@ -33,7 +33,7 @@ import { GameSwitchModal } from './components/GameSwitchModal'
 type ImportedOnline = { poe1: string | null; poe2: string | null }
 
 export function AppWindow(): JSX.Element {
-  const [settings, setSettings] = useState<AppSettings | null>(null)
+  const [settings, setSettings] = useState<RuntimeSettings | null>(null)
   const [step, setStep] = useState<Step>('profiles')
   const [direction, setDirection] = useState<'forward' | 'back'>('forward')
   const [importedOnline, setImportedOnline] = useState<ImportedOnline>({ poe1: null, poe2: null })
@@ -106,7 +106,7 @@ export function AppWindow(): JSX.Element {
     setSettings({ ...settings, [key]: value })
   }
 
-  const updateProfileSettingForGame = async (game: 1 | 2, key: 'league', value: unknown): Promise<void> => {
+  const updateProfileSettingForGame = async (game: 1 | 2, key: 'league', value: string): Promise<void> => {
     setSettings(await window.api.setProfileSettingForGame(game, key, value))
   }
 

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -128,7 +128,17 @@ export function AppWindow(): JSX.Element {
 
   const editProfile = async (profile: PoeProfileSummary): Promise<void> => {
     const nextGames = { poe1: profile.gameVariant === 1, poe2: profile.gameVariant === 2 }
-    setSettings(await window.api.setActiveProfile(profile.id))
+    const result = await window.api.setActiveProfile(profile.id)
+    if (!result.ok && 'requiresRestart' in result) {
+      const confirmed = window.confirm(
+        `Editing this PoE${profile.gameVariant} profile requires restarting Scalpel so the overlay can attach to the correct game. Restart now?`,
+      )
+      if (confirmed) await window.api.setActiveProfile(profile.id, true)
+      return
+    }
+    if (!result.ok) return
+    if ('restarting' in result) return
+    setSettings(result.settings)
     setSelectedGames(nextGames)
     goTo(filterFolderStepFor(profile.gameVariant), nextGames)
   }

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -162,8 +162,8 @@ export function AppWindow(): JSX.Element {
       <div
         className="flex-1 overflow-y-auto overflow-x-hidden flex justify-center"
         style={{
-          alignItems: step !== 'settings' ? 'center' : undefined,
-          marginTop: step !== 'settings' ? -10 : undefined,
+          alignItems: step !== 'settings' && step !== 'profiles' ? 'center' : undefined,
+          marginTop: step !== 'settings' && step !== 'profiles' ? -10 : undefined,
         }}
       >
         <div className={`w-full max-w-[480px] px-6 py-8 ${step !== 'settings' ? 'select-none' : ''}`}>

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -7,7 +7,6 @@ import {
   filterFolderStepFor,
   filterStepFor,
   filterStepNum,
-  hasConfiguredProfile,
   nextStepAfterFilter,
   nextStepAfterOnlineSetup,
   onlineSetupStepFor,
@@ -48,27 +47,17 @@ export function AppWindow(): JSX.Element {
     const nextIdx = STEP_ORDER.indexOf(next)
     setDirection(nextIdx >= curIdx ? 'forward' : 'back')
     setStep(next)
+    if (next !== 'settings' && next !== 'done') {
+      window.api.setSetting('onboardingStep', next)
+      window.api.setSetting('onboardingSelectedGames', selectedGames)
+      window.api.setSetting('onboardingImportedOnline', importedOnline)
+    }
   }
 
-  /** Switch the active poeVersion mid-onboarding and rebuild the flat
-   *  filterDir/filterPath/league fields from the target version's mirror keys.
-   *  Without this, FilterPicker on the second game would show the first game's
-   *  values until the user changed them.
-   *
-   *  Order matters: `poeVersion` MUST be written first so the mirror logic in
-   *  applySetting() writes the subsequent filterDir/filterPath/league updates
-   *  into the target version's mirror keys. Writing in the other order would
-   *  overwrite the *outgoing* version's saved values with the incoming game's. */
-  const switchOnboardingGame = (target: 1 | 2): void => {
+  const switchOnboardingGame = async (target: 1 | 2): Promise<void> => {
     if (!settings) return
-    const dir = target === 2 ? settings.filterDirPoe2 : settings.filterDirPoe1
-    const path = target === 2 ? settings.filterPathPoe2 : settings.filterPathPoe1
-    const league = target === 2 ? settings.leaguePoe2 : settings.leaguePoe1
-    window.api.setSetting('poeVersion', target)
-    window.api.setSetting('filterDir', dir)
-    window.api.setSetting('filterPath', path)
-    window.api.setSetting('league', league)
-    setSettings({ ...settings, poeVersion: target, filterDir: dir, filterPath: path, league })
+    await window.api.setSetting('poeVersion', target)
+    setSettings(await window.api.getSettings())
   }
 
   useEffect(() => {
@@ -78,7 +67,13 @@ export function AppWindow(): JSX.Element {
   useEffect(() => {
     window.api.getSettings().then((s) => {
       setSettings(s)
-      if (hasConfiguredProfile(s)) goTo('settings')
+      if (s.onboardingCompleted) {
+        goTo('settings')
+      } else if (s.onboardingStep) {
+        setStep(s.onboardingStep as Step)
+        if (s.onboardingSelectedGames) setSelectedGames(s.onboardingSelectedGames)
+        if (s.onboardingImportedOnline) setImportedOnline(s.onboardingImportedOnline)
+      }
     })
     // Re-fetch leagues each time the app window mounts. The cooldown gate in
     // refreshLeagues short-circuits the network call when the launch-time
@@ -98,7 +93,7 @@ export function AppWindow(): JSX.Element {
 
   useEffect(() => {
     const onFocus = (): void => {
-      if (settings && hasConfiguredProfile(settings) && step !== 'settings' && !revisitingOnboarding) goTo('settings')
+      if (settings?.onboardingCompleted && step !== 'settings' && !revisitingOnboarding) goTo('settings')
     }
     window.addEventListener('focus', onFocus)
     return () => window.removeEventListener('focus', onFocus)
@@ -112,8 +107,8 @@ export function AppWindow(): JSX.Element {
 
   if (!settings) return <div />
 
-  const showExit = hasConfiguredProfile(settings)
-  const onExitSetup = (): void => {
+  const showBackToSettings = revisitingOnboarding
+  const onBackToSettings = (): void => {
     setRevisitingOnboarding(false)
     goTo('settings')
   }
@@ -123,9 +118,14 @@ export function AppWindow(): JSX.Element {
   const orderedGames = selectedGameOrder(selectedGames)
   const showGameLabel = orderedGames.length === 2
 
-  const startFilterFlowFor = (game: 1 | 2): void => {
-    switchOnboardingGame(game)
+  const startFilterFlowFor = async (game: 1 | 2): Promise<void> => {
+    await switchOnboardingGame(game)
     goTo(filterFolderStepFor(game))
+  }
+
+  const switchGameThenGoTo = async (game: 1 | 2, next: Step): Promise<void> => {
+    await switchOnboardingGame(game)
+    goTo(next)
   }
 
   return (
@@ -157,8 +157,10 @@ export function AppWindow(): JSX.Element {
               <WelcomeStep
                 selectedGames={selectedGames}
                 onSelectedGamesChange={setSelectedGames}
-                onNext={() => startFilterFlowFor(orderedGames[0] ?? 1)}
-                onExitSetup={showExit ? onExitSetup : undefined}
+                onNext={() => {
+                  void startFilterFlowFor(orderedGames[0] ?? 1)
+                }}
+                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -181,13 +183,16 @@ export function AppWindow(): JSX.Element {
                       onNext={() => goTo(filterStep)}
                       onBack={() => {
                         const back = backStepFromFilterFolder(game, selectedGames, importedOnline)
-                        if (game === 2 && selectedGames.poe1) switchOnboardingGame(1)
+                        if (game === 2 && selectedGames.poe1) {
+                          void switchGameThenGoTo(1, back)
+                          return
+                        }
                         goTo(back)
                       }}
                       game={showGameLabel ? game : null}
                       stepNum={filterStepNum(selectedGames, game, 'folder')}
                       totalSteps={total}
-                      onExitSetup={showExit ? onExitSetup : undefined}
+                      onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
                     />
                   </SlideIn>
                 )}
@@ -198,7 +203,10 @@ export function AppWindow(): JSX.Element {
                       onSettingsChange={setSettings}
                       onNext={() => {
                         const next = nextStepAfterFilter(game, selectedGames, importedOnline)
-                        if (next === 'filter-folder-poe2') switchOnboardingGame(2)
+                        if (next === 'filter-folder-poe2') {
+                          void switchGameThenGoTo(2, next)
+                          return
+                        }
                         goTo(next)
                       }}
                       onBack={() => goTo(folderStep)}
@@ -206,7 +214,7 @@ export function AppWindow(): JSX.Element {
                       game={showGameLabel ? game : null}
                       stepNum={filterStepNum(selectedGames, game, 'filter')}
                       totalSteps={total}
-                      onExitSetup={showExit ? onExitSetup : undefined}
+                      onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
                     />
                   </SlideIn>
                 )}
@@ -216,7 +224,10 @@ export function AppWindow(): JSX.Element {
                       filterName={importedName}
                       onNext={() => {
                         const next = nextStepAfterOnlineSetup(game, selectedGames)
-                        if (next === 'filter-folder-poe2') switchOnboardingGame(2)
+                        if (next === 'filter-folder-poe2') {
+                          void switchGameThenGoTo(2, next)
+                          return
+                        }
                         goTo(next)
                       }}
                       onBack={() => {
@@ -225,7 +236,7 @@ export function AppWindow(): JSX.Element {
                       }}
                       stepNum={filterStepNum(selectedGames, game, 'filter') + 1}
                       totalSteps={total + 1}
-                      onExitSetup={showExit ? onExitSetup : undefined}
+                      onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
                     />
                   </SlideIn>
                 )}
@@ -242,7 +253,7 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo(backStepFromHotkey(selectedGames, importedOnline))}
                 stepNum={sharedBase + 1}
                 totalSteps={total}
-                onExitSetup={showExit ? onExitSetup : undefined}
+                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -255,7 +266,7 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo('hotkey')}
                 stepNum={sharedBase + 2}
                 totalSteps={total}
-                onExitSetup={showExit ? onExitSetup : undefined}
+                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -266,7 +277,7 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo('pricecheck-hotkey')}
                 stepNum={sharedBase + 3}
                 totalSteps={total}
-                onExitSetup={showExit ? onExitSetup : undefined}
+                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -280,7 +291,7 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo('trade-login')}
                 stepNum={sharedBase + 4}
                 totalSteps={total}
-                onExitSetup={showExit ? onExitSetup : undefined}
+                onBackToSettings={showBackToSettings ? onBackToSettings : undefined}
               />
             </SlideIn>
           )}
@@ -288,7 +299,8 @@ export function AppWindow(): JSX.Element {
             <SlideIn stepKey="done" direction={direction}>
               <DoneStep
                 onFinish={() => {
-                  window.api.finishOnboarding()
+                  window.api.setSetting('onboardingCompleted', true)
+                  window.api.setSetting('onboardingStep', '')
                   setRevisitingOnboarding(false)
                   goTo('settings')
                 }}

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -7,6 +7,7 @@ import {
   filterFolderStepFor,
   filterStepFor,
   filterStepNum,
+  hasConfiguredProfile,
   nextStepAfterFilter,
   nextStepAfterOnlineSetup,
   onlineSetupStepFor,
@@ -77,7 +78,7 @@ export function AppWindow(): JSX.Element {
   useEffect(() => {
     window.api.getSettings().then((s) => {
       setSettings(s)
-      if (s.filterPath) goTo('settings')
+      if (hasConfiguredProfile(s)) goTo('settings')
     })
     // Re-fetch leagues each time the app window mounts. The cooldown gate in
     // refreshLeagues short-circuits the network call when the launch-time
@@ -97,7 +98,7 @@ export function AppWindow(): JSX.Element {
 
   useEffect(() => {
     const onFocus = (): void => {
-      if (settings?.filterPath && step !== 'settings' && !revisitingOnboarding) goTo('settings')
+      if (settings && hasConfiguredProfile(settings) && step !== 'settings' && !revisitingOnboarding) goTo('settings')
     }
     window.addEventListener('focus', onFocus)
     return () => window.removeEventListener('focus', onFocus)
@@ -110,6 +111,12 @@ export function AppWindow(): JSX.Element {
   }
 
   if (!settings) return <div />
+
+  const showExit = hasConfiguredProfile(settings)
+  const onExitSetup = (): void => {
+    setRevisitingOnboarding(false)
+    goTo('settings')
+  }
 
   const total = totalOnboardingSteps(selectedGames)
   const sharedBase = sharedStepBase(selectedGames)
@@ -151,6 +158,7 @@ export function AppWindow(): JSX.Element {
                 selectedGames={selectedGames}
                 onSelectedGamesChange={setSelectedGames}
                 onNext={() => startFilterFlowFor(orderedGames[0] ?? 1)}
+                onExitSetup={showExit ? onExitSetup : undefined}
               />
             </SlideIn>
           )}
@@ -179,6 +187,7 @@ export function AppWindow(): JSX.Element {
                       game={showGameLabel ? game : null}
                       stepNum={filterStepNum(selectedGames, game, 'folder')}
                       totalSteps={total}
+                      onExitSetup={showExit ? onExitSetup : undefined}
                     />
                   </SlideIn>
                 )}
@@ -197,6 +206,7 @@ export function AppWindow(): JSX.Element {
                       game={showGameLabel ? game : null}
                       stepNum={filterStepNum(selectedGames, game, 'filter')}
                       totalSteps={total}
+                      onExitSetup={showExit ? onExitSetup : undefined}
                     />
                   </SlideIn>
                 )}
@@ -215,6 +225,7 @@ export function AppWindow(): JSX.Element {
                       }}
                       stepNum={filterStepNum(selectedGames, game, 'filter') + 1}
                       totalSteps={total + 1}
+                      onExitSetup={showExit ? onExitSetup : undefined}
                     />
                   </SlideIn>
                 )}
@@ -231,6 +242,7 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo(backStepFromHotkey(selectedGames, importedOnline))}
                 stepNum={sharedBase + 1}
                 totalSteps={total}
+                onExitSetup={showExit ? onExitSetup : undefined}
               />
             </SlideIn>
           )}
@@ -243,6 +255,7 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo('hotkey')}
                 stepNum={sharedBase + 2}
                 totalSteps={total}
+                onExitSetup={showExit ? onExitSetup : undefined}
               />
             </SlideIn>
           )}
@@ -253,6 +266,7 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo('pricecheck-hotkey')}
                 stepNum={sharedBase + 3}
                 totalSteps={total}
+                onExitSetup={showExit ? onExitSetup : undefined}
               />
             </SlideIn>
           )}
@@ -266,6 +280,7 @@ export function AppWindow(): JSX.Element {
                 onBack={() => goTo('trade-login')}
                 stepNum={sharedBase + 4}
                 totalSteps={total}
+                onExitSetup={showExit ? onExitSetup : undefined}
               />
             </SlideIn>
           )}

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -106,6 +106,10 @@ export function AppWindow(): JSX.Element {
     setSettings({ ...settings, [key]: value })
   }
 
+  const updateProfileSettingForGame = async (game: 1 | 2, key: 'league', value: unknown): Promise<void> => {
+    setSettings(await window.api.setProfileSettingForGame(game, key, value))
+  }
+
   if (!settings) return <div />
 
   const showBackToSettings = revisitingOnboarding
@@ -324,6 +328,7 @@ export function AppWindow(): JSX.Element {
                 settings={settings}
                 selectedGames={selectedGames}
                 onUpdate={updateSetting}
+                onProfileUpdateForGame={updateProfileSettingForGame}
                 onNext={() => goTo('done')}
                 onBack={() => goTo('trade-login')}
                 stepNum={sharedBase + 4}

--- a/src/renderer/src/app-window/AppSettingsWrapper.tsx
+++ b/src/renderer/src/app-window/AppSettingsWrapper.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import type { AppSettings } from '../../../shared/types'
+import type { RuntimeSettings } from '../../../shared/types'
 import { OnlineFilterModal } from '../components/OnlineFilterModal'
 import { SettingsPanel } from '../components/SettingsPanel'
 
@@ -8,8 +8,8 @@ export function AppSettingsWrapper({
   onSettingsChange,
   onManageProfiles,
 }: {
-  settings: AppSettings
-  onSettingsChange: (s: AppSettings) => void
+  settings: RuntimeSettings
+  onSettingsChange: (s: RuntimeSettings) => void
   onManageProfiles: () => void
 }): JSX.Element {
   const [onlineImportName, setOnlineImportName] = useState<string | null>(null)

--- a/src/renderer/src/app-window/AppSettingsWrapper.tsx
+++ b/src/renderer/src/app-window/AppSettingsWrapper.tsx
@@ -6,11 +6,11 @@ import { SettingsPanel } from '../components/SettingsPanel'
 export function AppSettingsWrapper({
   settings,
   onSettingsChange,
-  onShowOnboarding,
+  onManageProfiles,
 }: {
   settings: AppSettings
   onSettingsChange: (s: AppSettings) => void
-  onShowOnboarding: () => void
+  onManageProfiles: () => void
 }): JSX.Element {
   const [onlineImportName, setOnlineImportName] = useState<string | null>(null)
 
@@ -20,7 +20,7 @@ export function AppSettingsWrapper({
         settings={settings}
         onSettingsChange={onSettingsChange}
         mode="app"
-        onShowOnboarding={onShowOnboarding}
+        onManageProfiles={onManageProfiles}
         onOnlineImport={setOnlineImportName}
       />
       {onlineImportName && (

--- a/src/renderer/src/app-window/AppSettingsWrapper.tsx
+++ b/src/renderer/src/app-window/AppSettingsWrapper.tsx
@@ -7,10 +7,12 @@ export function AppSettingsWrapper({
   settings,
   onSettingsChange,
   onManageProfiles,
+  tabRequest,
 }: {
   settings: RuntimeSettings
   onSettingsChange: (s: RuntimeSettings) => void
   onManageProfiles: () => void
+  tabRequest?: { tab: string; n: number } | null
 }): JSX.Element {
   const [onlineImportName, setOnlineImportName] = useState<string | null>(null)
 
@@ -22,6 +24,7 @@ export function AppSettingsWrapper({
         mode="app"
         onManageProfiles={onManageProfiles}
         onOnlineImport={setOnlineImportName}
+        tabRequest={tabRequest}
       />
       {onlineImportName && (
         <OnlineFilterModal filterName={onlineImportName} onDismiss={() => setOnlineImportName(null)} />

--- a/src/renderer/src/app-window/AppSettingsWrapper.tsx
+++ b/src/renderer/src/app-window/AppSettingsWrapper.tsx
@@ -1,17 +1,17 @@
 import { useState } from 'react'
-import type { RuntimeSettings } from '../../../shared/types'
+import type { PoeProfileSummary, RuntimeSettings } from '../../../shared/types'
 import { OnlineFilterModal } from '../components/OnlineFilterModal'
 import { SettingsPanel } from '../components/SettingsPanel'
 
 export function AppSettingsWrapper({
   settings,
   onSettingsChange,
-  onManageProfiles,
+  onEditProfile,
   tabRequest,
 }: {
   settings: RuntimeSettings
   onSettingsChange: (s: RuntimeSettings) => void
-  onManageProfiles: () => void
+  onEditProfile: (profile: PoeProfileSummary) => void
   tabRequest?: { tab: string; n: number } | null
 }): JSX.Element {
   const [onlineImportName, setOnlineImportName] = useState<string | null>(null)
@@ -22,7 +22,7 @@ export function AppSettingsWrapper({
         settings={settings}
         onSettingsChange={onSettingsChange}
         mode="app"
-        onManageProfiles={onManageProfiles}
+        onEditProfile={onEditProfile}
         onOnlineImport={setOnlineImportName}
         tabRequest={tabRequest}
       />

--- a/src/renderer/src/app-window/NavButtons.tsx
+++ b/src/renderer/src/app-window/NavButtons.tsx
@@ -3,12 +3,16 @@ export function NavButtons({
   onNext,
   nextLabel,
   nextDisabled,
+  secondaryLabel,
+  onSecondary,
   onBackToSettings,
 }: {
   onBack?: () => void
   onNext: () => void
   nextLabel?: string
   nextDisabled?: boolean
+  secondaryLabel?: string
+  onSecondary?: () => void
   onBackToSettings?: () => void
 }): JSX.Element {
   return (
@@ -22,6 +26,11 @@ export function NavButtons({
       {onBack && (
         <button onClick={onBack} className="px-5 py-[10px] text-[13px]">
           Back
+        </button>
+      )}
+      {onSecondary && (
+        <button onClick={onSecondary} className="px-5 py-[10px] text-[13px]">
+          {secondaryLabel ?? 'Skip'}
         </button>
       )}
       <button

--- a/src/renderer/src/app-window/NavButtons.tsx
+++ b/src/renderer/src/app-window/NavButtons.tsx
@@ -3,14 +3,22 @@ export function NavButtons({
   onNext,
   nextLabel,
   nextDisabled,
+  onExitSetup,
 }: {
   onBack?: () => void
   onNext: () => void
   nextLabel?: string
   nextDisabled?: boolean
+  onExitSetup?: () => void
 }): JSX.Element {
   return (
     <div className="flex gap-[10px] mt-8">
+      {onExitSetup && (
+        <button onClick={onExitSetup} className="px-5 py-[10px] text-[12px] text-text-dim">
+          Exit Setup
+        </button>
+      )}
+      <div className="flex-1" />
       {onBack && (
         <button onClick={onBack} className="px-5 py-[10px] text-[13px]">
           Back

--- a/src/renderer/src/app-window/NavButtons.tsx
+++ b/src/renderer/src/app-window/NavButtons.tsx
@@ -3,19 +3,19 @@ export function NavButtons({
   onNext,
   nextLabel,
   nextDisabled,
-  onExitSetup,
+  onBackToSettings,
 }: {
   onBack?: () => void
   onNext: () => void
   nextLabel?: string
   nextDisabled?: boolean
-  onExitSetup?: () => void
+  onBackToSettings?: () => void
 }): JSX.Element {
   return (
     <div className="flex gap-[10px] mt-8">
-      {onExitSetup && (
-        <button onClick={onExitSetup} className="px-5 py-[10px] text-[12px] text-text-dim">
-          Exit Setup
+      {onBackToSettings && (
+        <button onClick={onBackToSettings} className="px-5 py-[10px] text-[12px] text-text-dim">
+          Back to Settings
         </button>
       )}
       <div className="flex-1" />

--- a/src/renderer/src/app-window/ProfileManagerStep.tsx
+++ b/src/renderer/src/app-window/ProfileManagerStep.tsx
@@ -46,7 +46,28 @@ export function ProfileManagerStep({
 
   const activate = async (profile: PoeProfileSummary): Promise<void> => {
     setError(null)
-    onSettingsChange(await window.api.setActiveProfile(profile.id))
+    const result = await window.api.setActiveProfile(profile.id)
+    if (!result.ok && 'requiresRestart' in result) {
+      const confirmed = window.confirm(
+        `Switching to a PoE${result.targetGame} profile requires restarting Scalpel so the overlay can attach to the correct game. Restart now?`,
+      )
+      if (!confirmed) return
+      const restartResult = await window.api.setActiveProfile(profile.id, true)
+      if (!restartResult.ok) {
+        setError('Could not switch profile.')
+        return
+      }
+      if ('devRestartRequired' in restartResult) {
+        setError('Profile selected. Restart the dev app to attach to the selected game.')
+      }
+      return
+    }
+    if (!result.ok) {
+      setError(result.error)
+      return
+    }
+    if (!('settings' in result)) return
+    onSettingsChange(result.settings)
     setSwitchedFilterName(inGameFilterName(profile))
     await reloadProfiles()
   }
@@ -159,43 +180,46 @@ export function ProfileManagerStep({
               {matching.length === 0 ? (
                 <p className="text-[11px] text-text-dim m-0">No profiles yet.</p>
               ) : (
-                matching.map((profile) => (
-                  <div
-                    key={profile.id}
-                    className="rounded border border-border bg-black/20 px-3 py-2 flex flex-col gap-2"
-                  >
-                    <div className="flex items-start gap-2">
-                      <div className="flex-1 min-w-0">
-                        <div className="text-[13px] font-semibold text-text truncate">{profile.name}</div>
-                        <div className="text-[11px] text-text-dim truncate">
-                          {profile.league || 'No league'} - {filterName(profile)}
+                matching.map((profile) => {
+                  const needsRestart = profile.gameVariant !== settings.poeVersion
+                  return (
+                    <div
+                      key={profile.id}
+                      className="rounded border border-border bg-black/20 px-3 py-2 flex flex-col gap-2"
+                    >
+                      <div className="flex items-start gap-2">
+                        <div className="flex-1 min-w-0">
+                          <div className="text-[13px] font-semibold text-text truncate">{profile.name}</div>
+                          <div className="text-[11px] text-text-dim truncate">
+                            {profile.league || 'No league'} - {filterName(profile)}
+                          </div>
                         </div>
+                        {profile.id === settings.activeProfileId && (
+                          <span className="text-[10px] text-accent font-semibold shrink-0">Active</span>
+                        )}
                       </div>
-                      {profile.id === settings.activeProfileId && (
-                        <span className="text-[10px] text-accent font-semibold shrink-0">Active</span>
-                      )}
-                    </div>
-                    <div className="flex flex-wrap gap-1.5">
-                      {profile.id !== settings.activeProfileId && (
-                        <button className="primary text-[11px] px-3 py-1.5" onClick={() => void activate(profile)}>
-                          Switch
+                      <div className="flex flex-wrap gap-1.5">
+                        {profile.id !== settings.activeProfileId && (
+                          <button className="primary text-[11px] px-3 py-1.5" onClick={() => void activate(profile)}>
+                            {needsRestart ? 'Restart to Switch' : 'Switch'}
+                          </button>
+                        )}
+                        <button className="text-[11px] px-3 py-1.5" onClick={() => onEditProfile(profile)}>
+                          {needsRestart ? 'Restart to Edit' : 'Edit'}
                         </button>
-                      )}
-                      <button className="text-[11px] px-3 py-1.5" onClick={() => onEditProfile(profile)}>
-                        Edit
-                      </button>
-                      <button className="text-[11px] px-3 py-1.5" onClick={() => void duplicate(profile)}>
-                        Duplicate
-                      </button>
-                      <button className="text-[11px] px-3 py-1.5" onClick={() => void rename(profile)}>
-                        Rename
-                      </button>
-                      <button className="text-[11px] px-3 py-1.5 text-text-dim" onClick={() => void remove(profile)}>
-                        Delete
-                      </button>
+                        <button className="text-[11px] px-3 py-1.5" onClick={() => void duplicate(profile)}>
+                          Duplicate
+                        </button>
+                        <button className="text-[11px] px-3 py-1.5" onClick={() => void rename(profile)}>
+                          Rename
+                        </button>
+                        <button className="text-[11px] px-3 py-1.5 text-text-dim" onClick={() => void remove(profile)}>
+                          Delete
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                ))
+                  )
+                })
               )}
             </section>
           )

--- a/src/renderer/src/app-window/ProfileManagerStep.tsx
+++ b/src/renderer/src/app-window/ProfileManagerStep.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import type { AppSettings, GameVariant, PoeProfileSummary } from '../../../shared/types'
+import type { GameVariant, PoeProfileSummary, RuntimeSettings } from '../../../shared/types'
 import { DismissibleTip } from '../shared/DismissibleTip'
 import { StepHeader } from './StepHeader'
 
@@ -22,8 +22,8 @@ export function ProfileManagerStep({
   onEditProfile,
   onFinish,
 }: {
-  settings: AppSettings
-  onSettingsChange: (settings: AppSettings) => void
+  settings: RuntimeSettings
+  onSettingsChange: (settings: RuntimeSettings) => void
   onEditProfile: (profile: PoeProfileSummary) => void
   onFinish: () => void
 }): JSX.Element {

--- a/src/renderer/src/app-window/ProfileManagerStep.tsx
+++ b/src/renderer/src/app-window/ProfileManagerStep.tsx
@@ -32,6 +32,7 @@ export function ProfileManagerStep({
   const [draft, setDraft] = useState<
     | { kind: 'create'; gameVariant: GameVariant; name: string }
     | { kind: 'duplicate'; sourceId: string; name: string }
+    | { kind: 'rename'; sourceId: string; name: string }
     | null
   >(null)
   const [error, setError] = useState<string | null>(null)
@@ -56,6 +57,11 @@ export function ProfileManagerStep({
       if (!restartResult.ok) {
         setError('Could not switch profile.')
         return
+      }
+      if ('settings' in restartResult) {
+        onSettingsChange(restartResult.settings)
+        setSwitchedFilterName(inGameFilterName(profile))
+        await reloadProfiles()
       }
       if ('devRestartRequired' in restartResult) {
         setError('Profile selected. Restart the dev app to attach to the selected game.')
@@ -83,8 +89,10 @@ export function ProfileManagerStep({
     try {
       if (draft.kind === 'create') {
         await window.api.createProfile({ name, gameVariant: draft.gameVariant })
-      } else {
+      } else if (draft.kind === 'duplicate') {
         await window.api.duplicateProfile(draft.sourceId, name)
+      } else {
+        await window.api.renameProfile(draft.sourceId, name)
       }
       setDraft(null)
       await reloadProfiles()
@@ -94,11 +102,8 @@ export function ProfileManagerStep({
   }
 
   const rename = async (profile: PoeProfileSummary): Promise<void> => {
-    const name = window.prompt('Profile name', profile.name)?.trim()
-    if (!name || name === profile.name) return
+    setDraft({ kind: 'rename', sourceId: profile.id, name: profile.name })
     setError(null)
-    await window.api.renameProfile(profile.id, name)
-    await reloadProfiles()
   }
 
   const duplicate = async (profile: PoeProfileSummary): Promise<void> => {
@@ -137,7 +142,11 @@ export function ProfileManagerStep({
         {draft && (
           <section className="rounded border border-border bg-black/20 px-3 py-3 flex flex-col gap-3">
             <label className="text-[11px] text-text-dim">
-              {draft.kind === 'create' ? 'New profile name' : 'Duplicate profile name'}
+              {draft.kind === 'create'
+                ? 'New profile name'
+                : draft.kind === 'duplicate'
+                  ? 'Duplicate profile name'
+                  : 'Rename profile'}
             </label>
             <input
               value={draft.name}

--- a/src/renderer/src/app-window/ProfileManagerStep.tsx
+++ b/src/renderer/src/app-window/ProfileManagerStep.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useState } from 'react'
 import type { AppSettings, GameVariant, PoeProfileSummary } from '../../../shared/types'
+import { DismissibleTip } from '../shared/DismissibleTip'
 import { StepHeader } from './StepHeader'
 
 function filterName(profile: PoeProfileSummary): string {
   return profile.filterPath ? profile.filterPath.replace(/^.*[\\/]/, '') : 'No filter selected'
+}
+
+function inGameFilterName(profile: PoeProfileSummary): string | null {
+  if (!profile.filterPath) return null
+  return profile.filterPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
 }
 
 function defaultProfileName(variant: GameVariant): string {
@@ -22,6 +28,7 @@ export function ProfileManagerStep({
   onFinish: () => void
 }): JSX.Element {
   const [profiles, setProfiles] = useState<PoeProfileSummary[]>([])
+  const [switchedFilterName, setSwitchedFilterName] = useState<string | null>(null)
   const [draft, setDraft] = useState<
     | { kind: 'create'; gameVariant: GameVariant; name: string }
     | { kind: 'duplicate'; sourceId: string; name: string }
@@ -40,6 +47,7 @@ export function ProfileManagerStep({
   const activate = async (profile: PoeProfileSummary): Promise<void> => {
     setError(null)
     onSettingsChange(await window.api.setActiveProfile(profile.id))
+    setSwitchedFilterName(inGameFilterName(profile))
     await reloadProfiles()
   }
 
@@ -98,6 +106,13 @@ export function ProfileManagerStep({
       />
 
       <div className="flex flex-col gap-5">
+        {switchedFilterName && (
+          <DismissibleTip id="profile-manager.itemfilter-command">
+            Update Path of Exile after switching profiles: type{' '}
+            <code className="font-mono text-[11px] text-text">/itemfilter {switchedFilterName}</code> in chat.
+          </DismissibleTip>
+        )}
+
         {draft && (
           <section className="rounded border border-border bg-black/20 px-3 py-3 flex flex-col gap-3">
             <label className="text-[11px] text-text-dim">

--- a/src/renderer/src/app-window/ProfileManagerStep.tsx
+++ b/src/renderer/src/app-window/ProfileManagerStep.tsx
@@ -60,11 +60,11 @@ export function ProfileManagerStep({
     }
     setError(null)
     try {
-      const profile =
-        draft.kind === 'create'
-          ? await window.api.createProfile({ name, gameVariant: draft.gameVariant })
-          : await window.api.duplicateProfile(draft.sourceId, name)
-      onSettingsChange(await window.api.setActiveProfile(profile.id))
+      if (draft.kind === 'create') {
+        await window.api.createProfile({ name, gameVariant: draft.gameVariant })
+      } else {
+        await window.api.duplicateProfile(draft.sourceId, name)
+      }
       setDraft(null)
       await reloadProfiles()
     } catch (err) {

--- a/src/renderer/src/app-window/ProfileManagerStep.tsx
+++ b/src/renderer/src/app-window/ProfileManagerStep.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useState } from 'react'
+import type { AppSettings, GameVariant, PoeProfileSummary } from '../../../shared/types'
+import { StepHeader } from './StepHeader'
+
+function filterName(profile: PoeProfileSummary): string {
+  return profile.filterPath ? profile.filterPath.replace(/^.*[\\/]/, '') : 'No filter selected'
+}
+
+function defaultProfileName(variant: GameVariant): string {
+  return variant === 2 ? 'PoE2 profile' : 'PoE1 profile'
+}
+
+export function ProfileManagerStep({
+  settings,
+  onSettingsChange,
+  onEditProfile,
+  onFinish,
+}: {
+  settings: AppSettings
+  onSettingsChange: (settings: AppSettings) => void
+  onEditProfile: (profile: PoeProfileSummary) => void
+  onFinish: () => void
+}): JSX.Element {
+  const [profiles, setProfiles] = useState<PoeProfileSummary[]>([])
+  const [draft, setDraft] = useState<
+    | { kind: 'create'; gameVariant: GameVariant; name: string }
+    | { kind: 'duplicate'; sourceId: string; name: string }
+    | null
+  >(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const reloadProfiles = async (): Promise<void> => {
+    setProfiles(await window.api.listProfiles())
+  }
+
+  useEffect(() => {
+    void reloadProfiles()
+  }, [])
+
+  const activate = async (profile: PoeProfileSummary): Promise<void> => {
+    setError(null)
+    onSettingsChange(await window.api.setActiveProfile(profile.id))
+    await reloadProfiles()
+  }
+
+  const submitDraft = async (): Promise<void> => {
+    if (!draft) return
+    const name = draft.name.trim()
+    if (!name) {
+      setError('Profile name is required.')
+      return
+    }
+    setError(null)
+    try {
+      const profile =
+        draft.kind === 'create'
+          ? await window.api.createProfile({ name, gameVariant: draft.gameVariant })
+          : await window.api.duplicateProfile(draft.sourceId, name)
+      onSettingsChange(await window.api.setActiveProfile(profile.id))
+      setDraft(null)
+      await reloadProfiles()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not save profile.')
+    }
+  }
+
+  const rename = async (profile: PoeProfileSummary): Promise<void> => {
+    const name = window.prompt('Profile name', profile.name)?.trim()
+    if (!name || name === profile.name) return
+    setError(null)
+    await window.api.renameProfile(profile.id, name)
+    await reloadProfiles()
+  }
+
+  const duplicate = async (profile: PoeProfileSummary): Promise<void> => {
+    setDraft({ kind: 'duplicate', sourceId: profile.id, name: `${profile.name} copy` })
+    setError(null)
+  }
+
+  const remove = async (profile: PoeProfileSummary): Promise<void> => {
+    if (!window.confirm(`Delete "${profile.name}"?`)) return
+    setError(null)
+    await window.api.deleteProfile(profile.id)
+    onSettingsChange(await window.api.getSettings())
+    await reloadProfiles()
+  }
+
+  const groups: Array<{ variant: GameVariant; label: string }> = [
+    { variant: 1, label: 'Path of Exile 1' },
+    { variant: 2, label: 'Path of Exile 2' },
+  ]
+
+  return (
+    <div>
+      <StepHeader
+        title="Manage Profiles"
+        subtitle="Create a named setup for each league, character, or filter context you want to switch back to later."
+      />
+
+      <div className="flex flex-col gap-5">
+        {draft && (
+          <section className="rounded border border-border bg-black/20 px-3 py-3 flex flex-col gap-3">
+            <label className="text-[11px] text-text-dim">
+              {draft.kind === 'create' ? 'New profile name' : 'Duplicate profile name'}
+            </label>
+            <input
+              value={draft.name}
+              onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void submitDraft()
+                if (e.key === 'Escape') setDraft(null)
+              }}
+              className="w-full text-[12px] bg-black/30 rounded px-2 py-[7px] border-none text-text"
+              autoFocus
+            />
+            {error && <p className="text-[11px] text-red-300 m-0">{error}</p>}
+            <div className="flex gap-2 justify-end">
+              <button className="text-[11px] px-3 py-1.5" onClick={() => setDraft(null)}>
+                Cancel
+              </button>
+              <button className="primary text-[11px] px-3 py-1.5" onClick={() => void submitDraft()}>
+                Save
+              </button>
+            </div>
+          </section>
+        )}
+
+        {groups.map(({ variant, label }) => {
+          const matching = profiles.filter((profile) => profile.gameVariant === variant)
+          return (
+            <section key={variant} className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <div className="settings-section-title mt-0 flex-1">{label}</div>
+                <button
+                  className="text-[11px] px-3 py-1.5"
+                  onClick={() => {
+                    setDraft({ kind: 'create', gameVariant: variant, name: defaultProfileName(variant) })
+                    setError(null)
+                  }}
+                >
+                  New
+                </button>
+              </div>
+              {matching.length === 0 ? (
+                <p className="text-[11px] text-text-dim m-0">No profiles yet.</p>
+              ) : (
+                matching.map((profile) => (
+                  <div
+                    key={profile.id}
+                    className="rounded border border-border bg-black/20 px-3 py-2 flex flex-col gap-2"
+                  >
+                    <div className="flex items-start gap-2">
+                      <div className="flex-1 min-w-0">
+                        <div className="text-[13px] font-semibold text-text truncate">{profile.name}</div>
+                        <div className="text-[11px] text-text-dim truncate">
+                          {profile.league || 'No league'} - {filterName(profile)}
+                        </div>
+                      </div>
+                      {profile.id === settings.activeProfileId && (
+                        <span className="text-[10px] text-accent font-semibold shrink-0">Active</span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {profile.id !== settings.activeProfileId && (
+                        <button className="primary text-[11px] px-3 py-1.5" onClick={() => void activate(profile)}>
+                          Switch
+                        </button>
+                      )}
+                      <button className="text-[11px] px-3 py-1.5" onClick={() => onEditProfile(profile)}>
+                        Edit
+                      </button>
+                      <button className="text-[11px] px-3 py-1.5" onClick={() => void duplicate(profile)}>
+                        Duplicate
+                      </button>
+                      <button className="text-[11px] px-3 py-1.5" onClick={() => void rename(profile)}>
+                        Rename
+                      </button>
+                      <button className="text-[11px] px-3 py-1.5 text-text-dim" onClick={() => void remove(profile)}>
+                        Delete
+                      </button>
+                    </div>
+                  </div>
+                ))
+              )}
+            </section>
+          )
+        })}
+      </div>
+
+      <div className="flex gap-[10px] mt-8">
+        <div className="flex-1" />
+        <button className="primary px-6 py-[10px] text-[13px] font-semibold" onClick={onFinish}>
+          Finish
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/app-window/constants.ts
+++ b/src/renderer/src/app-window/constants.ts
@@ -1,4 +1,5 @@
 export type Step =
+  | 'profiles'
   | 'welcome'
   | 'filter-folder-poe1'
   | 'filter-poe1'
@@ -14,6 +15,7 @@ export type Step =
   | 'settings'
 
 export const STEP_ORDER: Step[] = [
+  'profiles',
   'welcome',
   'filter-folder-poe1',
   'filter-poe1',

--- a/src/renderer/src/app-window/constants.ts
+++ b/src/renderer/src/app-window/constants.ts
@@ -1,5 +1,4 @@
 export type Step =
-  | 'profiles'
   | 'welcome'
   | 'filter-folder-poe1'
   | 'filter-poe1'
@@ -15,7 +14,6 @@ export type Step =
   | 'settings'
 
 export const STEP_ORDER: Step[] = [
-  'profiles',
   'welcome',
   'filter-folder-poe1',
   'filter-poe1',

--- a/src/renderer/src/app-window/onboarding-nav.test.ts
+++ b/src/renderer/src/app-window/onboarding-nav.test.ts
@@ -3,6 +3,7 @@ import {
   backStepFromFilterFolder,
   backStepFromHotkey,
   filterStepNum,
+  hasConfiguredProfile,
   nextStepAfterFilter,
   nextStepAfterOnlineSetup,
   selectedGameOrder,
@@ -99,5 +100,23 @@ describe('backStepFromHotkey', () => {
   })
   it('returns to PoE2 last step in PoE2-only flow', () => {
     expect(backStepFromHotkey(onlyPoe2, noImports)).toBe('filter-poe2')
+  })
+})
+
+describe('hasConfiguredProfile', () => {
+  it('returns false when neither per-game filter path is set', () => {
+    expect(hasConfiguredProfile({ filterPathPoe1: '', filterPathPoe2: '' })).toBe(false)
+  })
+
+  it('returns true when filterPathPoe1 is configured', () => {
+    expect(hasConfiguredProfile({ filterPathPoe1: 'C:/filters/poe1.filter', filterPathPoe2: '' })).toBe(true)
+  })
+
+  it('returns true when filterPathPoe2 is configured', () => {
+    expect(hasConfiguredProfile({ filterPathPoe1: '', filterPathPoe2: 'C:/filters/poe2.filter' })).toBe(true)
+  })
+
+  it('returns true when both are configured', () => {
+    expect(hasConfiguredProfile({ filterPathPoe1: 'C:/poe1.filter', filterPathPoe2: 'C:/poe2.filter' })).toBe(true)
   })
 })

--- a/src/renderer/src/app-window/onboarding-nav.test.ts
+++ b/src/renderer/src/app-window/onboarding-nav.test.ts
@@ -3,7 +3,6 @@ import {
   backStepFromFilterFolder,
   backStepFromHotkey,
   filterStepNum,
-  hasConfiguredProfile,
   nextStepAfterFilter,
   nextStepAfterOnlineSetup,
   selectedGameOrder,
@@ -100,23 +99,5 @@ describe('backStepFromHotkey', () => {
   })
   it('returns to PoE2 last step in PoE2-only flow', () => {
     expect(backStepFromHotkey(onlyPoe2, noImports)).toBe('filter-poe2')
-  })
-})
-
-describe('hasConfiguredProfile', () => {
-  it('returns false when neither per-game filter path is set', () => {
-    expect(hasConfiguredProfile({ filterPathPoe1: '', filterPathPoe2: '' })).toBe(false)
-  })
-
-  it('returns true when filterPathPoe1 is configured', () => {
-    expect(hasConfiguredProfile({ filterPathPoe1: 'C:/filters/poe1.filter', filterPathPoe2: '' })).toBe(true)
-  })
-
-  it('returns true when filterPathPoe2 is configured', () => {
-    expect(hasConfiguredProfile({ filterPathPoe1: '', filterPathPoe2: 'C:/filters/poe2.filter' })).toBe(true)
-  })
-
-  it('returns true when both are configured', () => {
-    expect(hasConfiguredProfile({ filterPathPoe1: 'C:/poe1.filter', filterPathPoe2: 'C:/poe2.filter' })).toBe(true)
   })
 })

--- a/src/renderer/src/app-window/onboarding-nav.ts
+++ b/src/renderer/src/app-window/onboarding-nav.ts
@@ -83,9 +83,3 @@ export function backStepFromHotkey(
   const importedKey = lastGame === 1 ? 'poe1' : 'poe2'
   return importedOnline[importedKey] ? onlineSetupStepFor(lastGame) : filterStepFor(lastGame)
 }
-
-/** Returns true when the user already has a configured PoE profile (a stored
- *  filterPathPoe1 or filterPathPoe2), allowing them to skip onboarding. */
-export function hasConfiguredProfile(settings: { filterPathPoe1: string; filterPathPoe2: string }): boolean {
-  return settings.filterPathPoe1 !== '' || settings.filterPathPoe2 !== ''
-}

--- a/src/renderer/src/app-window/onboarding-nav.ts
+++ b/src/renderer/src/app-window/onboarding-nav.ts
@@ -83,3 +83,9 @@ export function backStepFromHotkey(
   const importedKey = lastGame === 1 ? 'poe1' : 'poe2'
   return importedOnline[importedKey] ? onlineSetupStepFor(lastGame) : filterStepFor(lastGame)
 }
+
+/** Returns true when the user already has a configured PoE profile (a stored
+ *  filterPathPoe1 or filterPathPoe2), allowing them to skip onboarding. */
+export function hasConfiguredProfile(settings: { filterPathPoe1: string; filterPathPoe2: string }): boolean {
+  return settings.filterPathPoe1 !== '' || settings.filterPathPoe2 !== ''
+}

--- a/src/renderer/src/app-window/onboarding-steps.tsx
+++ b/src/renderer/src/app-window/onboarding-steps.tsx
@@ -176,7 +176,7 @@ export function FilterStep({
         stepNum={stepNum}
         totalSteps={totalSteps}
         title={prefix ? `Select your ${prefix} filter` : 'Select your filter'}
-        subtitle="Pick your starting filter. If you select an online filter, it will be resaved locally for fast editing, and you can merge in changes from your online filter whenever there are updates."
+        subtitle="Pick your starting filter, or skip this for now and add one later from settings. If you select an online filter, it will be resaved locally for fast editing."
       />
       <div className="-mt-3">
         <FilterPicker
@@ -187,7 +187,14 @@ export function FilterStep({
           maxListHeight={140}
         />
       </div>
-      <NavButtons onBack={onBack} onNext={onNext} onBackToSettings={onBackToSettings} />
+      <NavButtons
+        onBack={onBack}
+        onNext={onNext}
+        nextDisabled={!settings.filterPath}
+        secondaryLabel="Skip for now"
+        onSecondary={onNext}
+        onBackToSettings={onBackToSettings}
+      />
     </div>
   )
 }

--- a/src/renderer/src/app-window/onboarding-steps.tsx
+++ b/src/renderer/src/app-window/onboarding-steps.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useAuth } from '../shared/use-auth'
 import appIcon from '../../../../resources/icon.png'
 import { getGameFeatures } from '../../../shared/game-features'
-import type { AppSettings } from '../../../shared/types'
+import type { AppSettings, PoeProfileSummary } from '../../../shared/types'
 import poeFilterSettingImg from '../assets/other/poe-filter-setting.png'
 import poe1Logo from '../assets/other/poe1-logo.png'
 import poe2Logo from '../assets/other/poe2-logo.png'
@@ -190,7 +190,7 @@ export function FilterStep({
       <NavButtons
         onBack={onBack}
         onNext={onNext}
-        nextDisabled={!settings.filterPath}
+        nextDisabled={!settings.activeProfile?.filterPath}
         secondaryLabel="Skip for now"
         onSecondary={onNext}
         onBackToSettings={onBackToSettings}
@@ -371,6 +371,7 @@ export function PreferencesStep({
   settings,
   selectedGames,
   onUpdate,
+  onProfileUpdateForGame,
   onNext,
   onBack,
   stepNum,
@@ -380,6 +381,7 @@ export function PreferencesStep({
   settings: AppSettings
   selectedGames: SelectedGames
   onUpdate: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
+  onProfileUpdateForGame: (game: 1 | 2, key: 'league', value: string) => Promise<void>
   onNext: () => void
   onBack: () => void
   stepNum: number
@@ -387,6 +389,28 @@ export function PreferencesStep({
   onBackToSettings?: () => void
 }): JSX.Element {
   const both = selectedGames.poe1 && selectedGames.poe2
+  const [profiles, setProfiles] = useState<PoeProfileSummary[]>([])
+
+  useEffect(() => {
+    if (!both) return
+    void window.api.listProfiles().then(setProfiles)
+  }, [both, settings.activeProfileId, settings.lastProfileIdPoe1, settings.lastProfileIdPoe2])
+
+  const leagueForGame = (game: 1 | 2): string => {
+    if (!both) return settings.activeProfile?.league ?? ''
+    const lastId = game === 2 ? settings.lastProfileIdPoe2 : settings.lastProfileIdPoe1
+    return profiles.find((profile) => profile.id === lastId)?.league ?? profiles.find((profile) => profile.gameVariant === game)?.league ?? ''
+  }
+
+  const updateLeagueForGame = (game: 1 | 2, league: string): void => {
+    setProfiles((prev) =>
+      prev.map((profile) =>
+        profile.id === (game === 2 ? settings.lastProfileIdPoe2 : settings.lastProfileIdPoe1) ? { ...profile, league } : profile,
+      ),
+    )
+    void onProfileUpdateForGame(game, 'league', league).then(() => window.api.listProfiles().then(setProfiles))
+  }
+
   // Prefer the live-fetched league lists from the trade APIs; fall back to the
   // hardcoded list in shared/game-features.ts if the launch-time fetch failed.
   const poe1Leagues: readonly string[] =
@@ -407,22 +431,16 @@ export function PreferencesStep({
             <LeagueDropdown
               id="league-poe1-onboarding"
               label="PoE1 League"
-              value={settings.leaguePoe1}
+              value={leagueForGame(1)}
               options={poe1Leagues}
-              onChange={(v) => {
-                onUpdate('leaguePoe1', v)
-                if (settings.poeVersion === 1) onUpdate('league', v)
-              }}
+              onChange={(v) => updateLeagueForGame(1, v)}
             />
             <LeagueDropdown
               id="league-poe2-onboarding"
               label="PoE2 League"
-              value={settings.leaguePoe2}
+              value={leagueForGame(2)}
               options={poe2Leagues}
-              onChange={(v) => {
-                onUpdate('leaguePoe2', v)
-                if (settings.poeVersion === 2) onUpdate('league', v)
-              }}
+              onChange={(v) => updateLeagueForGame(2, v)}
             />
           </section>
         ) : (
@@ -430,9 +448,9 @@ export function PreferencesStep({
             <LeagueDropdown
               id="league-select-onboarding"
               label="League"
-              value={settings.league}
+              value={settings.activeProfile?.league ?? ''}
               options={selectedGames.poe2 ? poe2Leagues : poe1Leagues}
-              onChange={(v) => onUpdate('league', v)}
+              onChange={(v) => onProfileUpdateForGame(selectedGames.poe2 ? 2 : 1, 'league', v)}
             />
           </section>
         )}

--- a/src/renderer/src/app-window/onboarding-steps.tsx
+++ b/src/renderer/src/app-window/onboarding-steps.tsx
@@ -56,12 +56,12 @@ export function WelcomeStep({
   selectedGames,
   onSelectedGamesChange,
   onNext,
-  onExitSetup,
+  onBackToSettings,
 }: {
   selectedGames: SelectedGames
   onSelectedGamesChange: (g: SelectedGames) => void
   onNext: () => void
-  onExitSetup?: () => void
+  onBackToSettings?: () => void
 }): JSX.Element {
   const anySelected = selectedGames.poe1 || selectedGames.poe2
   return (
@@ -97,7 +97,12 @@ export function WelcomeStep({
           />
         </div>
       </div>
-      <NavButtons onNext={onNext} nextLabel="Continue" nextDisabled={!anySelected} onExitSetup={onExitSetup} />
+      <NavButtons
+        onNext={onNext}
+        nextLabel="Continue"
+        nextDisabled={!anySelected}
+        onBackToSettings={onBackToSettings}
+      />
     </div>
   )
 }
@@ -116,7 +121,7 @@ export function FilterFolderStep({
   game,
   stepNum,
   totalSteps,
-  onExitSetup,
+  onBackToSettings,
 }: {
   settings: AppSettings
   onSettingsChange: (s: AppSettings) => void
@@ -125,7 +130,7 @@ export function FilterFolderStep({
   game: 1 | 2 | null
   stepNum: number
   totalSteps: number
-  onExitSetup?: () => void
+  onBackToSettings?: () => void
 }): JSX.Element {
   const prefix = gameLabel(game)
   const folderHint = getGameFeatures(game ?? 1).filterFolderHint
@@ -138,7 +143,7 @@ export function FilterFolderStep({
         subtitle={`Choose your filter folder, generally ${folderHint}, so Scalpel can find your filters.`}
       />
       <FilterPicker settings={settings} onSettingsChange={onSettingsChange} mode="folder" />
-      <NavButtons onBack={onBack} onNext={onNext} nextDisabled={!settings.filterDir} onExitSetup={onExitSetup} />
+      <NavButtons onBack={onBack} onNext={onNext} onBackToSettings={onBackToSettings} />
     </div>
   )
 }
@@ -152,7 +157,7 @@ export function FilterStep({
   game,
   stepNum,
   totalSteps,
-  onExitSetup,
+  onBackToSettings,
 }: {
   settings: AppSettings
   onSettingsChange: (s: AppSettings) => void
@@ -162,7 +167,7 @@ export function FilterStep({
   game: 1 | 2 | null
   stepNum: number
   totalSteps: number
-  onExitSetup?: () => void
+  onBackToSettings?: () => void
 }): JSX.Element {
   const prefix = gameLabel(game)
   return (
@@ -182,7 +187,7 @@ export function FilterStep({
           maxListHeight={140}
         />
       </div>
-      <NavButtons onBack={onBack} onNext={onNext} nextDisabled={!settings.filterPath} onExitSetup={onExitSetup} />
+      <NavButtons onBack={onBack} onNext={onNext} onBackToSettings={onBackToSettings} />
     </div>
   )
 }
@@ -193,14 +198,14 @@ export function OnlineFilterSetupStep({
   onBack,
   stepNum,
   totalSteps,
-  onExitSetup,
+  onBackToSettings,
 }: {
   filterName: string
   onNext: () => void
   onBack: () => void
   stepNum?: number
   totalSteps?: number
-  onExitSetup?: () => void
+  onBackToSettings?: () => void
 }): JSX.Element {
   return (
     <div>
@@ -226,7 +231,7 @@ export function OnlineFilterSetupStep({
 
       <img src={poeFilterSettingImg} alt="PoE filter dropdown" className="mt-4 rounded border border-border w-full" />
 
-      <NavButtons onNext={onNext} onBack={onBack} nextLabel="Done" onExitSetup={onExitSetup} />
+      <NavButtons onNext={onNext} onBack={onBack} nextLabel="Done" onBackToSettings={onBackToSettings} />
     </div>
   )
 }
@@ -238,7 +243,7 @@ export function HotkeyStep({
   onBack,
   stepNum,
   totalSteps,
-  onExitSetup,
+  onBackToSettings,
 }: {
   settings: AppSettings
   onUpdate: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
@@ -246,7 +251,7 @@ export function HotkeyStep({
   onBack: () => void
   stepNum: number
   totalSteps: number
-  onExitSetup?: () => void
+  onBackToSettings?: () => void
 }): JSX.Element {
   return (
     <div>
@@ -257,7 +262,7 @@ export function HotkeyStep({
         subtitle="This key combo activates the overlay while you're in game. Hover an item and press it to analyze your filter."
       />
       <HotkeyField value={settings.hotkey} onChange={(acc) => onUpdate('hotkey', acc)} />
-      <NavButtons onBack={onBack} onNext={onNext} onExitSetup={onExitSetup} />
+      <NavButtons onBack={onBack} onNext={onNext} onBackToSettings={onBackToSettings} />
     </div>
   )
 }
@@ -269,7 +274,7 @@ export function PriceCheckHotkeyStep({
   onBack,
   stepNum,
   totalSteps,
-  onExitSetup,
+  onBackToSettings,
 }: {
   settings: AppSettings
   onUpdate: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
@@ -277,7 +282,7 @@ export function PriceCheckHotkeyStep({
   onBack: () => void
   stepNum: number
   totalSteps: number
-  onExitSetup?: () => void
+  onBackToSettings?: () => void
 }): JSX.Element {
   return (
     <div>
@@ -288,7 +293,7 @@ export function PriceCheckHotkeyStep({
         subtitle="This key combo is used to... price check items. You should know how to use this one."
       />
       <HotkeyField value={settings.priceCheckHotkey} onChange={(acc) => onUpdate('priceCheckHotkey', acc)} />
-      <NavButtons onBack={onBack} onNext={onNext} onExitSetup={onExitSetup} />
+      <NavButtons onBack={onBack} onNext={onNext} onBackToSettings={onBackToSettings} />
     </div>
   )
 }
@@ -298,13 +303,13 @@ export function TradeLoginStep({
   onBack,
   stepNum,
   totalSteps,
-  onExitSetup,
+  onBackToSettings,
 }: {
   onNext: () => void
   onBack: () => void
   stepNum: number
   totalSteps: number
-  onExitSetup?: () => void
+  onBackToSettings?: () => void
 }): JSX.Element {
   const { auth, login, logout } = useAuth()
 
@@ -349,7 +354,7 @@ export function TradeLoginStep({
         onBack={onBack}
         onNext={onNext}
         nextLabel={auth?.loggedIn ? 'Continue' : 'Skip'}
-        onExitSetup={onExitSetup}
+        onBackToSettings={onBackToSettings}
       />
     </div>
   )
@@ -363,7 +368,7 @@ export function PreferencesStep({
   onBack,
   stepNum,
   totalSteps,
-  onExitSetup,
+  onBackToSettings,
 }: {
   settings: AppSettings
   selectedGames: SelectedGames
@@ -372,7 +377,7 @@ export function PreferencesStep({
   onBack: () => void
   stepNum: number
   totalSteps: number
-  onExitSetup?: () => void
+  onBackToSettings?: () => void
 }): JSX.Element {
   const both = selectedGames.poe1 && selectedGames.poe2
   // Prefer the live-fetched league lists from the trade APIs; fall back to the
@@ -445,7 +450,7 @@ export function PreferencesStep({
           </div>
         </section>
       </div>
-      <NavButtons onBack={onBack} onNext={onNext} nextLabel="Finish" onExitSetup={onExitSetup} />
+      <NavButtons onBack={onBack} onNext={onNext} nextLabel="Finish" onBackToSettings={onBackToSettings} />
     </div>
   )
 }

--- a/src/renderer/src/app-window/onboarding-steps.tsx
+++ b/src/renderer/src/app-window/onboarding-steps.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useAuth } from '../shared/use-auth'
 import appIcon from '../../../../resources/icon.png'
 import { getGameFeatures } from '../../../shared/game-features'
-import type { AppSettings, PoeProfileSummary } from '../../../shared/types'
+import type { AppSettings, PoeProfileSummary, RuntimeSettings } from '../../../shared/types'
 import poeFilterSettingImg from '../assets/other/poe-filter-setting.png'
 import poe1Logo from '../assets/other/poe1-logo.png'
 import poe2Logo from '../assets/other/poe2-logo.png'
@@ -123,8 +123,8 @@ export function FilterFolderStep({
   totalSteps,
   onBackToSettings,
 }: {
-  settings: AppSettings
-  onSettingsChange: (s: AppSettings) => void
+  settings: RuntimeSettings
+  onSettingsChange: (s: RuntimeSettings) => void
   onNext: () => void
   onBack?: () => void
   game: 1 | 2 | null
@@ -159,8 +159,8 @@ export function FilterStep({
   totalSteps,
   onBackToSettings,
 }: {
-  settings: AppSettings
-  onSettingsChange: (s: AppSettings) => void
+  settings: RuntimeSettings
+  onSettingsChange: (s: RuntimeSettings) => void
   onNext: () => void
   onBack: () => void
   onOnlineImport?: (name: string) => void
@@ -378,7 +378,7 @@ export function PreferencesStep({
   totalSteps,
   onBackToSettings,
 }: {
-  settings: AppSettings
+  settings: RuntimeSettings
   selectedGames: SelectedGames
   onUpdate: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
   onProfileUpdateForGame: (game: 1 | 2, key: 'league', value: string) => Promise<void>
@@ -399,13 +399,19 @@ export function PreferencesStep({
   const leagueForGame = (game: 1 | 2): string => {
     if (!both) return settings.activeProfile?.league ?? ''
     const lastId = game === 2 ? settings.lastProfileIdPoe2 : settings.lastProfileIdPoe1
-    return profiles.find((profile) => profile.id === lastId)?.league ?? profiles.find((profile) => profile.gameVariant === game)?.league ?? ''
+    return (
+      profiles.find((profile) => profile.id === lastId)?.league ??
+      profiles.find((profile) => profile.gameVariant === game)?.league ??
+      ''
+    )
   }
 
   const updateLeagueForGame = (game: 1 | 2, league: string): void => {
     setProfiles((prev) =>
       prev.map((profile) =>
-        profile.id === (game === 2 ? settings.lastProfileIdPoe2 : settings.lastProfileIdPoe1) ? { ...profile, league } : profile,
+        profile.id === (game === 2 ? settings.lastProfileIdPoe2 : settings.lastProfileIdPoe1)
+          ? { ...profile, league }
+          : profile,
       ),
     )
     void onProfileUpdateForGame(game, 'league', league).then(() => window.api.listProfiles().then(setProfiles))

--- a/src/renderer/src/app-window/onboarding-steps.tsx
+++ b/src/renderer/src/app-window/onboarding-steps.tsx
@@ -56,10 +56,12 @@ export function WelcomeStep({
   selectedGames,
   onSelectedGamesChange,
   onNext,
+  onExitSetup,
 }: {
   selectedGames: SelectedGames
   onSelectedGamesChange: (g: SelectedGames) => void
   onNext: () => void
+  onExitSetup?: () => void
 }): JSX.Element {
   const anySelected = selectedGames.poe1 || selectedGames.poe2
   return (
@@ -95,7 +97,7 @@ export function WelcomeStep({
           />
         </div>
       </div>
-      <NavButtons onNext={onNext} nextLabel="Continue" nextDisabled={!anySelected} />
+      <NavButtons onNext={onNext} nextLabel="Continue" nextDisabled={!anySelected} onExitSetup={onExitSetup} />
     </div>
   )
 }
@@ -114,6 +116,7 @@ export function FilterFolderStep({
   game,
   stepNum,
   totalSteps,
+  onExitSetup,
 }: {
   settings: AppSettings
   onSettingsChange: (s: AppSettings) => void
@@ -122,6 +125,7 @@ export function FilterFolderStep({
   game: 1 | 2 | null
   stepNum: number
   totalSteps: number
+  onExitSetup?: () => void
 }): JSX.Element {
   const prefix = gameLabel(game)
   const folderHint = getGameFeatures(game ?? 1).filterFolderHint
@@ -134,7 +138,7 @@ export function FilterFolderStep({
         subtitle={`Choose your filter folder, generally ${folderHint}, so Scalpel can find your filters.`}
       />
       <FilterPicker settings={settings} onSettingsChange={onSettingsChange} mode="folder" />
-      <NavButtons onBack={onBack} onNext={onNext} nextDisabled={!settings.filterDir} />
+      <NavButtons onBack={onBack} onNext={onNext} nextDisabled={!settings.filterDir} onExitSetup={onExitSetup} />
     </div>
   )
 }
@@ -148,6 +152,7 @@ export function FilterStep({
   game,
   stepNum,
   totalSteps,
+  onExitSetup,
 }: {
   settings: AppSettings
   onSettingsChange: (s: AppSettings) => void
@@ -157,6 +162,7 @@ export function FilterStep({
   game: 1 | 2 | null
   stepNum: number
   totalSteps: number
+  onExitSetup?: () => void
 }): JSX.Element {
   const prefix = gameLabel(game)
   return (
@@ -176,7 +182,7 @@ export function FilterStep({
           maxListHeight={140}
         />
       </div>
-      <NavButtons onBack={onBack} onNext={onNext} nextDisabled={!settings.filterPath} />
+      <NavButtons onBack={onBack} onNext={onNext} nextDisabled={!settings.filterPath} onExitSetup={onExitSetup} />
     </div>
   )
 }
@@ -187,12 +193,14 @@ export function OnlineFilterSetupStep({
   onBack,
   stepNum,
   totalSteps,
+  onExitSetup,
 }: {
   filterName: string
   onNext: () => void
   onBack: () => void
   stepNum?: number
   totalSteps?: number
+  onExitSetup?: () => void
 }): JSX.Element {
   return (
     <div>
@@ -218,7 +226,7 @@ export function OnlineFilterSetupStep({
 
       <img src={poeFilterSettingImg} alt="PoE filter dropdown" className="mt-4 rounded border border-border w-full" />
 
-      <NavButtons onNext={onNext} onBack={onBack} nextLabel="Done" />
+      <NavButtons onNext={onNext} onBack={onBack} nextLabel="Done" onExitSetup={onExitSetup} />
     </div>
   )
 }
@@ -230,6 +238,7 @@ export function HotkeyStep({
   onBack,
   stepNum,
   totalSteps,
+  onExitSetup,
 }: {
   settings: AppSettings
   onUpdate: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
@@ -237,6 +246,7 @@ export function HotkeyStep({
   onBack: () => void
   stepNum: number
   totalSteps: number
+  onExitSetup?: () => void
 }): JSX.Element {
   return (
     <div>
@@ -247,7 +257,7 @@ export function HotkeyStep({
         subtitle="This key combo activates the overlay while you're in game. Hover an item and press it to analyze your filter."
       />
       <HotkeyField value={settings.hotkey} onChange={(acc) => onUpdate('hotkey', acc)} />
-      <NavButtons onBack={onBack} onNext={onNext} />
+      <NavButtons onBack={onBack} onNext={onNext} onExitSetup={onExitSetup} />
     </div>
   )
 }
@@ -259,6 +269,7 @@ export function PriceCheckHotkeyStep({
   onBack,
   stepNum,
   totalSteps,
+  onExitSetup,
 }: {
   settings: AppSettings
   onUpdate: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
@@ -266,6 +277,7 @@ export function PriceCheckHotkeyStep({
   onBack: () => void
   stepNum: number
   totalSteps: number
+  onExitSetup?: () => void
 }): JSX.Element {
   return (
     <div>
@@ -276,7 +288,7 @@ export function PriceCheckHotkeyStep({
         subtitle="This key combo is used to... price check items. You should know how to use this one."
       />
       <HotkeyField value={settings.priceCheckHotkey} onChange={(acc) => onUpdate('priceCheckHotkey', acc)} />
-      <NavButtons onBack={onBack} onNext={onNext} />
+      <NavButtons onBack={onBack} onNext={onNext} onExitSetup={onExitSetup} />
     </div>
   )
 }
@@ -286,11 +298,13 @@ export function TradeLoginStep({
   onBack,
   stepNum,
   totalSteps,
+  onExitSetup,
 }: {
   onNext: () => void
   onBack: () => void
   stepNum: number
   totalSteps: number
+  onExitSetup?: () => void
 }): JSX.Element {
   const { auth, login, logout } = useAuth()
 
@@ -331,7 +345,12 @@ export function TradeLoginStep({
           </>
         )}
       </div>
-      <NavButtons onBack={onBack} onNext={onNext} nextLabel={auth?.loggedIn ? 'Continue' : 'Skip'} />
+      <NavButtons
+        onBack={onBack}
+        onNext={onNext}
+        nextLabel={auth?.loggedIn ? 'Continue' : 'Skip'}
+        onExitSetup={onExitSetup}
+      />
     </div>
   )
 }
@@ -344,6 +363,7 @@ export function PreferencesStep({
   onBack,
   stepNum,
   totalSteps,
+  onExitSetup,
 }: {
   settings: AppSettings
   selectedGames: SelectedGames
@@ -352,6 +372,7 @@ export function PreferencesStep({
   onBack: () => void
   stepNum: number
   totalSteps: number
+  onExitSetup?: () => void
 }): JSX.Element {
   const both = selectedGames.poe1 && selectedGames.poe2
   // Prefer the live-fetched league lists from the trade APIs; fall back to the
@@ -424,7 +445,7 @@ export function PreferencesStep({
           </div>
         </section>
       </div>
-      <NavButtons onBack={onBack} onNext={onNext} nextLabel="Finish" />
+      <NavButtons onBack={onBack} onNext={onNext} nextLabel="Finish" onExitSetup={onExitSetup} />
     </div>
   )
 }

--- a/src/renderer/src/cheat-sheets-grid/App.tsx
+++ b/src/renderer/src/cheat-sheets-grid/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { GridFour, GridNine, GridSixteen } from '@icon-park/react'
-import type { CheatSheetsSettings, CheatSheetCategory } from '../../../shared/types'
+import type { CheatSheetsSettings, CheatSheetCategory, RuntimeSettings } from '../../../shared/types'
 import { CHEAT_SHEET_MINIMIZED_HEIGHT, CHEAT_SHEET_MINIMIZED_SLACK } from '../../../shared/cheat-sheet-window'
 import { Chrome } from '../secondary-overlay/Chrome'
 import { useStickyZone } from '../shared/use-current-zone'
@@ -37,6 +37,7 @@ function loadThumbSize(): ThumbSize {
 export function App(): JSX.Element {
   const [settings, setSettings] = useState<CheatSheetsSettings | null>(null)
   const [activeCategoryId, setActiveCategoryId] = useState<string | null>(null)
+  const [poeVersion, setPoeVersion] = useState<1 | 2>(1)
   const [thumbSize, setThumbSize] = useState<ThumbSize>(loadThumbSize)
   // Derive collapsed state from the live window height so the icon stays
   // correct across drag-resizes and app restarts (where react state would
@@ -52,11 +53,16 @@ export function App(): JSX.Element {
 
   useEffect(() => {
     void window.api.getSettings().then((s) => {
-      setSettings(s.cheatSheets)
-      setActiveCategoryId(s.cheatSheets.categories[0]?.id ?? null)
+      const cs = s.activeProfile?.cheatSheets ?? { globalHotkey: '', categories: [], pinned: false }
+      setSettings(cs)
+      setActiveCategoryId(cs.categories[0]?.id ?? null)
+      setPoeVersion(s.poeVersion === 2 ? 2 : 1)
     })
     return window.api.onSettingUpdated((key, value) => {
-      if (key === 'cheatSheets') setSettings(value as CheatSheetsSettings)
+      if (key === 'activeProfile') {
+        const next = (value as RuntimeSettings['activeProfile'])?.cheatSheets
+        if (next) setSettings(next)
+      }
     })
   }, [])
 
@@ -91,7 +97,7 @@ export function App(): JSX.Element {
     // never get our own echo back. Update local state immediately, then persist.
     const next: CheatSheetsSettings = { ...settings, pinned: !pinned }
     setSettings(next)
-    void window.api.setSetting('cheatSheets', next)
+    void window.api.setProfileSettingForGame(poeVersion, 'cheatSheets', next)
   }
   const sizeControls = (
     <SizeControls value={thumbSize} onChange={setThumbSize} pinned={pinned} onTogglePin={togglePin} />

--- a/src/renderer/src/components/FilterPicker.tsx
+++ b/src/renderer/src/components/FilterPicker.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
 import { CloseSmall, Info } from '@icon-park/react'
-import type { AppSettings, FilterListEntry, GameVariant } from '../../../shared/types'
+import type { FilterListEntry, GameVariant, RuntimeSettings } from '../../../shared/types'
 
 interface Props {
-  settings: AppSettings
-  onSettingsChange: (s: AppSettings) => void
+  settings: RuntimeSettings
+  onSettingsChange: (s: RuntimeSettings) => void
   /** Called when an online filter is imported and the user needs instructions */
   onOnlineImport?: (filterName: string) => void
   /** When true, automatically send /itemfilter command to PoE after importing */
@@ -48,13 +48,6 @@ export function FilterPicker({
   const fDir = settings.activeProfile?.filterDir ?? ''
   const fPath = settings.activeProfile?.filterPath ?? ''
   const gameVariant = (settings.poeVersion === 2 ? 2 : 1) as GameVariant
-
-  const updateLocalProfile = (patch: Partial<{ filterPath: string; filterDir: string }>): void => {
-    onSettingsChange({
-      ...settings,
-      activeProfile: settings.activeProfile ? { ...settings.activeProfile, ...patch } : null,
-    })
-  }
 
   // Listen for online filter changes
   useEffect(() => {
@@ -144,10 +137,7 @@ export function FilterPicker({
 
     if (autoSwitchInGame) {
       setSwitching(true)
-      const currentFilter =
-        freshImport && fPath
-          ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
-          : undefined
+      const currentFilter = freshImport && fPath ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '') : undefined
       await window.api.switchIngameFilter(filterName, currentFilter)
       setSwitching(false)
     }
@@ -189,9 +179,7 @@ export function FilterPicker({
     await scanDir(dir)
     if (autoSwitchInGame) {
       setSwitching(true)
-      const currentFilter = fPath
-        ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
-        : undefined
+      const currentFilter = fPath ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '') : undefined
       await window.api.switchIngameFilter(localName, currentFilter)
       setSwitching(false)
     }
@@ -212,9 +200,7 @@ export function FilterPicker({
     const filterName = entry.name.replace(/[<>:"/\\|?*]/g, '_') + '-local'
     if (autoSwitchInGame) {
       setSwitching(true)
-      const currentFilter = fPath
-        ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
-        : undefined
+      const currentFilter = fPath ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '') : undefined
       await window.api.switchIngameFilter(filterName, currentFilter)
       setSwitching(false)
     } else {

--- a/src/renderer/src/components/FilterPicker.tsx
+++ b/src/renderer/src/components/FilterPicker.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { CloseSmall, Info } from '@icon-park/react'
-import type { AppSettings, FilterListEntry } from '../../../shared/types'
+import type { AppSettings, FilterListEntry, GameVariant } from '../../../shared/types'
 
 interface Props {
   settings: AppSettings
@@ -45,6 +45,17 @@ export function FilterPicker({
     conflicts: Array<{ description: string; actionType: string }>
   } | null>(null)
 
+  const fDir = settings.activeProfile?.filterDir ?? ''
+  const fPath = settings.activeProfile?.filterPath ?? ''
+  const gameVariant = (settings.poeVersion === 2 ? 2 : 1) as GameVariant
+
+  const updateLocalProfile = (patch: Partial<{ filterPath: string; filterDir: string }>): void => {
+    onSettingsChange({
+      ...settings,
+      activeProfile: settings.activeProfile ? { ...settings.activeProfile, ...patch } : null,
+    })
+  }
+
   // Listen for online filter changes
   useEffect(() => {
     const unsub = window.api.onOnlineFilterChanged((changed) => {
@@ -66,51 +77,56 @@ export function FilterPicker({
 
   // Scan on mount if we already have a directory
   useEffect(() => {
-    if (settings.filterDir) scanDir(settings.filterDir)
-  }, [settings.filterDir])
+    if (fDir) scanDir(fDir)
+  }, [fDir])
 
   const pickDir = async (): Promise<void> => {
     const dir = await window.api.pickFilterDir()
     if (dir) {
-      onSettingsChange({ ...settings, filterDir: dir })
+      const updated = await window.api.setProfileSettingForGame(gameVariant, 'filterDir', dir)
+      onSettingsChange(updated)
     }
   }
 
   const importOnlineFilter = async (entry: FilterListEntry, force: boolean): Promise<boolean> => {
-    const result = await window.api.importOnlineFilter(entry.path, entry.name, settings.filterDir, force)
+    const dir = settings.activeProfile?.filterDir ?? ''
+    const result = await window.api.importOnlineFilter(entry.path, entry.name, dir, force)
     if (result.conflict) {
       setConflictEntry(entry)
       return false
     }
     if (!result.ok || !result.path) return false
-    onSettingsChange({ ...settings, filterPath: result.path })
-    await scanDir(settings.filterDir)
+    const updated = await window.api.setProfileSettingForGame(gameVariant, 'filterPath', result.path)
+    onSettingsChange(updated)
+    await scanDir(dir)
     return true
   }
 
   const selectFilter = async (entry: FilterListEntry): Promise<void> => {
     let filterName: string
     let freshImport = false
+    const dir = settings.activeProfile?.filterDir ?? ''
 
     if (entry.online) {
       const safeName = entry.name.replace(/[<>:"/\\|?*]/g, '_')
       const localName = `${safeName}-local`
-      const sep = settings.filterDir.includes('/') ? '/' : '\\'
-      const localPath = `${settings.filterDir}${sep}${localName}.filter`
+      const sep = dir.includes('/') ? '/' : '\\'
+      const localPath = `${dir}${sep}${localName}.filter`
 
       // Check if local copy already exists by attempting a non-force import
-      const result = await window.api.importOnlineFilter(entry.path, entry.name, settings.filterDir, false)
+      const result = await window.api.importOnlineFilter(entry.path, entry.name, dir, false)
       if (result.conflict) {
         // Local copy exists - switch to it and check for updates
-        window.api.setSetting('filterPath', localPath)
-        onSettingsChange({ ...settings, filterPath: localPath })
+        const updated = await window.api.setProfileSettingForGame(gameVariant, 'filterPath', localPath)
+        onSettingsChange(updated)
         filterName = localName
         // Trigger update check in the background (same as overlay's "Check for Updates")
         window.api.checkForOnlineUpdate().catch(() => {})
       } else if (result.ok && result.path) {
         // First import - set up the local copy
-        onSettingsChange({ ...settings, filterPath: result.path })
-        await scanDir(settings.filterDir)
+        const updated = await window.api.setProfileSettingForGame(gameVariant, 'filterPath', result.path)
+        onSettingsChange(updated)
+        await scanDir(dir)
         filterName = localName
         freshImport = true
         if (!autoSwitchInGame) {
@@ -121,16 +137,16 @@ export function FilterPicker({
         return
       }
     } else {
-      window.api.setSetting('filterPath', entry.path)
-      onSettingsChange({ ...settings, filterPath: entry.path })
+      const updated = await window.api.setProfileSettingForGame(gameVariant, 'filterPath', entry.path)
+      onSettingsChange(updated)
       filterName = entry.name
     }
 
     if (autoSwitchInGame) {
       setSwitching(true)
       const currentFilter =
-        freshImport && settings.filterPath
-          ? settings.filterPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
+        freshImport && fPath
+          ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
           : undefined
       await window.api.switchIngameFilter(filterName, currentFilter)
       setSwitching(false)
@@ -140,7 +156,8 @@ export function FilterPicker({
   const mergeOnlineFilter = async (entry: FilterListEntry): Promise<void> => {
     const safeName = entry.name.replace(/[<>:"/\\|?*]/g, '_')
     const localName = `${safeName}-local`
-    const localPath = `${settings.filterDir}${settings.filterDir.includes('/') ? '/' : '\\'}${localName}.filter`
+    const dir = settings.activeProfile?.filterDir ?? ''
+    const localPath = `${dir}${dir.includes('/') ? '/' : '\\'}${localName}.filter`
 
     setMerging(true)
     setConflictEntry(null)
@@ -169,11 +186,11 @@ export function FilterPicker({
     }
 
     // Reload filter list and switch in game if needed
-    await scanDir(settings.filterDir)
+    await scanDir(dir)
     if (autoSwitchInGame) {
       setSwitching(true)
-      const currentFilter = settings.filterPath
-        ? settings.filterPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
+      const currentFilter = fPath
+        ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
         : undefined
       await window.api.switchIngameFilter(localName, currentFilter)
       setSwitching(false)
@@ -195,8 +212,8 @@ export function FilterPicker({
     const filterName = entry.name.replace(/[<>:"/\\|?*]/g, '_') + '-local'
     if (autoSwitchInGame) {
       setSwitching(true)
-      const currentFilter = settings.filterPath
-        ? settings.filterPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
+      const currentFilter = fPath
+        ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
         : undefined
       await window.api.switchIngameFilter(filterName, currentFilter)
       setSwitching(false)
@@ -205,7 +222,8 @@ export function FilterPicker({
     }
   }
 
-  const dirName = settings.filterDir ? settings.filterDir.replace(/^.*[\\/]/, '') : null
+  const dirName = fDir ? fDir.replace(/^.*[\\/]/, '') : null
+  const currentPath = settings.activeProfile?.filterPath
 
   const localFilters = filters.filter((f) => !f.online)
   const onlineFilters = filters.filter((f) => f.online)
@@ -232,7 +250,7 @@ export function FilterPicker({
       )}
 
       {/* Filter list */}
-      {showList && settings.filterDir && !scanning && filters.length > 0 && (
+      {showList && fDir && !scanning && filters.length > 0 && (
         <div
           className="flex flex-col gap-0.5 overflow-y-auto rounded p-1 bg-black/20"
           style={{
@@ -244,7 +262,7 @@ export function FilterPicker({
               <FilterRow
                 key={f.path}
                 entry={f}
-                active={settings.filterPath === f.path}
+                active={currentPath === f.path}
                 switching={switching}
                 hasUpdate={false}
                 onSelect={() => selectFilter(f)}
@@ -259,7 +277,7 @@ export function FilterPicker({
                 <FilterRow
                   key={f.path}
                   entry={f}
-                  active={settings.filterPath === f.path}
+                  active={currentPath === f.path}
                   switching={switching}
                   hasUpdate={updatedFilters.has(f.name)}
                   onSelect={() => selectFilter(f)}
@@ -270,14 +288,14 @@ export function FilterPicker({
         </div>
       )}
 
-      {showList && settings.filterDir && !scanning && filters.length > 0 && (
+      {showList && fDir && !scanning && filters.length > 0 && (
         <p className="text-[10px] text-text-dim flex items-center gap-1 m-0 ml-1 mt-0.5">
           <Info size={12} theme="two-tone" fill={['currentColor', 'rgba(255,255,255,0.2)']} className="flex shrink-0" />
           To add a new online filter, load it in-game first and it will appear here next time you open settings.
         </p>
       )}
 
-      {showList && settings.filterDir && !scanning && filters.length === 0 && (
+      {showList && fDir && !scanning && filters.length === 0 && (
         <p className="text-[11px] text-text-dim m-0">No filter files found in this folder.</p>
       )}
 

--- a/src/renderer/src/components/SettingsPanel.test.tsx
+++ b/src/renderer/src/components/SettingsPanel.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeSettings } from '../../../shared/types'
+import { SettingsPanel } from './SettingsPanel'
+
+vi.mock('./settings', () => ({
+  GeneralTab: () => <div>General Tab</div>,
+  ViewTab: () => <div>View Tab</div>,
+  MacrosTab: () => <div>Macros Tab</div>,
+  FilterTab: () => <div>Filter Tab</div>,
+  PriceCheckTab: () => <div>Trade Tab</div>,
+  FaqTab: () => <div>FAQ Tab</div>,
+  CheatSheetsTab: () => <div>Sheets Tab</div>,
+  prettyHotkey: (hotkey: string) => hotkey,
+}))
+
+vi.mock('./settings/DeveloperSection', () => ({
+  DeveloperSection: () => <div>Developer Tab</div>,
+}))
+
+vi.mock('./settings/PluginsSection', () => ({
+  PluginsSection: () => <div>Plugins Tab</div>,
+}))
+
+vi.mock('../features/profiles/ProfileManagerTab', () => ({
+  ProfileManagerTab: () => <div>Profiles Tab</div>,
+}))
+
+function settings(input: Partial<RuntimeSettings> = {}): RuntimeSettings {
+  return {
+    poeVersion: 1,
+    activeProfileId: 'poe1',
+    lastProfileIdPoe1: 'poe1',
+    lastProfileIdPoe2: '',
+    activeProfile: null,
+    onboardingCompleted: true,
+    hotkey: '',
+    priceCheckHotkey: '',
+    overlayOpacity: 0.95,
+    overlayScale: 1,
+    openSide: 'both',
+    closeOnClickOutside: false,
+    useCurrentZoneAreaLevel: false,
+    reloadOnSave: true,
+    updateChannel: 'stable',
+    tradeStatus: 'available',
+    priceCheckDefaultPercent: 90,
+    tradeDefaultToBase: false,
+    chatCommands: [],
+    appMacros: [],
+    stashScrollEnabled: false,
+    regexPresetsPoe1: [],
+    regexPresetsPoe2: [],
+    leaguesPoe1: [],
+    leaguesPoe2: [],
+    themeId: 'default',
+    customThemePalette: null,
+    ...input,
+  } as RuntimeSettings
+}
+
+describe('SettingsPanel tab routing', () => {
+  beforeEach(() => {
+    ;(globalThis as unknown as { __APP_VERSION__: string }).__APP_VERSION__ = 'test'
+    ;(window as unknown as { api: Partial<typeof window.api> }).api = {
+      setSetting: vi.fn(),
+      setProfileSettingForGame: vi.fn(),
+    }
+  })
+
+  it('opens the Profiles tab from an app-mode tab request', () => {
+    render(
+      <SettingsPanel
+        settings={settings()}
+        onSettingsChange={vi.fn()}
+        mode="app"
+        onEditProfile={vi.fn()}
+        tabRequest={{ tab: 'profiles', n: 1 }}
+      />,
+    )
+
+    expect(screen.getByText('Profiles Tab')).toBeInTheDocument()
+  })
+
+  it('blocks the Profiles tab in overlay mode', () => {
+    render(
+      <SettingsPanel
+        settings={settings()}
+        onSettingsChange={vi.fn()}
+        mode="overlay"
+        onEditProfile={vi.fn()}
+        tabRequest={{ tab: 'profiles', n: 1 }}
+      />,
+    )
+
+    expect(screen.queryByText('Profiles Tab')).not.toBeInTheDocument()
+    expect(screen.getByText('General Tab')).toBeInTheDocument()
+  })
+
+  it('opens the Filter tab from a tab request', () => {
+    render(
+      <SettingsPanel
+        settings={settings()}
+        onSettingsChange={vi.fn()}
+        mode="app"
+        onEditProfile={vi.fn()}
+        tabRequest={{ tab: 'filter', n: 1 }}
+      />,
+    )
+
+    expect(screen.getByText('Filter Tab')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import type {
   AppSettings,
   PoeItem,
+  PoeProfileSummary,
   ProfileSettingKey,
   ProfileSettingValue,
   RuntimeSettings,
@@ -21,6 +22,7 @@ import { PluginsSection } from './settings/PluginsSection'
 import { ErrorBanner } from './ErrorBanner'
 import { findHotkeyCollision, type HotkeySlot } from './settings/hotkey-collisions'
 import { usePoeVersion } from '../shared/poe-version-context'
+import { ProfileManagerTab } from '../features/profiles/ProfileManagerTab'
 
 interface Props {
   settings: RuntimeSettings
@@ -29,7 +31,7 @@ interface Props {
   onDone?: () => void
   onOnlineFilterUpdated?: (name: string) => void
   onOnlineImport?: (name: string) => void
-  onManageProfiles?: () => void
+  onEditProfile?: (profile: PoeProfileSummary) => void
   /** Item currently loaded in the overlay, used to preserve context when undoing/restoring */
   currentItem?: PoeItem
   /** Optional callback to show a short banner at the top of the overlay */
@@ -50,6 +52,7 @@ const TAB_KEYS = [
   'cheatsheets',
   'filter',
   'pricecheck',
+  'profiles',
   'plugins',
   'faq',
   'developer',
@@ -62,6 +65,7 @@ const TAB_LABELS: Record<TabKey, string> = {
   cheatsheets: 'Sheets',
   filter: 'Filter',
   pricecheck: 'Trade',
+  profiles: 'Profiles',
   plugins: 'Plugins',
   faq: 'FAQ',
   developer: 'Developer',
@@ -74,7 +78,7 @@ export function SettingsPanel({
   onDone: _onDone,
   onOnlineFilterUpdated,
   onOnlineImport,
-  onManageProfiles,
+  onEditProfile,
   currentItem,
   onError,
   tabRequest,
@@ -85,7 +89,9 @@ export function SettingsPanel({
   // right tab without waiting for an effect.
   const [tab, setTab] = useState<TabKey>(() => {
     const t = tabRequest?.tab
-    return t && (TAB_KEYS as readonly string[]).includes(t) ? (t as TabKey) : 'general'
+    if (!t || !(TAB_KEYS as readonly string[]).includes(t)) return 'general'
+    if (mode === 'overlay' && t === 'profiles') return 'general'
+    return t as TabKey
   })
   const [localError, setLocalError] = useState<string | null>(null)
   const [localErrorTone, setLocalErrorTone] = useState<'error' | 'warn'>('error')
@@ -94,8 +100,9 @@ export function SettingsPanel({
   // the initial mount since useState above already consumed the seed.
   useEffect(() => {
     if (!tabRequest) return
+    if (mode === 'overlay' && tabRequest.tab === 'profiles') return
     if ((TAB_KEYS as readonly string[]).includes(tabRequest.tab)) setTab(tabRequest.tab as TabKey)
-  }, [tabRequest?.n])
+  }, [mode, tabRequest?.n])
 
   const update = <K extends keyof AppSettings>(key: K, value: AppSettings[K]): void => {
     window.api.setSetting(key, value)
@@ -158,6 +165,7 @@ export function SettingsPanel({
         <div className="flex flex-wrap gap-[6px]">
           {(TAB_KEYS as readonly TabKey[])
             .filter((t) => t !== 'developer' || settings.developerMode)
+            .filter((t) => t !== 'profiles' || !isOverlay)
             .map((t) => (
               <button
                 key={t}
@@ -167,11 +175,6 @@ export function SettingsPanel({
                 {TAB_LABELS[t]}
               </button>
             ))}
-          {!isOverlay && onManageProfiles && (
-            <button onClick={onManageProfiles} className="text-[11px] text-text-dim px-3 py-1.5">
-              Manage Profiles
-            </button>
-          )}
         </div>
       </div>
 
@@ -196,6 +199,9 @@ export function SettingsPanel({
       )}
       {tab === 'pricecheck' && (
         <PriceCheckTab settings={settings} update={update} updateProfile={updateProfile} tryHotkey={tryHotkey} />
+      )}
+      {tab === 'profiles' && !isOverlay && onEditProfile && (
+        <ProfileManagerTab settings={settings} onSettingsChange={onSettingsChange} onEditProfile={onEditProfile} />
       )}
       {tab === 'plugins' && <PluginsSection onError={showError} />}
       {tab === 'faq' && <FaqTab />}

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -23,7 +23,7 @@ interface Props {
   onDone?: () => void
   onOnlineFilterUpdated?: (name: string) => void
   onOnlineImport?: (name: string) => void
-  onShowOnboarding?: () => void
+  onManageProfiles?: () => void
   /** Item currently loaded in the overlay, used to preserve context when undoing/restoring */
   currentItem?: PoeItem
   /** Optional callback to show a short banner at the top of the overlay */
@@ -68,7 +68,7 @@ export function SettingsPanel({
   onDone: _onDone,
   onOnlineFilterUpdated,
   onOnlineImport,
-  onShowOnboarding,
+  onManageProfiles,
   currentItem,
   onError,
   tabRequest,
@@ -155,9 +155,9 @@ export function SettingsPanel({
                 {TAB_LABELS[t]}
               </button>
             ))}
-          {!isOverlay && onShowOnboarding && (
-            <button onClick={onShowOnboarding} className="text-[11px] text-text-dim px-3 py-1.5">
-              Setup Wizard
+          {!isOverlay && onManageProfiles && (
+            <button onClick={onManageProfiles} className="text-[11px] text-text-dim px-3 py-1.5">
+              Manage Profiles
             </button>
           )}
         </div>

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -96,6 +96,12 @@ export function SettingsPanel({
     onSettingsChange({ ...settings, [key]: value })
   }
 
+  const updateProfile = async (key: 'league' | 'filterPath' | 'filterDir' | 'tradePriceOption' | 'cheatSheets', value: unknown): Promise<void> => {
+    const variant = settings.poeVersion === 2 ? 2 : 1
+    const updated = await window.api.setProfileSettingForGame(variant, key, value)
+    onSettingsChange(updated)
+  }
+
   // A single merged onSettingsChange avoids the stale-settings-closure clobber you'd get from two sequential update() calls in one tick.
   const updateMany = (patch: Partial<AppSettings>): void => {
     for (const k of Object.keys(patch) as Array<keyof AppSettings>) {
@@ -163,16 +169,17 @@ export function SettingsPanel({
         </div>
       </div>
 
-      {tab === 'general' && <GeneralTab settings={settings} update={update} />}
+      {tab === 'general' && <GeneralTab settings={settings} update={update} updateProfile={updateProfile} />}
       {tab === 'view' && <ViewTab settings={settings} update={update} updateMany={updateMany} />}
       {tab === 'macros' && <MacrosTab settings={settings} update={update} tryHotkey={tryHotkey} />}
       {tab === 'cheatsheets' && (
-        <CheatSheetsTab settings={settings} update={update} tryHotkey={tryHotkey} onError={showError} />
+        <CheatSheetsTab settings={settings} update={update} updateProfile={updateProfile} tryHotkey={tryHotkey} onError={showError} />
       )}
       {tab === 'filter' && (
         <FilterTab
           settings={settings}
           update={update}
+          updateProfile={updateProfile}
           isOverlay={isOverlay}
           onOnlineFilterUpdated={onOnlineFilterUpdated}
           onOnlineImport={onOnlineImport}
@@ -181,7 +188,7 @@ export function SettingsPanel({
           currentItem={currentItem}
         />
       )}
-      {tab === 'pricecheck' && <PriceCheckTab settings={settings} update={update} tryHotkey={tryHotkey} />}
+      {tab === 'pricecheck' && <PriceCheckTab settings={settings} update={update} updateProfile={updateProfile} tryHotkey={tryHotkey} />}
       {tab === 'plugins' && <PluginsSection onError={showError} />}
       {tab === 'faq' && <FaqTab />}
       {tab === 'developer' && <DeveloperSection settings={settings} update={update} onError={showError} />}

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react'
-import type { AppSettings, PoeItem } from '../../../shared/types'
+import type {
+  AppSettings,
+  PoeItem,
+  ProfileSettingKey,
+  ProfileSettingValue,
+  RuntimeSettings,
+} from '../../../shared/types'
 import {
   GeneralTab,
   ViewTab,
@@ -17,8 +23,8 @@ import { findHotkeyCollision, type HotkeySlot } from './settings/hotkey-collisio
 import { usePoeVersion } from '../shared/poe-version-context'
 
 interface Props {
-  settings: AppSettings
-  onSettingsChange: (s: AppSettings) => void
+  settings: RuntimeSettings
+  onSettingsChange: (s: RuntimeSettings) => void
   mode: 'overlay' | 'app'
   onDone?: () => void
   onOnlineFilterUpdated?: (name: string) => void
@@ -96,7 +102,7 @@ export function SettingsPanel({
     onSettingsChange({ ...settings, [key]: value })
   }
 
-  const updateProfile = async (key: 'league' | 'filterPath' | 'filterDir' | 'tradePriceOption' | 'cheatSheets', value: unknown): Promise<void> => {
+  const updateProfile = async <K extends ProfileSettingKey>(key: K, value: ProfileSettingValue<K>): Promise<void> => {
     const variant = settings.poeVersion === 2 ? 2 : 1
     const updated = await window.api.setProfileSettingForGame(variant, key, value)
     onSettingsChange(updated)
@@ -173,7 +179,13 @@ export function SettingsPanel({
       {tab === 'view' && <ViewTab settings={settings} update={update} updateMany={updateMany} />}
       {tab === 'macros' && <MacrosTab settings={settings} update={update} tryHotkey={tryHotkey} />}
       {tab === 'cheatsheets' && (
-        <CheatSheetsTab settings={settings} update={update} updateProfile={updateProfile} tryHotkey={tryHotkey} onError={showError} />
+        <CheatSheetsTab
+          settings={settings}
+          update={update}
+          updateProfile={updateProfile}
+          tryHotkey={tryHotkey}
+          onError={showError}
+        />
       )}
       {tab === 'filter' && (
         <FilterTab
@@ -188,7 +200,9 @@ export function SettingsPanel({
           currentItem={currentItem}
         />
       )}
-      {tab === 'pricecheck' && <PriceCheckTab settings={settings} update={update} updateProfile={updateProfile} tryHotkey={tryHotkey} />}
+      {tab === 'pricecheck' && (
+        <PriceCheckTab settings={settings} update={update} updateProfile={updateProfile} tryHotkey={tryHotkey} />
+      )}
       {tab === 'plugins' && <PluginsSection onError={showError} />}
       {tab === 'faq' && <FaqTab />}
       {tab === 'developer' && <DeveloperSection settings={settings} update={update} onError={showError} />}

--- a/src/renderer/src/components/SettingsPanel.tsx
+++ b/src/renderer/src/components/SettingsPanel.tsx
@@ -179,13 +179,7 @@ export function SettingsPanel({
       {tab === 'view' && <ViewTab settings={settings} update={update} updateMany={updateMany} />}
       {tab === 'macros' && <MacrosTab settings={settings} update={update} tryHotkey={tryHotkey} />}
       {tab === 'cheatsheets' && (
-        <CheatSheetsTab
-          settings={settings}
-          update={update}
-          updateProfile={updateProfile}
-          tryHotkey={tryHotkey}
-          onError={showError}
-        />
+        <CheatSheetsTab settings={settings} updateProfile={updateProfile} tryHotkey={tryHotkey} onError={showError} />
       )}
       {tab === 'filter' && (
         <FilterTab

--- a/src/renderer/src/components/SocketRecolor.tsx
+++ b/src/renderer/src/components/SocketRecolor.tsx
@@ -253,7 +253,7 @@ export function SocketRecolor({ item, priceInfo }: Props): JSX.Element {
         const settings = await window.api.getSettings()
         const prices = await window.api.batchLookupPrices(
           ['Chromatic Orb', "Jeweller's Orb", 'Orb of Fusing'],
-          settings.league,
+          settings.activeProfile?.league ?? '',
         )
         setRates({
           chrom: prices['Chromatic Orb']?.chaosValue ?? 1 / 8,

--- a/src/renderer/src/components/div-card-explorer/DivCardExplorer.tsx
+++ b/src/renderer/src/components/div-card-explorer/DivCardExplorer.tsx
@@ -41,7 +41,7 @@ export function DivCardExplorer({ onSelectItem }: Props): JSX.Element {
         const chunkSize = 200
         for (let i = 0; i < cardNames.length; i += chunkSize) {
           const chunk = cardNames.slice(i, i + chunkSize)
-          const p = await window.api.batchLookupDivCardPrices(chunk, settings.league)
+          const p = await window.api.batchLookupDivCardPrices(chunk, settings.activeProfile?.league ?? '')
           for (const [name, info] of Object.entries(p)) {
             if (info?.chaosValue) result[name] = info.chaosValue
           }
@@ -53,7 +53,7 @@ export function DivCardExplorer({ onSelectItem }: Props): JSX.Element {
           return
         }
         setPrices(result)
-        const currPrices = await window.api.batchLookupPrices(['Divine Orb'], settings.league)
+        const currPrices = await window.api.batchLookupPrices(['Divine Orb'], settings.activeProfile?.league ?? '')
         const divPrice = currPrices['Divine Orb']?.chaosValue ?? 0
         if (divPrice > 0) setDivineRate(divPrice)
       } catch {

--- a/src/renderer/src/components/div-card-explorer/DivCardExplorer.tsx
+++ b/src/renderer/src/components/div-card-explorer/DivCardExplorer.tsx
@@ -17,6 +17,7 @@ export function DivCardExplorer({ onSelectItem }: Props): JSX.Element {
   const [tierStyles, setTierStyles] = useState<Record<string, TierStyle>>({})
   const [cardTiers, setCardTiers] = useState<Record<string, string>>({})
   const [hiddenCards, setHiddenCards] = useState<Record<string, boolean>>({})
+  const [filterVersion, setFilterVersion] = useState(0)
   const [manualFlags, setManualFlags] = useState<Record<string, boolean>>(() => {
     try {
       return JSON.parse(localStorage.getItem('div-outlier-flags') || '{}')
@@ -25,13 +26,19 @@ export function DivCardExplorer({ onSelectItem }: Props): JSX.Element {
     }
   })
 
-  // Fetch live prices and tier data
+  useEffect(() => window.api.onFilterChanged(() => setFilterVersion((v) => v + 1)), [])
+
+  // Filter-derived tier/visibility data -- refetched when the filter reloads.
   useEffect(() => {
     window.api.getDivCardTiers().then(({ tierStyles: ts, cardTiers: ct, hiddenCards: hc }) => {
       setTierStyles(ts)
       setCardTiers(ct)
       setHiddenCards(hc)
     })
+  }, [filterVersion])
+
+  // Fetch live prices
+  useEffect(() => {
     let cancelled = false
     const fetchPrices = async (attempt = 0): Promise<void> => {
       try {

--- a/src/renderer/src/components/dust-explorer/DustExplorer.tsx
+++ b/src/renderer/src/components/dust-explorer/DustExplorer.tsx
@@ -33,6 +33,7 @@ export function DustExplorer({
   const [loading, setLoading] = useState(true)
   const [filters, setFiltersState] = useState<ActiveFilter[]>(persistedState.filters)
   const [visibility, setVisibility] = useState<Record<string, 'Show' | 'Hide'>>({})
+  const [filterVersion, setFilterVersion] = useState(0)
 
   const setFilters = (fn: ActiveFilter[] | ((prev: ActiveFilter[]) => ActiveFilter[])) => {
     setFiltersState((prev) => {
@@ -90,6 +91,8 @@ export function DustExplorer({
     }
   }, [baseEntries])
 
+  useEffect(() => window.api.onFilterChanged(() => setFilterVersion((v) => v + 1)), [])
+
   useEffect(() => {
     let cancelled = false
     window.api
@@ -101,7 +104,7 @@ export function DustExplorer({
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [filterVersion])
 
   const entries: DustEntry[] = useMemo(() => {
     return baseEntries

--- a/src/renderer/src/components/dust-explorer/DustExplorer.tsx
+++ b/src/renderer/src/components/dust-explorer/DustExplorer.tsx
@@ -54,7 +54,7 @@ export function DustExplorer({
         const chunkSize = 200
         for (let i = 0; i < names.length; i += chunkSize) {
           const chunk = names.slice(i, i + chunkSize)
-          const p = await window.api.batchLookupPrices(chunk, settings.league)
+          const p = await window.api.batchLookupPrices(chunk, settings.activeProfile?.league ?? '')
           for (const [name, info] of Object.entries(p)) {
             if (info?.chaosValue) result[name] = info.chaosValue
           }
@@ -67,7 +67,7 @@ export function DustExplorer({
           return
         }
         setPrices(result)
-        const currPrices = await window.api.batchLookupPrices(['Divine Orb', 'Mirror of Kalandra'], settings.league)
+        const currPrices = await window.api.batchLookupPrices(['Divine Orb', 'Mirror of Kalandra'], settings.activeProfile?.league ?? '')
         const divPrice = currPrices['Divine Orb']?.chaosValue ?? 0
         const mirPrice = currPrices['Mirror of Kalandra']?.chaosValue ?? 0
         if (divPrice > 0) setDivineRate(divPrice)

--- a/src/renderer/src/components/dust-explorer/DustExplorer.tsx
+++ b/src/renderer/src/components/dust-explorer/DustExplorer.tsx
@@ -67,7 +67,10 @@ export function DustExplorer({
           return
         }
         setPrices(result)
-        const currPrices = await window.api.batchLookupPrices(['Divine Orb', 'Mirror of Kalandra'], settings.activeProfile?.league ?? '')
+        const currPrices = await window.api.batchLookupPrices(
+          ['Divine Orb', 'Mirror of Kalandra'],
+          settings.activeProfile?.league ?? '',
+        )
         const divPrice = currPrices['Divine Orb']?.chaosValue ?? 0
         const mirPrice = currPrices['Mirror of Kalandra']?.chaosValue ?? 0
         if (divPrice > 0) setDivineRate(divPrice)

--- a/src/renderer/src/components/filter-block-editor/EffectsGroup.tsx
+++ b/src/renderer/src/components/filter-block-editor/EffectsGroup.tsx
@@ -67,9 +67,9 @@ function AlertSoundEditor({
   useEffect(() => {
     window.api.getSettings().then((s) => {
       if (typeof s.previewVolume === 'number') previewVolumeRef.current = s.previewVolume
-      if (s.filterDir) {
-        filterDirRef.current = s.filterDir
-        window.api.scanSoundFiles(s.filterDir).then(setSoundFiles)
+      if (s.activeProfile?.filterDir) {
+        filterDirRef.current = s.activeProfile.filterDir
+        window.api.scanSoundFiles(s.activeProfile.filterDir).then(setSoundFiles)
       }
     })
   }, [])

--- a/src/renderer/src/components/filter-block-editor/useAuditPricePreview.ts
+++ b/src/renderer/src/components/filter-block-editor/useAuditPricePreview.ts
@@ -24,7 +24,7 @@ export function useAuditPricePreview(baseTypes: string[], isUniqueTier: boolean)
     setNoPrices(undefined)
     void (async (): Promise<void> => {
       const settings = await window.api.getSettings()
-      const prices = await window.api.batchLookupPrices(baseTypes, settings.league, isUniqueTier)
+      const prices = await window.api.batchLookupPrices(baseTypes, settings.activeProfile?.league ?? '', isUniqueTier)
       if (cancelled) return
       setNoPrices(Object.values(prices).every((p) => p == null))
     })()

--- a/src/renderer/src/components/filter-panel/UniquesForBase.tsx
+++ b/src/renderer/src/components/filter-panel/UniquesForBase.tsx
@@ -29,7 +29,7 @@ export function UniquesForBase({ baseType, itemClass }: { baseType: string; item
   }, [baseType])
 
   useEffect(() => {
-    window.api.getSettings().then((s) => setLeague(s.league ?? ''))
+    window.api.getSettings().then((s) => setLeague(s.activeProfile?.league ?? ''))
   }, [])
 
   useEffect(() => {

--- a/src/renderer/src/components/price-audit/useAuditState.ts
+++ b/src/renderer/src/components/price-audit/useAuditState.ts
@@ -157,9 +157,9 @@ export function useAuditState({ block, blockIndex, tierGroup, item }: UseAuditSt
     try {
       const settings = await window.api.getSettings()
       const isUnique = block.conditions.some((c) => c.type === 'Rarity' && c.values.some((v) => v === 'Unique'))
-      const prices = await window.api.batchLookupPrices(baseTypes, settings.league, isUnique)
+      const prices = await window.api.batchLookupPrices(baseTypes, settings.activeProfile?.league ?? '', isUnique)
 
-      const currPrices = await window.api.batchLookupPrices(['Divine Orb', 'Mirror of Kalandra'], settings.league)
+      const currPrices = await window.api.batchLookupPrices(['Divine Orb', 'Mirror of Kalandra'], settings.activeProfile?.league ?? '')
       const divPrice = currPrices['Divine Orb']?.chaosValue ?? 0
       const mirPrice = currPrices['Mirror of Kalandra']?.chaosValue ?? 0
       if (divPrice > 0) setDivineRate(divPrice)

--- a/src/renderer/src/components/price-audit/useAuditState.ts
+++ b/src/renderer/src/components/price-audit/useAuditState.ts
@@ -159,7 +159,10 @@ export function useAuditState({ block, blockIndex, tierGroup, item }: UseAuditSt
       const isUnique = block.conditions.some((c) => c.type === 'Rarity' && c.values.some((v) => v === 'Unique'))
       const prices = await window.api.batchLookupPrices(baseTypes, settings.activeProfile?.league ?? '', isUnique)
 
-      const currPrices = await window.api.batchLookupPrices(['Divine Orb', 'Mirror of Kalandra'], settings.activeProfile?.league ?? '')
+      const currPrices = await window.api.batchLookupPrices(
+        ['Divine Orb', 'Mirror of Kalandra'],
+        settings.activeProfile?.league ?? '',
+      )
       const divPrice = currPrices['Divine Orb']?.chaosValue ?? 0
       const mirPrice = currPrices['Mirror of Kalandra']?.chaosValue ?? 0
       if (divPrice > 0) setDivineRate(divPrice)

--- a/src/renderer/src/components/price-check/PriceCheck.tsx
+++ b/src/renderer/src/components/price-check/PriceCheck.tsx
@@ -203,7 +203,7 @@ export function PriceCheck({
       // sees a real exchange rate (PoE1: chaos<->divine, PoE2: exalted<->divine).
       const crossCurrency = primaryCurrencySwap(item.name, poeVersion)
       if (crossCurrency) setPriceOption(crossCurrency)
-      else if (s.tradePriceOption) setPriceOption(s.tradePriceOption as PriceOption)
+      else if (s.activeProfile?.tradePriceOption) setPriceOption(s.activeProfile.tradePriceOption as PriceOption)
       if (s.tradeStatus) setStatusOption(s.tradeStatus as StatusOption)
       if (s.tradeDefaultListedTime !== undefined) setListedTime(s.tradeDefaultListedTime as ListedTime)
       if (s.tradeResultsView) setResultsView(s.tradeResultsView)

--- a/src/renderer/src/components/settings/CheatSheetsTab.tsx
+++ b/src/renderer/src/components/settings/CheatSheetsTab.tsx
@@ -9,6 +9,7 @@ import { PrefabPicker } from './cheatsheets/PrefabPicker'
 interface Props {
   settings: AppSettings
   update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
+  updateProfile: (key: 'cheatSheets', value: unknown) => Promise<void>
   tryHotkey: (hotkey: string, slot: HotkeySlot) => boolean
   /** Shows a banner error message via the parent SettingsPanel. Called for
    *  URL-paste failures and other transient operations the user should know
@@ -16,10 +17,10 @@ interface Props {
   onError: (message: string, tone?: 'error' | 'warn') => void
 }
 
-export function CheatSheetsTab({ settings, update, tryHotkey, onError }: Props): JSX.Element {
-  const cheatSheets = settings.cheatSheets ?? { globalHotkey: '', categories: [] }
+export function CheatSheetsTab({ settings, update, updateProfile, tryHotkey, onError }: Props): JSX.Element {
+  const cheatSheets = settings.activeProfile?.cheatSheets ?? { globalHotkey: '', categories: [] }
   const setCategories = (categories: CheatSheetCategory[]): void => {
-    update('cheatSheets', { ...cheatSheets, categories })
+    updateProfile('cheatSheets', { ...cheatSheets, categories })
   }
 
   return (
@@ -34,7 +35,7 @@ export function CheatSheetsTab({ settings, update, tryHotkey, onError }: Props):
             value={cheatSheets.globalHotkey}
             onChange={(hotkey) => {
               if (!tryHotkey(hotkey, { kind: 'cheatsheet-global' })) return
-              update('cheatSheets', { ...cheatSheets, globalHotkey: hotkey })
+              updateProfile('cheatSheets', { ...cheatSheets, globalHotkey: hotkey })
             }}
           />
         </div>

--- a/src/renderer/src/components/settings/CheatSheetsTab.tsx
+++ b/src/renderer/src/components/settings/CheatSheetsTab.tsx
@@ -1,5 +1,5 @@
 import { ReactSortable } from 'react-sortablejs'
-import type { AppSettings, CheatSheetCategory } from '../../../../shared/types'
+import type { AppSettings, CheatSheetCategory, ProfileSettingValue, RuntimeSettings } from '../../../../shared/types'
 import { HotkeyField } from './HotkeyField'
 import { generateClientCategoryId } from './utils'
 import type { HotkeySlot } from './hotkey-collisions'
@@ -7,9 +7,9 @@ import { CategoryCard } from './cheatsheets/CategoryCard'
 import { PrefabPicker } from './cheatsheets/PrefabPicker'
 
 interface Props {
-  settings: AppSettings
+  settings: RuntimeSettings
   update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
-  updateProfile: (key: 'cheatSheets', value: unknown) => Promise<void>
+  updateProfile: <K extends 'cheatSheets'>(key: K, value: ProfileSettingValue<K>) => Promise<void>
   tryHotkey: (hotkey: string, slot: HotkeySlot) => boolean
   /** Shows a banner error message via the parent SettingsPanel. Called for
    *  URL-paste failures and other transient operations the user should know

--- a/src/renderer/src/components/settings/CheatSheetsTab.tsx
+++ b/src/renderer/src/components/settings/CheatSheetsTab.tsx
@@ -1,5 +1,5 @@
 import { ReactSortable } from 'react-sortablejs'
-import type { AppSettings, CheatSheetCategory, ProfileSettingValue, RuntimeSettings } from '../../../../shared/types'
+import type { CheatSheetCategory, ProfileSettingValue, RuntimeSettings } from '../../../../shared/types'
 import { HotkeyField } from './HotkeyField'
 import { generateClientCategoryId } from './utils'
 import type { HotkeySlot } from './hotkey-collisions'
@@ -8,7 +8,6 @@ import { PrefabPicker } from './cheatsheets/PrefabPicker'
 
 interface Props {
   settings: RuntimeSettings
-  update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
   updateProfile: <K extends 'cheatSheets'>(key: K, value: ProfileSettingValue<K>) => Promise<void>
   tryHotkey: (hotkey: string, slot: HotkeySlot) => boolean
   /** Shows a banner error message via the parent SettingsPanel. Called for
@@ -17,7 +16,7 @@ interface Props {
   onError: (message: string, tone?: 'error' | 'warn') => void
 }
 
-export function CheatSheetsTab({ settings, update, updateProfile, tryHotkey, onError }: Props): JSX.Element {
+export function CheatSheetsTab({ settings, updateProfile, tryHotkey, onError }: Props): JSX.Element {
   const cheatSheets = settings.activeProfile?.cheatSheets ?? { globalHotkey: '', categories: [] }
   const setCategories = (categories: CheatSheetCategory[]): void => {
     updateProfile('cheatSheets', { ...cheatSheets, categories })

--- a/src/renderer/src/components/settings/FilterTab.tsx
+++ b/src/renderer/src/components/settings/FilterTab.tsx
@@ -1,4 +1,4 @@
-import type { AppSettings, PoeItem } from '../../../../shared/types'
+import type { AppSettings, ProfileSettingValue, PoeItem, RuntimeSettings } from '../../../../shared/types'
 import { getGameFeatures } from '../../../../shared/game-features'
 import { FilterPicker } from '../FilterPicker'
 import { HistoryPanel } from '../HistoryPanel'
@@ -6,13 +6,13 @@ import { HotkeyField } from './HotkeyField'
 import { SettingToggleBox } from './SettingToggleBox'
 
 interface Props {
-  settings: AppSettings
+  settings: RuntimeSettings
   update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
-  updateProfile: (key: 'filterPath' | 'filterDir', value: unknown) => Promise<void>
+  updateProfile: <K extends 'filterPath' | 'filterDir'>(key: K, value: ProfileSettingValue<K>) => Promise<void>
   isOverlay: boolean
   onOnlineFilterUpdated?: (name: string) => void
   onOnlineImport?: (name: string) => void
-  onSettingsChange: (s: AppSettings) => void
+  onSettingsChange: (s: RuntimeSettings) => void
   tryHotkey: (hotkey: string, slot: { kind: 'filter' }) => boolean
   currentItem?: PoeItem
 }

--- a/src/renderer/src/components/settings/FilterTab.tsx
+++ b/src/renderer/src/components/settings/FilterTab.tsx
@@ -8,6 +8,7 @@ import { SettingToggleBox } from './SettingToggleBox'
 interface Props {
   settings: AppSettings
   update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
+  updateProfile: (key: 'filterPath' | 'filterDir', value: unknown) => Promise<void>
   isOverlay: boolean
   onOnlineFilterUpdated?: (name: string) => void
   onOnlineImport?: (name: string) => void
@@ -19,6 +20,7 @@ interface Props {
 export function FilterTab({
   settings,
   update,
+  updateProfile: _updateProfile,
   isOverlay,
   onOnlineFilterUpdated,
   onOnlineImport,
@@ -27,6 +29,7 @@ export function FilterTab({
   currentItem,
 }: Props): JSX.Element {
   const features = getGameFeatures(settings.poeVersion)
+  const filterPath = settings.activeProfile?.filterPath
 
   return (
     <>
@@ -44,7 +47,7 @@ export function FilterTab({
             onOnlineImport={onOnlineImport}
           />
         </div>
-        {isOverlay && !settings.filterPath && (
+        {isOverlay && !filterPath && (
           <p className="text-[11px] text-text-dim mt-1">
             Typically: <code>{features.filterFolderHint}</code>
           </p>

--- a/src/renderer/src/components/settings/GeneralTab.tsx
+++ b/src/renderer/src/components/settings/GeneralTab.tsx
@@ -6,15 +6,17 @@ import { reportDiagnosticError } from '../../shared/diagnostics'
 interface Props {
   settings: AppSettings
   update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
+  updateProfile: (key: 'league', value: unknown) => Promise<void>
 }
 
-export function GeneralTab({ settings, update }: Props): JSX.Element {
+export function GeneralTab({ settings, update, updateProfile }: Props): JSX.Element {
   const [reportMessage, setReportMessage] = useState<string | null>(null)
   const [reporting, setReporting] = useState(false)
   const [simulateCrash, setSimulateCrash] = useState(false)
   const features = getGameFeatures(settings.poeVersion)
   const cachedLeagues = settings.poeVersion === 2 ? settings.leaguesPoe2 : settings.leaguesPoe1
   const leagueOptions: readonly string[] = cachedLeagues && cachedLeagues.length > 0 ? cachedLeagues : features.leagues
+  const activeLeague = settings.activeProfile?.league ?? ''
 
   const reportBug = async (): Promise<void> => {
     setReporting(true)
@@ -42,17 +44,17 @@ export function GeneralTab({ settings, update }: Props): JSX.Element {
         // "Private League" is a sentinel option in the dropdown (matches APT's
         // pattern). When selected, an input below lets the user type the actual
         // private league name (e.g. "MyPL (PL12345)") which is what gets persisted
-        // to settings.league and sent to the trade API verbatim. We detect "private
-        // mode" by absence from the standard league list rather than a separate flag,
-        // so a typed value that happens to match a standard league cleanly switches
-        // back to dropdown mode.
+        // to the active profile's league and sent to the trade API verbatim. We
+        // detect "private mode" by absence from the standard league list rather
+        // than a separate flag, so a typed value that happens to match a standard
+        // league cleanly switches back to dropdown mode.
         const PRIVATE_LEAGUE_LABEL = 'Private League'
-        const isPrivate = !leagueOptions.includes(settings.league)
+        const isPrivate = !leagueOptions.includes(activeLeague)
         return (
           <section>
             <label>League</label>
             <div className="setting-box mt-[6px] relative">
-              <span className="value">{settings.league || PRIVATE_LEAGUE_LABEL}</span>
+              <span className="value">{activeLeague || PRIVATE_LEAGUE_LABEL}</span>
               <button
                 className="primary"
                 onClick={() => {
@@ -65,15 +67,15 @@ export function GeneralTab({ settings, update }: Props): JSX.Element {
               </button>
               <select
                 id="league-select-unified"
-                value={isPrivate ? PRIVATE_LEAGUE_LABEL : settings.league}
+                value={isPrivate ? PRIVATE_LEAGUE_LABEL : activeLeague}
                 onChange={(e) => {
                   if (e.target.value === PRIVATE_LEAGUE_LABEL) {
                     // First-time switch into private mode: clear so the input below
                     // shows empty + placeholder. Re-selecting while already private
                     // is a no-op (the typed value stays).
-                    if (!isPrivate) update('league', '')
+                    if (!isPrivate) updateProfile('league', '')
                   } else {
-                    update('league', e.target.value)
+                    updateProfile('league', e.target.value)
                   }
                 }}
                 className="absolute inset-0 opacity-0 cursor-pointer"
@@ -89,8 +91,8 @@ export function GeneralTab({ settings, update }: Props): JSX.Element {
             {isPrivate && (
               <input
                 type="text"
-                value={settings.league}
-                onChange={(e) => update('league', e.target.value)}
+                value={activeLeague}
+                onChange={(e) => updateProfile('league', e.target.value)}
                 placeholder="Enter Private League - Full name including (PL#####)"
                 className="mt-[6px] w-full text-[11px] bg-black/30 rounded px-2 py-[5px] border-none"
               />
@@ -98,123 +100,3 @@ export function GeneralTab({ settings, update }: Props): JSX.Element {
           </section>
         )
       })()}
-
-      {/* Update channel */}
-      <section>
-        <label>Update channel</label>
-        <div className="flex gap-1.5 mt-[6px]">
-          {(['stable', 'beta'] as const).map((ch) => (
-            <button
-              key={ch}
-              onClick={() => update('updateChannel', ch)}
-              className={`text-[11px] px-3 py-1.5 ${
-                settings.updateChannel === ch ? 'bg-accent text-bg-solid' : 'text-text-dim'
-              }`}
-            >
-              {ch === 'stable' ? 'Stable' : 'Beta'}
-            </button>
-          ))}
-        </div>
-        {settings.updateChannel === 'beta' && (
-          <div className="mt-2 flex flex-col gap-1.5">
-            <p className="text-[10px] text-text-dim">
-              Warning: expect beta releases to break stuff and be generally annoying. Please join discord to tell me
-              what to fix and watch me squirm
-            </p>
-            <a
-              href="https://discord.com/invite/nUNcrmEAP5"
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => {
-                e.preventDefault()
-                window.api.openExternal('https://discord.com/invite/nUNcrmEAP5')
-              }}
-              className="flex items-center justify-center gap-1.5 text-[11px] font-semibold px-3 py-1.5 rounded no-underline"
-              style={{ background: '#5865F2', color: '#fff' }}
-            >
-              Join Discord
-            </a>
-          </div>
-        )}
-      </section>
-
-      <section>
-        <label>Filter sound preview volume</label>
-        <div className="flex items-center gap-[10px] mt-[2px]">
-          <input
-            type="range"
-            min={0}
-            max={100}
-            step={5}
-            value={Math.round((settings.previewVolume ?? 0.25) * 100)}
-            onChange={(e) => update('previewVolume', parseInt(e.target.value, 10) / 100)}
-            className="flex-1"
-          />
-          <span className="text-[13px] font-semibold text-text min-w-[36px] text-right">
-            {Math.round((settings.previewVolume ?? 0.25) * 100)}%
-          </span>
-        </div>
-      </section>
-
-      <section>
-        <label>Bug reports</label>
-        <div className="mt-[6px] flex flex-col gap-2">
-          <button onClick={reportBug} disabled={reporting} className="self-start text-[11px] px-3 py-1.5 text-text-dim">
-            {reporting ? 'Creating report...' : 'Report a bug'}
-          </button>
-          {reportMessage && <div className="text-[10px] text-text-dim break-all">{reportMessage}</div>}
-        </div>
-      </section>
-
-      {import.meta.env.DEV && (
-        <section>
-          <div className="settings-section-title mt-3">Dev Only Stuff</div>
-          <div className="flex gap-1.5 mt-[6px] flex-wrap">
-            <button
-              onClick={() => {
-                for (let i = localStorage.length - 1; i >= 0; i--) {
-                  const k = localStorage.key(i)
-                  if (k && k.startsWith('tip.')) localStorage.removeItem(k)
-                }
-                // Mounted DismissibleTip instances only check localStorage on mount,
-                // so reload to surface the dismissed tips again.
-                window.location.reload()
-              }}
-              className="text-[11px] px-3 py-1.5 text-text-dim"
-            >
-              Reset tooltips
-            </button>
-            <button
-              onClick={() => window.api.devFakeUpdate()}
-              className="text-[11px] px-3 py-1.5 text-text-dim"
-              title="Inject a fake update-available event so you can test the channel-switch rescind flow"
-            >
-              Fake update banner
-            </button>
-            <button
-              onClick={() =>
-                reportDiagnosticError(
-                  'renderer',
-                  'action',
-                  new Error('Simulated small renderer error from Dev Only Stuff'),
-                  'Dev Only Stuff: simulate a small error',
-                )
-              }
-              className="text-[11px] px-3 py-1.5 text-text-dim"
-              title="Report a handled diagnostics error without breaking the UI"
-            >
-              Simulate a small error
-            </button>
-            <button
-              onClick={() => setSimulateCrash(true)}
-              className="text-[11px] px-3 py-1.5 text-text-dim"
-              title="Throw during render so the diagnostics error boundary catches it"
-            >
-              Simulate a fatal crash
-            </button>
-          </div>
-        </section>
-      )}
-    </>
-  )
-}

--- a/src/renderer/src/components/settings/GeneralTab.tsx
+++ b/src/renderer/src/components/settings/GeneralTab.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
-import type { AppSettings } from '../../../../shared/types'
+import type { AppSettings, ProfileSettingValue, RuntimeSettings } from '../../../../shared/types'
 import { getGameFeatures } from '../../../../shared/game-features'
 import { reportDiagnosticError } from '../../shared/diagnostics'
 
 interface Props {
-  settings: AppSettings
+  settings: RuntimeSettings
   update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
-  updateProfile: (key: 'league', value: unknown) => Promise<void>
+  updateProfile: <K extends 'league'>(key: K, value: ProfileSettingValue<K>) => Promise<void>
 }
 
 export function GeneralTab({ settings, update, updateProfile }: Props): JSX.Element {
@@ -41,13 +41,6 @@ export function GeneralTab({ settings, update, updateProfile }: Props): JSX.Elem
 
       {/* League */}
       {(() => {
-        // "Private League" is a sentinel option in the dropdown (matches APT's
-        // pattern). When selected, an input below lets the user type the actual
-        // private league name (e.g. "MyPL (PL12345)") which is what gets persisted
-        // to the active profile's league and sent to the trade API verbatim. We
-        // detect "private mode" by absence from the standard league list rather
-        // than a separate flag, so a typed value that happens to match a standard
-        // league cleanly switches back to dropdown mode.
         const PRIVATE_LEAGUE_LABEL = 'Private League'
         const isPrivate = !leagueOptions.includes(activeLeague)
         return (
@@ -70,9 +63,6 @@ export function GeneralTab({ settings, update, updateProfile }: Props): JSX.Elem
                 value={isPrivate ? PRIVATE_LEAGUE_LABEL : activeLeague}
                 onChange={(e) => {
                   if (e.target.value === PRIVATE_LEAGUE_LABEL) {
-                    // First-time switch into private mode: clear so the input below
-                    // shows empty + placeholder. Re-selecting while already private
-                    // is a no-op (the typed value stays).
                     if (!isPrivate) updateProfile('league', '')
                   } else {
                     updateProfile('league', e.target.value)
@@ -100,3 +90,121 @@ export function GeneralTab({ settings, update, updateProfile }: Props): JSX.Elem
           </section>
         )
       })()}
+
+      {/* Update channel */}
+      <section>
+        <label>Update channel</label>
+        <div className="flex gap-1.5 mt-[6px]">
+          {(['stable', 'beta'] as const).map((ch) => (
+            <button
+              key={ch}
+              onClick={() => update('updateChannel', ch)}
+              className={`text-[11px] px-3 py-1.5 ${
+                settings.updateChannel === ch ? 'bg-accent text-bg-solid' : 'text-text-dim'
+              }`}
+            >
+              {ch === 'stable' ? 'Stable' : 'Beta'}
+            </button>
+          ))}
+        </div>
+        {settings.updateChannel === 'beta' && (
+          <div className="mt-2 flex flex-col gap-1.5">
+            <p className="text-[10px] text-text-dim">
+              Warning: expect beta releases to break stuff and be generally annoying. Please join discord to tell me
+              what to fix and watch me squirm
+            </p>
+            <a
+              href="https://discord.com/invite/nUNcrmEAP5"
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => {
+                e.preventDefault()
+                window.api.openExternal('https://discord.com/invite/nUNcrmEAP5')
+              }}
+              className="flex items-center justify-center gap-1.5 text-[11px] font-semibold px-3 py-1.5 rounded no-underline"
+              style={{ background: '#5865F2', color: '#fff' }}
+            >
+              Join Discord
+            </a>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <label>Filter sound preview volume</label>
+        <div className="flex items-center gap-[10px] mt-[2px]">
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={5}
+            value={Math.round((settings.previewVolume ?? 0.25) * 100)}
+            onChange={(e) => update('previewVolume', parseInt(e.target.value, 10) / 100)}
+            className="flex-1"
+          />
+          <span className="text-[13px] font-semibold text-text min-w-[36px] text-right">
+            {Math.round((settings.previewVolume ?? 0.25) * 100)}%
+          </span>
+        </div>
+      </section>
+
+      <section>
+        <label>Bug reports</label>
+        <div className="mt-[6px] flex flex-col gap-2">
+          <button onClick={reportBug} disabled={reporting} className="self-start text-[11px] px-3 py-1.5 text-text-dim">
+            {reporting ? 'Creating report...' : 'Report a bug'}
+          </button>
+          {reportMessage && <div className="text-[10px] text-text-dim break-all">{reportMessage}</div>}
+        </div>
+      </section>
+
+      {import.meta.env.DEV && (
+        <section>
+          <div className="settings-section-title mt-3">Dev Only Stuff</div>
+          <div className="flex gap-1.5 mt-[6px] flex-wrap">
+            <button
+              onClick={() => {
+                for (let i = localStorage.length - 1; i >= 0; i--) {
+                  const k = localStorage.key(i)
+                  if (k && k.startsWith('tip.')) localStorage.removeItem(k)
+                }
+                window.location.reload()
+              }}
+              className="text-[11px] px-3 py-1.5 text-text-dim"
+            >
+              Reset tooltips
+            </button>
+            <button
+              onClick={() => window.api.devFakeUpdate()}
+              className="text-[11px] px-3 py-1.5 text-text-dim"
+              title="Inject a fake update-available event so you can test the channel-switch rescind flow"
+            >
+              Fake update banner
+            </button>
+            <button
+              onClick={() =>
+                reportDiagnosticError(
+                  'renderer',
+                  'action',
+                  new Error('Simulated small renderer error from Dev Only Stuff'),
+                  'Dev Only Stuff: simulate a small error',
+                )
+              }
+              className="text-[11px] px-3 py-1.5 text-text-dim"
+              title="Report a handled diagnostics error without breaking the UI"
+            >
+              Simulate a small error
+            </button>
+            <button
+              onClick={() => setSimulateCrash(true)}
+              className="text-[11px] px-3 py-1.5 text-text-dim"
+              title="Throw during render so the diagnostics error boundary catches it"
+            >
+              Simulate a fatal crash
+            </button>
+          </div>
+        </section>
+      )}
+    </>
+  )
+}

--- a/src/renderer/src/components/settings/MacrosTab.tsx
+++ b/src/renderer/src/components/settings/MacrosTab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import type { AppSettings, RegexPreset } from '../../../../shared/types'
+import type { AppSettings, RegexPreset, RuntimeSettings } from '../../../../shared/types'
 import { Toggle } from '../Toggle'
 import { RemoveButton } from '../RemoveButton'
 import { HotkeyRecorder } from './HotkeyRecorder'
@@ -28,7 +28,7 @@ function getMacroTags(presets: RegexPreset[]): string[] {
 }
 
 interface Props {
-  settings: AppSettings
+  settings: RuntimeSettings
   update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
   tryHotkey: (hotkey: string, slot: { kind: 'chat'; index: number } | { kind: 'appmacro'; index: number }) => boolean
 }

--- a/src/renderer/src/components/settings/PriceCheckTab.tsx
+++ b/src/renderer/src/components/settings/PriceCheckTab.tsx
@@ -14,10 +14,11 @@ import { SettingToggleBox } from './SettingToggleBox'
 interface Props {
   settings: AppSettings
   update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
+  updateProfile: (key: 'tradePriceOption', value: unknown) => Promise<void>
   tryHotkey: (hotkey: string, slot: { kind: 'pricecheck' }) => boolean
 }
 
-export function PriceCheckTab({ settings, update, tryHotkey }: Props): JSX.Element {
+export function PriceCheckTab({ settings, update, updateProfile, tryHotkey }: Props): JSX.Element {
   return (
     <>
       <div className="settings-section-title mt-3">Trade Settings</div>
@@ -55,9 +56,9 @@ export function PriceCheckTab({ settings, update, tryHotkey }: Props): JSX.Eleme
         />
         <SettingSelectBox
           label="Buyout currency"
-          value={settings.tradePriceOption ?? (settings.poeVersion === 2 ? 'exalted_divine' : 'chaos_divine')}
+          value={settings.activeProfile?.tradePriceOption ?? (settings.poeVersion === 2 ? 'exalted_divine' : 'chaos_divine')}
           options={getPriceOptions(settings.poeVersion ?? 1)}
-          onChange={(v) => update('tradePriceOption', v)}
+          onChange={(v) => updateProfile('tradePriceOption', v)}
         />
         <SettingSelectBox
           label="Listing time"

--- a/src/renderer/src/components/settings/PriceCheckTab.tsx
+++ b/src/renderer/src/components/settings/PriceCheckTab.tsx
@@ -1,4 +1,4 @@
-import type { AppSettings } from '../../../../shared/types'
+import type { AppSettings, ProfileSettingValue, RuntimeSettings } from '../../../../shared/types'
 import { PoeLoginButton } from './PoeLoginButton'
 import { HotkeyField } from './HotkeyField'
 import {
@@ -12,9 +12,9 @@ import { SettingSelectBox } from './SettingSelectBox'
 import { SettingToggleBox } from './SettingToggleBox'
 
 interface Props {
-  settings: AppSettings
+  settings: RuntimeSettings
   update: <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => void
-  updateProfile: (key: 'tradePriceOption', value: unknown) => Promise<void>
+  updateProfile: <K extends 'tradePriceOption'>(key: K, value: ProfileSettingValue<K>) => Promise<void>
   tryHotkey: (hotkey: string, slot: { kind: 'pricecheck' }) => boolean
 }
 
@@ -56,7 +56,9 @@ export function PriceCheckTab({ settings, update, updateProfile, tryHotkey }: Pr
         />
         <SettingSelectBox
           label="Buyout currency"
-          value={settings.activeProfile?.tradePriceOption ?? (settings.poeVersion === 2 ? 'exalted_divine' : 'chaos_divine')}
+          value={
+            settings.activeProfile?.tradePriceOption ?? (settings.poeVersion === 2 ? 'exalted_divine' : 'chaos_divine')
+          }
           options={getPriceOptions(settings.poeVersion ?? 1)}
           onChange={(v) => updateProfile('tradePriceOption', v)}
         />

--- a/src/renderer/src/components/settings/hotkey-collisions.test.ts
+++ b/src/renderer/src/components/settings/hotkey-collisions.test.ts
@@ -1,15 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import { findHotkeyCollision, narrowScopeForCrossGameConflict } from './hotkey-collisions'
-import type { AppSettings } from '../../../../shared/types'
+import type { RuntimeSettings } from '../../../../shared/types'
 
-function makeSettings(overrides: Partial<AppSettings> = {}): AppSettings {
+function makeSettings(overrides: Partial<RuntimeSettings> = {}): RuntimeSettings {
   return {
     hotkey: '',
     priceCheckHotkey: '',
     chatCommands: [],
     appMacros: [],
+    activeProfile: null,
     ...overrides,
-  } as AppSettings
+  } as RuntimeSettings
 }
 
 describe('findHotkeyCollision - scope-aware', () => {

--- a/src/renderer/src/components/settings/hotkey-collisions.ts
+++ b/src/renderer/src/components/settings/hotkey-collisions.ts
@@ -1,4 +1,4 @@
-import type { AppSettings } from '../../../../shared/types'
+import type { RuntimeSettings } from '../../../../shared/types'
 import {
   chatCommandEffectiveScope,
   appMacroEffectiveScope,
@@ -37,7 +37,7 @@ interface SlotEntry {
   scope: MacroScope
 }
 
-function buildSlots(settings: AppSettings): SlotEntry[] {
+function buildSlots(settings: RuntimeSettings): SlotEntry[] {
   const cheatSheets = settings.activeProfile?.cheatSheets
   return [
     { slot: { kind: 'filter' }, value: settings.hotkey ?? '', scope: 'both' },
@@ -61,7 +61,7 @@ function buildSlots(settings: AppSettings): SlotEntry[] {
           },
         ]
       : []),
-    ...(cheatSheets?.categories ?? []).map<SlotEntry>((cat, i) => ({
+    ...(cheatSheets?.categories ?? []).map<SlotEntry>((cat: { hotkey?: string; name: string }, i: number) => ({
       slot: { kind: 'cheatsheet-category', index: i },
       value: cat.hotkey ?? '',
       label: `Cheat sheet: ${cat.name}`,
@@ -77,7 +77,7 @@ function buildSlots(settings: AppSettings): SlotEntry[] {
  * other game are invisible here so the user can reuse the key.
  */
 export function findHotkeyCollision(
-  settings: AppSettings,
+  settings: RuntimeSettings,
   hotkey: string,
   excluding: HotkeySlot,
   currentGame: 1 | 2,
@@ -101,7 +101,7 @@ export function findHotkeyCollision(
  * collision already caught by findHotkeyCollision).
  */
 export function narrowScopeForCrossGameConflict(
-  settings: AppSettings,
+  settings: RuntimeSettings,
   hotkey: string,
   excluding: HotkeySlot,
   currentGame: 1 | 2,

--- a/src/renderer/src/components/settings/hotkey-collisions.ts
+++ b/src/renderer/src/components/settings/hotkey-collisions.ts
@@ -38,7 +38,7 @@ interface SlotEntry {
 }
 
 function buildSlots(settings: AppSettings): SlotEntry[] {
-  const cheatSheets = settings.cheatSheets
+  const cheatSheets = settings.activeProfile?.cheatSheets
   return [
     { slot: { kind: 'filter' }, value: settings.hotkey ?? '', scope: 'both' },
     { slot: { kind: 'pricecheck' }, value: settings.priceCheckHotkey ?? '', scope: 'both' },

--- a/src/renderer/src/features/profiles/ProfileManagerTab.stories.tsx
+++ b/src/renderer/src/features/profiles/ProfileManagerTab.stories.tsx
@@ -1,0 +1,173 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useEffect, useState } from 'react'
+import type { PoeProfileSummary, RuntimeSettings } from '../../../../shared/types'
+import { ProfileManagerTab } from './ProfileManagerTab'
+
+function profile(
+  input: Partial<PoeProfileSummary> & Pick<PoeProfileSummary, 'id' | 'name' | 'gameVariant'>,
+): PoeProfileSummary {
+  return {
+    league: input.gameVariant === 2 ? 'Fate of the Vaal' : 'Mirage',
+    filterDir: '',
+    filterPath: '',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    active: false,
+    ...input,
+  }
+}
+
+function settings(input: Partial<RuntimeSettings> = {}): RuntimeSettings {
+  return {
+    poeVersion: 1,
+    activeProfileId: 'poe1',
+    lastProfileIdPoe1: 'poe1',
+    lastProfileIdPoe2: 'poe2',
+    activeProfile: null,
+    onboardingCompleted: true,
+    hotkey: '',
+    priceCheckHotkey: '',
+    overlayOpacity: 0.95,
+    overlayScale: 1,
+    openSide: 'both',
+    closeOnClickOutside: false,
+    useCurrentZoneAreaLevel: false,
+    reloadOnSave: true,
+    updateChannel: 'stable',
+    tradeStatus: 'available',
+    priceCheckDefaultPercent: 90,
+    tradeDefaultToBase: false,
+    chatCommands: [],
+    appMacros: [],
+    stashScrollEnabled: false,
+    regexPresetsPoe1: [],
+    regexPresetsPoe2: [],
+    leaguesPoe1: [],
+    leaguesPoe2: [],
+    themeId: 'default',
+    customThemePalette: null,
+    ...input,
+  } as RuntimeSettings
+}
+
+function ProfileManagerStoryboard({
+  initialProfiles,
+  initialSettings,
+  autoOpenRename = false,
+}: {
+  initialProfiles: PoeProfileSummary[]
+  initialSettings: RuntimeSettings
+  autoOpenRename?: boolean
+}): JSX.Element {
+  const [profiles, setProfiles] = useState(initialProfiles)
+  const [currentSettings, setCurrentSettings] = useState(initialSettings)
+
+  ;(window as unknown as { api: Partial<typeof window.api> }).api = {
+    listProfiles: async () => profiles,
+    renameProfile: async (id: string, name: string) => {
+      let renamed: PoeProfileSummary | null = null
+      setProfiles((prev) =>
+        prev.map((p) => {
+          if (p.id !== id) return p
+          renamed = { ...p, name }
+          return renamed
+        }),
+      )
+      return renamed
+    },
+    createProfile: async ({ name, gameVariant }) => {
+      const created = profile({ id: crypto.randomUUID(), name, gameVariant })
+      setProfiles((prev) => [...prev, created])
+      return created
+    },
+    duplicateProfile: async (id: string, name: string) => {
+      const source = profiles.find((p) => p.id === id) ?? profile({ id, name, gameVariant: 1 })
+      const created = { ...source, id: crypto.randomUUID(), name, active: false }
+      setProfiles((prev) => [...prev, created])
+      return created
+    },
+    deleteProfile: async (id: string) => {
+      setProfiles((prev) => prev.filter((p) => p.id !== id))
+    },
+    getSettings: async () => currentSettings,
+    setActiveProfile: async (id: string) => {
+      const selected = profiles.find((p) => p.id === id)
+      if (!selected) return { ok: false, error: 'Profile not found' }
+      if (selected.gameVariant !== currentSettings.poeVersion) {
+        return { ok: false, requiresRestart: true, targetGame: selected.gameVariant }
+      }
+      const next = { ...currentSettings, activeProfileId: id }
+      setCurrentSettings(next)
+      setProfiles((prev) => prev.map((p) => ({ ...p, active: p.id === id })))
+      return { ok: true, settings: next }
+    },
+  }
+
+  useEffect(() => {
+    if (!autoOpenRename) return
+    const timer = window.setTimeout(() => {
+      const rename = Array.from(document.querySelectorAll('button')).find((button) => button.textContent === 'Rename')
+      rename?.click()
+    }, 50)
+    return () => window.clearTimeout(timer)
+  }, [autoOpenRename])
+
+  return (
+    <div className="w-[430px] bg-bg-solid text-text p-4">
+      <ProfileManagerTab settings={currentSettings} onSettingsChange={setCurrentSettings} onEditProfile={() => {}} />
+    </div>
+  )
+}
+
+const poe1 = profile({
+  id: 'poe1',
+  name: 'League Start Mapper',
+  gameVariant: 1,
+  league: 'Mirage',
+  filterPath: 'C:\\Filters\\mapper.filter',
+  active: true,
+})
+const poe2 = profile({
+  id: 'poe2',
+  name: 'PoE2 Boss Rush',
+  gameVariant: 2,
+  league: 'Fate of the Vaal',
+  filterPath: 'C:\\Filters\\poe2-boss.filter',
+})
+
+const meta: Meta<typeof ProfileManagerStoryboard> = {
+  title: 'Profiles / ProfileManagerTab',
+  component: ProfileManagerStoryboard,
+}
+export default meta
+
+type Story = StoryObj<typeof ProfileManagerStoryboard>
+
+export const Empty: Story = {
+  args: {
+    initialProfiles: [],
+    initialSettings: settings({ activeProfileId: '' }),
+  },
+}
+
+export const ActiveProfile: Story = {
+  args: {
+    initialProfiles: [poe1],
+    initialSettings: settings({ activeProfileId: 'poe1' }),
+  },
+}
+
+export const CrossGameRestart: Story = {
+  args: {
+    initialProfiles: [poe1, poe2],
+    initialSettings: settings({ poeVersion: 1, activeProfileId: 'poe1' }),
+  },
+}
+
+export const InlineRename: Story = {
+  args: {
+    initialProfiles: [poe1, poe2],
+    initialSettings: settings({ poeVersion: 1, activeProfileId: 'poe1' }),
+    autoOpenRename: true,
+  },
+}

--- a/src/renderer/src/features/profiles/ProfileManagerTab.test.tsx
+++ b/src/renderer/src/features/profiles/ProfileManagerTab.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PoeProfileSummary, RuntimeSettings } from '../../../../shared/types'
+import { ProfileManagerTab } from './ProfileManagerTab'
+
+function profile(
+  input: Partial<PoeProfileSummary> & Pick<PoeProfileSummary, 'id' | 'name' | 'gameVariant'>,
+): PoeProfileSummary {
+  return {
+    league: input.gameVariant === 2 ? 'Fate of the Vaal' : 'Mirage',
+    filterDir: '',
+    filterPath: '',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    active: false,
+    ...input,
+  }
+}
+
+function settings(input: Partial<RuntimeSettings> = {}): RuntimeSettings {
+  return {
+    poeVersion: 1,
+    activeProfileId: 'poe1',
+    lastProfileIdPoe1: 'poe1',
+    lastProfileIdPoe2: 'poe2',
+    activeProfile: null,
+    onboardingCompleted: true,
+    hotkey: '',
+    priceCheckHotkey: '',
+    overlayOpacity: 0.95,
+    overlayScale: 1,
+    openSide: 'both',
+    closeOnClickOutside: false,
+    useCurrentZoneAreaLevel: false,
+    reloadOnSave: true,
+    updateChannel: 'stable',
+    tradeStatus: 'available',
+    priceCheckDefaultPercent: 90,
+    tradeDefaultToBase: false,
+    chatCommands: [],
+    appMacros: [],
+    stashScrollEnabled: false,
+    regexPresetsPoe1: [],
+    regexPresetsPoe2: [],
+    leaguesPoe1: [],
+    leaguesPoe2: [],
+    themeId: 'default',
+    customThemePalette: null,
+    ...input,
+  } as RuntimeSettings
+}
+
+function installApi(profiles: PoeProfileSummary[]): void {
+  ;(window as unknown as { api: Partial<typeof window.api> }).api = {
+    listProfiles: vi.fn(async () => profiles),
+    renameProfile: vi.fn(async (id: string, name: string) => {
+      const existing = profiles.find((p) => p.id === id)
+      if (!existing) return null
+      existing.name = name
+      return existing
+    }),
+    createProfile: vi.fn(),
+    duplicateProfile: vi.fn(),
+    deleteProfile: vi.fn(),
+    getSettings: vi.fn(),
+    setActiveProfile: vi.fn(),
+  }
+}
+
+describe('ProfileManagerTab', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    const storage = new Map<string, string>()
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        setItem: (key: string, value: string) => storage.set(key, value),
+        removeItem: (key: string) => storage.delete(key),
+      },
+    })
+  })
+
+  it('opens an inline rename editor and saves the new profile name', async () => {
+    const profiles = [profile({ id: 'poe1', name: 'Atlas Mapper', gameVariant: 1, active: true })]
+    installApi(profiles)
+
+    render(<ProfileManagerTab settings={settings()} onSettingsChange={vi.fn()} onEditProfile={vi.fn()} />)
+
+    await screen.findByText('Atlas Mapper')
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+
+    const input = screen.getByDisplayValue('Atlas Mapper')
+    fireEvent.change(input, { target: { value: 'Boss Rush' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    await waitFor(() => expect(window.api.renameProfile).toHaveBeenCalledWith('poe1', 'Boss Rush'))
+    expect(await screen.findByText('Boss Rush')).toBeInTheDocument()
+  })
+
+  it('validates empty draft names before saving', async () => {
+    const profiles = [profile({ id: 'poe1', name: 'Atlas Mapper', gameVariant: 1, active: true })]
+    installApi(profiles)
+
+    render(<ProfileManagerTab settings={settings()} onSettingsChange={vi.fn()} onEditProfile={vi.fn()} />)
+
+    await screen.findByText('Atlas Mapper')
+    fireEvent.click(screen.getByRole('button', { name: 'Rename' }))
+    fireEvent.change(screen.getByDisplayValue('Atlas Mapper'), { target: { value: '   ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(await screen.findByText('Profile name is required.')).toBeInTheDocument()
+    expect(window.api.renameProfile).not.toHaveBeenCalled()
+  })
+
+  it('applies dev restart-to-switch settings after one confirmed click', async () => {
+    const profiles = [
+      profile({ id: 'poe1', name: 'PoE1 mapper', gameVariant: 1, active: true }),
+      profile({ id: 'poe2', name: 'PoE2 mapper', gameVariant: 2 }),
+    ]
+    installApi(profiles)
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    const nextSettings = settings({ poeVersion: 2, activeProfileId: 'poe2' })
+    vi.mocked(window.api.setActiveProfile)
+      .mockResolvedValueOnce({ ok: false, requiresRestart: true, targetGame: 2 })
+      .mockImplementationOnce(async () => {
+        profiles[0].active = false
+        profiles[1].active = true
+        return { ok: true, settings: nextSettings, devRestartRequired: true }
+      })
+    const onSettingsChange = vi.fn()
+
+    render(<ProfileManagerTab settings={settings()} onSettingsChange={onSettingsChange} onEditProfile={vi.fn()} />)
+
+    await screen.findByText('PoE2 mapper')
+    fireEvent.click(screen.getByRole('button', { name: 'Restart to Switch' }))
+
+    await waitFor(() => expect(onSettingsChange).toHaveBeenCalledWith(nextSettings))
+    expect(window.api.setActiveProfile).toHaveBeenCalledTimes(2)
+    expect(
+      await screen.findByText('Profile selected. Restart the dev app to attach to the selected game.'),
+    ).toBeInTheDocument()
+  })
+
+  it('delegates Edit clicks to the app-level route handler', async () => {
+    const profiles = [profile({ id: 'poe1', name: 'Atlas Mapper', gameVariant: 1, active: true })]
+    installApi(profiles)
+    const onEditProfile = vi.fn()
+
+    render(<ProfileManagerTab settings={settings()} onSettingsChange={vi.fn()} onEditProfile={onEditProfile} />)
+
+    await screen.findByText('Atlas Mapper')
+    fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
+
+    expect(onEditProfile).toHaveBeenCalledWith(profiles[0])
+  })
+})

--- a/src/renderer/src/features/profiles/ProfileManagerTab.tsx
+++ b/src/renderer/src/features/profiles/ProfileManagerTab.tsx
@@ -136,6 +136,8 @@ export function ProfileManagerTab({
           </DismissibleTip>
         )}
 
+        {error && !draft && <p className="text-[11px] text-red-300 m-0">{error}</p>}
+
         {draft && (
           <section className="rounded border border-border bg-black/20 px-3 py-3 flex flex-col gap-3">
             <label className="text-[11px] text-text-dim">

--- a/src/renderer/src/features/profiles/ProfileManagerTab.tsx
+++ b/src/renderer/src/features/profiles/ProfileManagerTab.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
-import type { GameVariant, PoeProfileSummary, RuntimeSettings } from '../../../shared/types'
-import { DismissibleTip } from '../shared/DismissibleTip'
-import { StepHeader } from './StepHeader'
+import type { GameVariant, PoeProfileSummary, RuntimeSettings } from '../../../../shared/types'
+import { DismissibleTip } from '../../shared/DismissibleTip'
 
 function filterName(profile: PoeProfileSummary): string {
   return profile.filterPath ? profile.filterPath.replace(/^.*[\\/]/, '') : 'No filter selected'
@@ -16,16 +15,14 @@ function defaultProfileName(variant: GameVariant): string {
   return variant === 2 ? 'PoE2 profile' : 'PoE1 profile'
 }
 
-export function ProfileManagerStep({
+export function ProfileManagerTab({
   settings,
   onSettingsChange,
   onEditProfile,
-  onFinish,
 }: {
   settings: RuntimeSettings
   onSettingsChange: (settings: RuntimeSettings) => void
   onEditProfile: (profile: PoeProfileSummary) => void
-  onFinish: () => void
 }): JSX.Element {
   const [profiles, setProfiles] = useState<PoeProfileSummary[]>([])
   const [switchedFilterName, setSwitchedFilterName] = useState<string | null>(null)
@@ -125,11 +122,11 @@ export function ProfileManagerStep({
   ]
 
   return (
-    <div>
-      <StepHeader
-        title="Manage Profiles"
-        subtitle="Create a named setup for each league, character, or filter context you want to switch back to later."
-      />
+    <>
+      <div className="settings-section-title mt-3">Profiles</div>
+      <p className="text-[11px] text-text-dim m-0 -mt-2">
+        Create a named setup for each league, character, or filter context you want to switch back to later.
+      </p>
 
       <div className="flex flex-col gap-5">
         {switchedFilterName && (
@@ -234,13 +231,6 @@ export function ProfileManagerStep({
           )
         })}
       </div>
-
-      <div className="flex gap-[10px] mt-8">
-        <div className="flex-1" />
-        <button className="primary px-6 py-[10px] text-[13px] font-semibold" onClick={onFinish}>
-          Finish
-        </button>
-      </div>
-    </div>
+    </>
   )
 }

--- a/src/renderer/src/overlay/App.tsx
+++ b/src/renderer/src/overlay/App.tsx
@@ -723,9 +723,9 @@ export default function App(): JSX.Element {
   // don't have a ninja price entry for this item -- ninja's PoE2 catalogue is
   // incomplete and items absent from it 404 on the deep link.
   const ninjaLinkHandler = (item: PoeItem | undefined, priceInfo: PriceInfo | undefined): (() => void) | undefined => {
-    if (!item || !poeVersion || !settings?.league || !priceInfo) return undefined
+    if (!item || !poeVersion || !settings?.activeProfile?.league || !priceInfo) return undefined
     const leagueSlugMap = getManifest().ninjaLeagues[poeVersion === 1 ? 'poe1' : 'poe2']
-    const url = ninjaLinkUrl(item, poeVersion, settings.league, leagueSlugMap, priceInfo)
+    const url = ninjaLinkUrl(item, poeVersion, settings.activeProfile.league, leagueSlugMap, priceInfo)
     if (!url) return undefined
     return () => window.api.openExternal(url)
   }
@@ -861,9 +861,9 @@ export default function App(): JSX.Element {
               }}
             />
 
-            {view === 'item' && settings?.filterPath && (
+            {view === 'item' && settings?.activeProfile?.filterPath && (
               <FilterInfoBanner
-                filterPath={settings.filterPath}
+                filterPath={settings.activeProfile.filterPath}
                 updatedOnlineFilters={updatedOnlineFilters}
                 checkingUpdate={checkingUpdate}
                 updatingFilter={updatingFilter}

--- a/src/renderer/src/overlay/App.tsx
+++ b/src/renderer/src/overlay/App.tsx
@@ -916,7 +916,18 @@ export default function App(): JSX.Element {
                 />
               )}
               {view === 'no-filter' && (
-                <Notice icon="⚠" title="No filter loaded" body="Click ⚙ to select your .filter file." />
+                <Notice
+                  icon="⚠"
+                  title="No filter loaded"
+                  body="Select your .filter file to get started."
+                  action={{
+                    label: 'Open Filter Settings',
+                    onClick: () => {
+                      setSettingsTabRequest({ tab: 'filter', n: Date.now() })
+                      setView('setup')
+                    },
+                  }}
+                />
               )}
               {view === 'no-item' && (
                 <>

--- a/src/renderer/src/overlay/App.tsx
+++ b/src/renderer/src/overlay/App.tsx
@@ -217,10 +217,7 @@ export default function App(): JSX.Element {
     [],
   )
   const onSubscribeLeagueChange = useCallback(
-    (h: (l: string) => void): (() => void) =>
-      window.api.onSettingUpdated((k, v) => {
-        if (k === 'league' && typeof v === 'string') h(v)
-      }),
+    (h: (l: string) => void): (() => void) => window.api.onLeagueUpdated((league) => h(league)),
     [],
   )
 

--- a/src/renderer/src/overlay/App.tsx
+++ b/src/renderer/src/overlay/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import { PluginHost } from '../plugins/PluginHost'
 import { PluginTabHost } from '../plugins/PluginTabHost'
 import type { RegisteredTab } from '../plugins/PluginHost'
-import type { AppSettings, OverlayData, PoeItem, PriceInfo } from '../../../shared/types'
+import type { RuntimeSettings, OverlayData, PoeItem, PriceInfo } from '../../../shared/types'
 import { isHideableTabKey } from '../../../shared/types'
 import type { ExternalLinkTarget } from '../../../shared/external-link'
 import { externalLinkUrl, ninjaLinkUrl } from '../../../shared/external-link'
@@ -78,7 +78,7 @@ export default function App(): JSX.Element {
   const showAnimDone = useRef(false)
   const [overlayData, setOverlayData] = useState<OverlayData | null>(null)
   const [searchId, setSearchId] = useState(0)
-  const [settings, setSettings] = useState<AppSettings | null>(null)
+  const [settings, setSettings] = useState<RuntimeSettings | null>(null)
   const [gameBounds, setGameBounds] = useState<{ gameWidth: number; gameHeight: number; sidebarWidth: number } | null>(
     null,
   )
@@ -739,7 +739,7 @@ export default function App(): JSX.Element {
           itemClass={tierSisterData?.itemClass ?? overlayData.item.itemClass}
           currentBaseType={overlayData.item.baseType}
           currentRarity={overlayData.item.rarity}
-          league={settings?.league ?? ''}
+          league={settings?.activeProfile?.league ?? ''}
           uniqueTier={tierSisterData?.uniqueTier}
           left={sisterLeft}
           top={PANEL_TOP + SISTER_NAV_OFFSET}
@@ -1038,7 +1038,7 @@ export default function App(): JSX.Element {
       <PluginHost
         ready={poeVersion !== null}
         poeVersion={poeVersion ?? 1}
-        league={settings?.league ?? ''}
+        league={settings?.activeProfile?.league ?? ''}
         currentItem={overlayData?.item ?? null}
         currentZone={currentZone}
         onSubscribeCurrentItem={onSubscribeCurrentItem}

--- a/src/renderer/src/overlay/Notice.tsx
+++ b/src/renderer/src/overlay/Notice.tsx
@@ -1,11 +1,26 @@
 import type { ReactNode } from 'react'
 
-export function Notice({ icon, title, body }: { icon: ReactNode; title: string; body: string }): JSX.Element {
+export function Notice({
+  icon,
+  title,
+  body,
+  action,
+}: {
+  icon: ReactNode
+  title: string
+  body: string
+  action?: { label: string; onClick: () => void }
+}): JSX.Element {
   return (
     <div className="p-6 text-center text-text-dim">
       <div className="text-[32px] mb-3 flex justify-center">{icon}</div>
       <div className="text-text font-semibold mb-1.5">{title}</div>
       <div className="text-xs">{body}</div>
+      {action && (
+        <button className="primary mt-4 px-5 py-[8px] text-[12px] font-semibold" onClick={action.onClick}>
+          {action.label}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/renderer/src/pinned-zone/App.tsx
+++ b/src/renderer/src/pinned-zone/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import type { AppSettings, CheatSheetCategory } from '../../../shared/types'
+import type { CheatSheetCategory, RuntimeSettings } from '../../../shared/types'
 import { useStickyZone } from '../shared/use-current-zone'
 
 export function App(): JSX.Element | null {
@@ -7,16 +7,13 @@ export function App(): JSX.Element | null {
   const currentZone = useStickyZone()
   const rootRef = useRef<HTMLDivElement>(null)
 
-  // Load categories from settings, subscribe to updates. The flat cheatSheets
-  // field always mirrors the active game's per-version slot (see MIRROR_KEYS
-  // in settings-write.ts), so we read it for both initial load and updates.
   useEffect(() => {
-    void window.api.getSettings().then((s: AppSettings) => {
-      setCategories(s.cheatSheets.categories)
+    void window.api.getSettings().then((s: RuntimeSettings) => {
+      setCategories(s.activeProfile?.cheatSheets.categories ?? [])
     })
     return window.api.onSettingUpdated((key, value) => {
-      if (key === 'cheatSheets') {
-        setCategories((value as AppSettings['cheatSheets']).categories)
+      if (key === 'activeProfile') {
+        setCategories((value as RuntimeSettings['activeProfile'])?.cheatSheets.categories ?? [])
       }
     })
   }, [])

--- a/src/renderer/src/shared/apply-theme.test.ts
+++ b/src/renderer/src/shared/apply-theme.test.ts
@@ -9,27 +9,36 @@ const SAMPLE_A = NON_DEFAULT[0]
 const SAMPLE_B = NON_DEFAULT[1]
 if (!SAMPLE_A || !SAMPLE_B) throw new Error('test requires >=2 non-default presets')
 
-function installLocalStorageMock(): void {
-  const store = new Map<string, string>()
-  Object.defineProperty(window, 'localStorage', {
-    configurable: true,
-    value: {
-      clear: () => store.clear(),
-      getItem: (key: string) => store.get(key) ?? null,
-      removeItem: (key: string) => {
-        store.delete(key)
-      },
-      setItem: (key: string, value: string) => {
-        store.set(key, value)
-      },
-    },
-  })
+// Vitest environmentMatchGlobs may run this in Node; always stub DOM globals
+const store = new Map<string, string>()
+const storageStub = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => {
+    store.set(k, v)
+  },
+  removeItem: (k: string) => {
+    store.delete(k)
+  },
+  clear: () => {
+    store.clear()
+  },
+  get length() {
+    return store.size
+  },
+  key: (i: number) => [...store.keys()][i] ?? null,
+}
+if (typeof localStorage === 'undefined' || typeof (localStorage as any).clear !== 'function') {
+  ;(globalThis as any).localStorage = storageStub
+}
+if (typeof document === 'undefined') {
+  ;(globalThis as any).document = { documentElement: {} as any }
 }
 
 beforeEach(() => {
-  installLocalStorageMock()
   localStorage.clear()
-  document.documentElement.removeAttribute('style')
+  if (document?.documentElement) {
+    document.documentElement.removeAttribute('style')
+  }
 })
 
 describe('applyPalette', () => {

--- a/src/renderer/src/shared/apply-theme.test.ts
+++ b/src/renderer/src/shared/apply-theme.test.ts
@@ -11,7 +11,7 @@ if (!SAMPLE_A || !SAMPLE_B) throw new Error('test requires >=2 non-default prese
 
 // Vitest environmentMatchGlobs may run this in Node; always stub DOM globals
 const store = new Map<string, string>()
-const storageStub = {
+const storageStub: Storage = {
   getItem: (k: string) => store.get(k) ?? null,
   setItem: (k: string, v: string) => {
     store.set(k, v)
@@ -27,11 +27,21 @@ const storageStub = {
   },
   key: (i: number) => [...store.keys()][i] ?? null,
 }
-if (typeof localStorage === 'undefined' || typeof (localStorage as any).clear !== 'function') {
-  ;(globalThis as any).localStorage = storageStub
+if (typeof localStorage === 'undefined' || typeof localStorage.clear !== 'function') {
+  Object.defineProperty(globalThis, 'localStorage', { value: storageStub, configurable: true })
 }
 if (typeof document === 'undefined') {
-  ;(globalThis as any).document = { documentElement: {} as any }
+  const style = new Map<string, string>()
+  const documentStub = {
+    documentElement: {
+      removeAttribute: () => style.clear(),
+      style: {
+        setProperty: (key: string, value: string) => style.set(key, value),
+        getPropertyValue: (key: string) => style.get(key) ?? '',
+      },
+    },
+  } as unknown as Document
+  Object.defineProperty(globalThis, 'document', { value: documentStub, configurable: true })
 }
 
 beforeEach(() => {

--- a/src/renderer/src/shared/poe-version-context.tsx
+++ b/src/renderer/src/shared/poe-version-context.tsx
@@ -1,16 +1,23 @@
 import { createContext, useContext, type ReactNode } from 'react'
+import type { GameVariant } from '../../../shared/types'
 
 /** React context for the current PoE game version. Reading via usePoeVersion()
  *  avoids prop-drilling through deep trees (overlay -> FilterPanel -> ItemSummary
  *  -> PriceChip, etc.). Version is stable for the process lifetime since game
  *  switches trigger app.relaunch, so consumers don't need memoization. Default
  *  is 1 to keep legacy renders working if a caller forgets the provider. */
-const PoeVersionContext = createContext<1 | 2>(1)
+const PoeVersionContext = createContext<GameVariant>(1)
 
-export function PoeVersionProvider({ version, children }: { version: 1 | 2 | null; children: ReactNode }): JSX.Element {
+export function PoeVersionProvider({
+  version,
+  children,
+}: {
+  version: GameVariant | null
+  children: ReactNode
+}): JSX.Element {
   return <PoeVersionContext.Provider value={version ?? 1}>{children}</PoeVersionContext.Provider>
 }
 
-export function usePoeVersion(): 1 | 2 {
+export function usePoeVersion(): GameVariant {
   return useContext(PoeVersionContext)
 }

--- a/src/shared/game-features.ts
+++ b/src/shared/game-features.ts
@@ -31,7 +31,9 @@ export interface GameFeatures {
   filterFolderHint: string
 }
 
-const FEATURES_BY_VERSION: Record<1 | 2, GameFeatures> = {
+import type { GameVariant } from './types'
+
+const FEATURES_BY_VERSION: Record<GameVariant, GameFeatures> = {
   1: {
     dustExplorer: true,
     divCards: true,
@@ -56,6 +58,6 @@ const FEATURES_BY_VERSION: Record<1 | 2, GameFeatures> = {
 
 /** Pure lookup -- when `version` is null (initial load, detection race) we fall
  *  back to PoE1 since that's the default-attached game. */
-export function getGameFeatures(version: 1 | 2 | null): GameFeatures {
+export function getGameFeatures(version: GameVariant | null): GameFeatures {
   return FEATURES_BY_VERSION[version ?? 1]
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3,6 +3,20 @@
 import type { MacroScope } from './macro-scope'
 import type { ThemePalette } from './theme/palette'
 
+export type GameVariant = 1 | 2
+
+export interface PoeProfile {
+  id: string
+  name: string
+  gameVariant: GameVariant
+  filterDir: string
+  filterPath: string
+  league: string
+  tradePriceOption: TradePriceOption
+  cheatSheets: CheatSheetsSettings
+  regexPresets: RegexPreset[]
+}
+
 export type Visibility = 'Show' | 'Hide' | 'Minimal'
 export type ComparisonOperator = '>' | '>=' | '=' | '==' | '<=' | '<'
 
@@ -362,6 +376,15 @@ export interface CheatSheetsSettings {
 /** Adaptive price-check defaults learning engine mode. */
 export type AdaptiveMode = 'eager' | 'conservative' | 'off'
 
+export type TradePriceOption =
+  | 'chaos_divine'
+  | 'chaos_equivalent'
+  | 'chaos'
+  | 'divine'
+  | 'exalted_divine'
+  | 'exalted_equivalent'
+  | 'exalted'
+
 export interface AppSettings {
   /** Active filter path + dir + league. Mirrored to/from the per-version fields
    *  (filterPathPoe1, filterPathPoe2, etc.) based on the current poeVersion at
@@ -407,16 +430,9 @@ export interface AppSettings {
   tradeCollapseListings?: boolean
   /** Volume (0.0-1.0) for the filter sound preview button. */
   previewVolume?: number
-  tradePriceOption:
-    | 'chaos_divine'
-    | 'chaos_equivalent'
-    | 'chaos'
-    | 'divine'
-    | 'exalted_divine'
-    | 'exalted_equivalent'
-    | 'exalted'
-  tradePriceOptionPoe1: AppSettings['tradePriceOption']
-  tradePriceOptionPoe2: AppSettings['tradePriceOption']
+  tradePriceOption: TradePriceOption
+  tradePriceOptionPoe1: TradePriceOption
+  tradePriceOptionPoe2: TradePriceOption
   /** Default "Listed" time for price-check searches. Empty string = any time. */
   tradeDefaultListedTime?:
     | ''
@@ -442,7 +458,7 @@ export interface AppSettings {
   cheatSheetsPoe1: CheatSheetsSettings
   cheatSheetsPoe2: CheatSheetsSettings
   stashScrollEnabled: boolean
-  poeVersion: 1 | 2
+  poeVersion: GameVariant
   /** Regex presets are persisted per game. Each session reads/writes the slot
    *  matching `poeVersion` -- the relaunch-on-switch flow guarantees the active
    *  version is stable for the lifetime of the process. */
@@ -467,6 +483,16 @@ export interface AppSettings {
    *  before changing a default; 'off' stops applying learned defaults but keeps
    *  recording so re-enabling is never cold-start. */
   adaptiveDefaultsMode: AdaptiveMode
+  /** UUID of the active profile (loaded from profiles/ dir). */
+  activeProfileId: string
+  /** True once the user clicks Finish in the onboarding wizard. */
+  onboardingCompleted: boolean
+  /** Onboarding resume: current step key (saved on every step transition). */
+  onboardingStep?: string
+  /** Onboarding resume: which games the user selected on the welcome screen. */
+  onboardingSelectedGames?: { poe1: boolean; poe2: boolean }
+  /** Onboarding resume: name of the online filter imported per game, if any. */
+  onboardingImportedOnline?: { poe1: string | null; poe2: string | null }
 }
 
 /** Title-bar tab keys the user is allowed to hide via View settings. Settings + Close

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,15 +6,30 @@ import type { ThemePalette } from './theme/palette'
 export type GameVariant = 1 | 2
 
 export interface PoeProfile {
+  schemaVersion: 1
   id: string
   name: string
   gameVariant: GameVariant
+  createdAt: string
+  updatedAt: string
   filterDir: string
   filterPath: string
   league: string
   tradePriceOption: TradePriceOption
   cheatSheets: CheatSheetsSettings
   regexPresets: RegexPreset[]
+}
+
+export interface PoeProfileSummary {
+  id: string
+  name: string
+  gameVariant: GameVariant
+  league: string
+  filterDir: string
+  filterPath: string
+  createdAt: string
+  updatedAt: string
+  active: boolean
 }
 
 export type Visibility = 'Show' | 'Hide' | 'Minimal'
@@ -485,13 +500,13 @@ export interface AppSettings {
   adaptiveDefaultsMode: AdaptiveMode
   /** UUID of the active profile (loaded from profiles/ dir). */
   activeProfileId: string
-  /** True once the user clicks Finish in the onboarding wizard. */
+  /** True once the user clicks Finish in first-run profile management. */
   onboardingCompleted: boolean
-  /** Onboarding resume: current step key (saved on every step transition). */
+  /** First-run/profile-management resume: current step key (saved on every step transition). */
   onboardingStep?: string
-  /** Onboarding resume: which games the user selected on the welcome screen. */
+  /** Legacy first-run resume: which games the user selected in the old setup flow. */
   onboardingSelectedGames?: { poe1: boolean; poe2: boolean }
-  /** Onboarding resume: name of the online filter imported per game, if any. */
+  /** Legacy first-run resume: name of the online filter imported per game, if any. */
   onboardingImportedOnline?: { poe1: string | null; poe2: string | null }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -500,6 +500,9 @@ export interface AppSettings {
   adaptiveDefaultsMode: AdaptiveMode
   /** UUID of the active profile (loaded from profiles/ dir). */
   activeProfileId: string
+  /** Last explicitly activated profile for each game. Used when switching games. */
+  lastProfileIdPoe1: string
+  lastProfileIdPoe2: string
   /** True once the user clicks Finish in first-run profile management. */
   onboardingCompleted: boolean
   /** First-run/profile-management resume: current step key (saved on every step transition). */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -514,9 +514,9 @@ export interface AppSettings {
   /** Last explicitly activated profile for each game. Used when switching games. */
   lastProfileIdPoe1: string
   lastProfileIdPoe2: string
-  /** True once the user clicks Finish in first-run profile management. */
+  /** True once the user completes the first-run onboarding wizard. */
   onboardingCompleted: boolean
-  /** First-run/profile-management resume: current step key (saved on every step transition). */
+  /** First-run onboarding resume: current step key (saved on every step transition). */
   onboardingStep?: string
   /** Legacy first-run resume: which games the user selected in the old setup flow. */
   onboardingSelectedGames?: { poe1: boolean; poe2: boolean }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -400,20 +400,26 @@ export type TradePriceOption =
   | 'exalted_equivalent'
   | 'exalted'
 
+/** Legacy settings keys that existed before the profile system. Used only by
+ *  migrateFromLegacy() to read one-time migration data from the electron-store. */
+export interface LegacyAppSettings {
+  filterPathPoe1?: string
+  filterPathPoe2?: string
+  filterDirPoe1?: string
+  filterDirPoe2?: string
+  leaguePoe1?: string
+  leaguePoe2?: string
+  tradePriceOptionPoe1?: TradePriceOption
+  tradePriceOptionPoe2?: TradePriceOption
+  cheatSheetsPoe1?: CheatSheetsSettings
+  cheatSheetsPoe2?: CheatSheetsSettings
+  regexPresetsPoe1?: RegexPreset[]
+  regexPresetsPoe2?: RegexPreset[]
+  filterPath?: string
+  filterDir?: string
+}
+
 export interface AppSettings {
-  /** Active filter path + dir + league. Mirrored to/from the per-version fields
-   *  (filterPathPoe1, filterPathPoe2, etc.) based on the current poeVersion at
-   *  startup and on every set. Consumers read these flat fields as before --
-   *  the version namespacing is an implementation detail of the store layer. */
-  filterPath: string
-  filterDir: string
-  league: string
-  filterPathPoe1: string
-  filterPathPoe2: string
-  filterDirPoe1: string
-  filterDirPoe2: string
-  leaguePoe1: string
-  leaguePoe2: string
   /** Cached league lists fetched from the trade APIs at app launch. The settings
    *  + onboarding dropdowns prefer these when populated; falls back to the
    *  hardcoded list in shared/game-features.ts if a fetch never succeeded. */
@@ -445,9 +451,6 @@ export interface AppSettings {
   tradeCollapseListings?: boolean
   /** Volume (0.0-1.0) for the filter sound preview button. */
   previewVolume?: number
-  tradePriceOption: TradePriceOption
-  tradePriceOptionPoe1: TradePriceOption
-  tradePriceOptionPoe2: TradePriceOption
   /** Default "Listed" time for price-check searches. Empty string = any time. */
   tradeDefaultListedTime?:
     | ''
@@ -469,9 +472,6 @@ export interface AppSettings {
   tradeNeverAutoSearch?: boolean
   chatCommands: Array<{ hotkey: string; command: string; autoSubmit?: boolean; scope?: MacroScope }>
   appMacros: Array<{ action: string; hotkey: string; tag?: string; scope?: MacroScope }>
-  cheatSheets: CheatSheetsSettings
-  cheatSheetsPoe1: CheatSheetsSettings
-  cheatSheetsPoe2: CheatSheetsSettings
   stashScrollEnabled: boolean
   poeVersion: GameVariant
   /** Regex presets are persisted per game. Each session reads/writes the slot
@@ -498,6 +498,10 @@ export interface AppSettings {
    *  before changing a default; 'off' stops applying learned defaults but keeps
    *  recording so re-enabling is never cold-start. */
   adaptiveDefaultsMode: AdaptiveMode
+  /** Runtime-only: the active profile data, populated from the profile store.
+   *  Never persisted to electron-store. Filter path, league, etc. are
+   *  accessed via activeProfile.* instead of top-level settings fields. */
+  activeProfile?: PoeProfile | null
   /** UUID of the active profile (loaded from profiles/ dir). */
   activeProfileId: string
   /** Last explicitly activated profile for each game. Used when switching games. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,14 @@ export interface PoeProfileSummary {
   active: boolean
 }
 
+export type ProfileSettingKey = 'league' | 'filterPath' | 'filterDir' | 'tradePriceOption' | 'cheatSheets'
+
+export type ProfileSettingValue<K extends ProfileSettingKey> = PoeProfile[K]
+
+export interface RuntimeSettings extends AppSettings {
+  activeProfile: PoeProfile | null
+}
+
 export type Visibility = 'Show' | 'Hide' | 'Minimal'
 export type ComparisonOperator = '>' | '>=' | '=' | '==' | '<=' | '<'
 
@@ -501,7 +509,6 @@ export interface AppSettings {
   /** Runtime-only: the active profile data, populated from the profile store.
    *  Never persisted to electron-store. Filter path, league, etc. are
    *  accessed via activeProfile.* instead of top-level settings fields. */
-  activeProfile?: PoeProfile | null
   /** UUID of the active profile (loaded from profiles/ dir). */
   activeProfileId: string
   /** Last explicitly activated profile for each game. Used when switching games. */


### PR DESCRIPTION
This PR aims to allow users to have multiple per-game profiles with seamless switching between them. Additionally, changes to onboarding now allow users to skip setup/return to main menu without re-configuration