### PR TITLE
Hotfix allow filterdir skip & fix sync online filters

### DIFF
--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -13,6 +13,7 @@ import {
 import {
   createProfile,
   deleteProfileAndChooseFallback,
+  ensureProfileForGame,
   getEffectiveSettings,
   getProfileBackedSetting,
   getProfileById,
@@ -47,6 +48,10 @@ export function register(store: Store<AppSettings>): void {
     (event, variant: GameVariant, key: ProfileSettingKey, value: ProfileSettingValue<typeof key>) =>
       applyProfileSettingForGame(store, variant, key, value, event.sender),
   )
+
+  ipcMain.handle('ensure-profile-for-game', (_event, variant: GameVariant) => {
+    ensureProfileForGame(store, variant)
+  })
 
   ipcMain.handle('list-profiles', () => listProfileSummaries(store))
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -457,18 +457,18 @@ function startLiveServices(): void {
     })
   }
 
-  // Start online filter sync
+  // Start online filter sync. The poll interval is kept alive regardless of
+  // whether filterDir is set yet so a folder picked after onboarding can begin
+  // watching without requiring a separate poll-start call.
   const filterDir = getProfileBackedSetting(store, 'filterDir') as string
-  if (filterDir) {
-    startOnlineSync(filterDir, () => {
-      const wins: BrowserWindow[] = []
-      const ow = getOverlayWindow()
-      const aw = getAppWindow()
-      if (ow) wins.push(ow)
-      if (aw) wins.push(aw)
-      return wins
-    })
-  }
+  startOnlineSync(filterDir, () => {
+    const wins: BrowserWindow[] = []
+    const ow = getOverlayWindow()
+    const aw = getAppWindow()
+    if (ow) wins.push(ow)
+    if (aw) wins.push(aw)
+    return wins
+  })
 }
 
 app.whenReady().then(() => {

--- a/src/main/online-sync.test.ts
+++ b/src/main/online-sync.test.ts
@@ -1,0 +1,173 @@
+import { createHash } from 'node:crypto'
+import { describe, expect, it, vi, beforeAll } from 'vitest'
+import type { BrowserWindow } from 'electron'
+
+const mockReadDir = vi.fn()
+const mockReadFile = vi.fn()
+const mockExistsSync = vi.fn()
+const mockStatSync = vi.fn()
+
+vi.mock('node:fs', () => ({
+  existsSync: (...args: unknown[]) => mockExistsSync(...args),
+  readdirSync: (...args: unknown[]) => mockReadDir(...args),
+  readFileSync: (...args: unknown[]) => mockReadFile(...args),
+  statSync: (...args: unknown[]) => mockStatSync(...args),
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+}))
+
+let checkForChanges: (filterDir: string) => void
+let scanOnlineFilters: (filterDir: string) => Array<{ path: string; name: string; hash: string }>
+let updateOnlineSyncDir: (filterDir: string) => void
+let checkOnlineSyncNow: () => void
+let startOnlineSync: (filterDir: string, windowProvider: () => BrowserWindow[]) => void
+let stopOnlineSync: () => void
+
+beforeAll(async () => {
+  const mod = await import('./online-sync')
+  checkForChanges = mod.checkForChanges
+  scanOnlineFilters = mod.scanOnlineFilters
+  updateOnlineSyncDir = mod.updateOnlineSyncDir
+  checkOnlineSyncNow = mod.checkOnlineSyncNow
+  startOnlineSync = mod.startOnlineSync
+  stopOnlineSync = mod.stopOnlineSync
+})
+
+function md5(content: string): string {
+  return createHash('md5').update(content, 'utf-8').digest('hex')
+}
+
+function setupFs(files: Array<{ name: string; content: string }>): void {
+  const onlineDirName = 'OnlineFilters'
+  mockReadDir.mockImplementation((dir: string) => {
+    if (dir.toLowerCase().endsWith('onlinefilters')) return files.map((f) => f.name)
+    return [onlineDirName]
+  })
+  mockExistsSync.mockReturnValue(true)
+  mockStatSync.mockReturnValue({ isDirectory: () => false })
+  mockReadFile.mockImplementation((path: string) => {
+    const name = String(path).replace(/^.*[\\/]/, '')
+    const f = files.find((x) => x.name === name)
+    if (!f) throw new Error(`file not found: ${name}`)
+    return f.content
+  })
+}
+
+function makeWin(): BrowserWindow {
+  return { webContents: { send: vi.fn() } } as unknown as BrowserWindow
+}
+
+describe('scanOnlineFilters', () => {
+  it('returns empty when no onlinefilters subfolder exists', () => {
+    mockReadDir.mockReturnValue([])
+    expect(scanOnlineFilters('/filters')).toEqual([])
+  })
+
+  it('returns an entry per file with name from #name: header', () => {
+    setupFs([
+      { name: 'abc123', content: '#name: NeverSink\nShow\n' },
+      { name: 'def456', content: '#name: FilterBlast\nHide\n' },
+    ])
+    const result = scanOnlineFilters('/filters')
+    expect(result).toHaveLength(2)
+    expect(result[0].name).toBe('NeverSink')
+    expect(result[1].name).toBe('FilterBlast')
+    expect(result[0].hash).toBe(md5('#name: NeverSink\nShow\n'))
+  })
+
+  it('falls back to filename when #name: header is absent', () => {
+    setupFs([{ name: 'rawfile', content: 'Show\n' }])
+    const result = scanOnlineFilters('/filters')
+    expect(result[0].name).toBe('rawfile')
+  })
+})
+
+describe('checkForChanges', () => {
+  it('detects a new file as changed', () => {
+    stopOnlineSync()
+    const win = makeWin()
+
+    setupFs([{ name: 'existing', content: 'Show\n' }])
+    updateOnlineSyncDir('/filters')
+
+    startOnlineSync('/filters', () => [win])
+
+    setupFs([
+      { name: 'existing', content: 'Show\n' },
+      { name: 'newfile', content: '#name: Fresh\nHide\n' },
+    ])
+
+    checkForChanges('/filters')
+
+    const sendCalls = vi.mocked(win.webContents.send).mock.calls.filter((c) => c[0] === 'online-filter-changed')
+    expect(sendCalls.length).toBeGreaterThanOrEqual(1)
+    const changed = sendCalls[0][1] as Array<{ path: string; name: string }>
+    expect(changed.some((c) => c.name === 'Fresh')).toBe(true)
+  })
+
+  it('detects a modified file as changed', () => {
+    stopOnlineSync()
+    const win = makeWin()
+
+    setupFs([{ name: 'modfile', content: '#name: Old\nv1\n' }])
+    updateOnlineSyncDir('/filters')
+
+    startOnlineSync('/filters', () => [win])
+
+    setupFs([{ name: 'modfile', content: '#name: Old\nv2\n' }])
+
+    checkForChanges('/filters')
+
+    const sendCalls = vi.mocked(win.webContents.send).mock.calls.filter((c) => c[0] === 'online-filter-changed')
+    expect(sendCalls.length).toBeGreaterThanOrEqual(1)
+    const changed = sendCalls[0][1] as Array<{ path: string; name: string }>
+    expect(changed.some((c) => c.name === 'Old')).toBe(true)
+  })
+
+  it('does not notify when nothing changed', () => {
+    stopOnlineSync()
+    const win = makeWin()
+
+    const files = [{ name: 'stable', content: '#name: Stable\nv1\n' }]
+    setupFs(files)
+    updateOnlineSyncDir('/filters')
+
+    startOnlineSync('/filters', () => [win])
+
+    setupFs(files)
+
+    checkForChanges('/filters')
+
+    const sendCalls = vi.mocked(win.webContents.send).mock.calls.filter((c) => c[0] === 'online-filter-changed')
+    expect(sendCalls.length).toBe(0)
+  })
+})
+
+describe('updateOnlineSyncDir lifecycle', () => {
+  it('survives switching from empty to a different dir', () => {
+    stopOnlineSync()
+    const win = makeWin()
+
+    setupFs([{ name: 'original', content: '#name: Original\noriginal\n' }])
+    updateOnlineSyncDir('/old-dir')
+    startOnlineSync('/old-dir', () => [win])
+
+    updateOnlineSyncDir('')
+
+    setupFs([{ name: 'fresh', content: '#name: Fresh\nfresh\n' }])
+    updateOnlineSyncDir('/new-dir')
+    startOnlineSync('/new-dir', () => [win])
+
+    checkForChanges('/new-dir')
+
+    expect(true).toBe(true)
+  })
+
+  it('does not throw when startOnlineSync is called with empty dir', () => {
+    stopOnlineSync()
+    expect(() => startOnlineSync('', () => [])).not.toThrow()
+    expect(() => checkOnlineSyncNow()).not.toThrow()
+  })
+})

--- a/src/main/online-sync.ts
+++ b/src/main/online-sync.ts
@@ -73,17 +73,12 @@ function checkForChanges(filterDir: string): void {
 
   for (const f of current) {
     const prev = knownHashes.get(f.path)
-    if (prev && prev !== f.hash) {
+    if (!prev) {
+      changed.push({ path: f.path, name: f.name })
+    } else if (prev !== f.hash) {
       changed.push({ path: f.path, name: f.name })
     }
     knownHashes.set(f.path, f.hash)
-  }
-
-  // Also detect new files (not previously tracked)
-  for (const f of current) {
-    if (!knownHashes.has(f.path)) {
-      knownHashes.set(f.path, f.hash)
-    }
   }
 
   if (changed.length > 0) {
@@ -93,21 +88,26 @@ function checkForChanges(filterDir: string): void {
   }
 }
 
-/** Start polling for online filter changes */
+/** Start polling for online filter changes. Safe to call with an empty
+ *  filterDir — the interval runs regardless so a later `updateOnlineSyncDir`
+ *  call can begin watching without the caller needing to restart polling. */
 export function startOnlineSync(filterDir: string, windowProvider: () => BrowserWindow[]): void {
   stopOnlineSync()
-  currentFilterDir = filterDir
+  currentFilterDir = filterDir || null
   getWindows = windowProvider
-  buildInitialHashes(filterDir)
+  if (filterDir) buildInitialHashes(filterDir)
   pollInterval = setInterval(() => {
     if (currentFilterDir) checkForChanges(currentFilterDir)
   }, 5_000)
 }
 
-/** Update the watched directory (e.g. when user changes filter folder) */
+/** Update the watched directory (e.g. when user changes filter folder).
+ *  Clears tracked hashes when `filterDir` is empty so a later re-point
+ *  doesn't treat old files as already known. */
 export function updateOnlineSyncDir(filterDir: string): void {
-  currentFilterDir = filterDir
-  buildInitialHashes(filterDir)
+  currentFilterDir = filterDir || null
+  if (filterDir) buildInitialHashes(filterDir)
+  else knownHashes.clear()
 }
 
 /** Stop polling */
@@ -123,3 +123,6 @@ export function stopOnlineSync(): void {
 export function checkOnlineSyncNow(): void {
   if (currentFilterDir) checkForChanges(currentFilterDir)
 }
+
+// ---- test-only exports (used by unit tests) ---------------------------
+export { checkForChanges, scanOnlineFilters }

--- a/src/main/profiles/profile-settings.test.ts
+++ b/src/main/profiles/profile-settings.test.ts
@@ -11,6 +11,7 @@ import {
   LAST_PROFILE_ID_POE2_KEY,
   PROFILE_VERSION_KEY,
   deleteProfileAndChooseFallback,
+  ensureProfileForGame,
   getEffectiveSettings,
   getProfileBackedSetting,
   listProfileSummaries,
@@ -363,5 +364,54 @@ describe('profile-settings', () => {
     const store = makeStore({ [ACTIVE_PROFILE_ID_KEY]: '' })
 
     expect(getProfileBackedSetting(store, 'league')).toBe('')
+  })
+
+  it('ensureProfileForGame creates a default profile when none exist', () => {
+    const profiles = setupProfiles()
+    const store = makeStore({
+      [LAST_PROFILE_ID_POE1_KEY]: '',
+      [ACTIVE_PROFILE_ID_KEY]: '',
+    })
+
+    const profile = ensureProfileForGame(store, 1)
+
+    expect(profile.gameVariant).toBe(1)
+    expect(profile.filterDir).toBe('')
+    expect(profile.filterPath).toBe('')
+    expect(store.get(LAST_PROFILE_ID_POE1_KEY)).toBe(profile.id)
+    // verify it actually landed in the profile store
+    expect(profiles.getProfile(profile.id)).not.toBeNull()
+  })
+
+  it('ensureProfileForGame returns existing profile without creating a duplicate', () => {
+    const profiles = setupProfiles()
+    const poe1 = profiles.createDefault(1)
+    profiles.saveProfile(poe1)
+
+    const store = makeStore({
+      [LAST_PROFILE_ID_POE1_KEY]: poe1.id,
+      [ACTIVE_PROFILE_ID_KEY]: poe1.id,
+    })
+
+    const profile = ensureProfileForGame(store, 1)
+
+    expect(profile.id).toBe(poe1.id)
+    expect(profiles.listProfiles().filter((p) => p.gameVariant === 1)).toHaveLength(1)
+  })
+
+  it('ensureProfileForGame sets the correct lastProfileId per variant', () => {
+    const profiles = setupProfiles()
+    const store = makeStore({
+      [LAST_PROFILE_ID_POE1_KEY]: '',
+      [LAST_PROFILE_ID_POE2_KEY]: '',
+      [ACTIVE_PROFILE_ID_KEY]: '',
+    })
+
+    const poe1 = ensureProfileForGame(store, 1)
+    const poe2 = ensureProfileForGame(store, 2)
+
+    expect(store.get(LAST_PROFILE_ID_POE1_KEY)).toBe(poe1.id)
+    expect(store.get(LAST_PROFILE_ID_POE2_KEY)).toBe(poe2.id)
+    expect(profiles.listProfiles()).toHaveLength(2)
   })
 })

--- a/src/main/profiles/profile-settings.ts
+++ b/src/main/profiles/profile-settings.ts
@@ -162,6 +162,21 @@ export function createProfile(input: { name: string; gameVariant: GameVariant; c
   return profileStore().createProfile(input)
 }
 
+/** Create a default profile for `variant` if none exists yet. Returns the
+ *  existing profile when one is already present, so callers can use it as an
+ *  idempotent "ensure" before entering per-game setup steps. */
+export function ensureProfileForGame(store: Store<AppSettings>, variant: GameVariant): PoeProfile {
+  const existing = listProfilesByGameVariant(variant)
+  if (existing.length > 0) return existing[0]!
+
+  const profile = profileStore().createProfile({
+    name: `Path of Exile ${variant === 2 ? '2' : '1'}`,
+    gameVariant: variant,
+  })
+  store.set(lastProfileIdKey(variant), profile.id)
+  return profile
+}
+
 export function renameProfile(id: string, name: string): PoeProfile | null {
   return profileStore().renameProfile(id, name)
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -44,6 +44,7 @@ export const api = {
   duplicateProfile: (id: string, name: string): Promise<PoeProfileSummary> =>
     ipcRenderer.invoke('duplicate-profile', id, name),
   deleteProfile: (id: string): Promise<void> => ipcRenderer.invoke('delete-profile', id),
+  ensureProfileForGame: (variant: GameVariant): Promise<void> => ipcRenderer.invoke('ensure-profile-for-game', variant),
   setActiveProfile: (
     id: string,
     restartIfNeeded = false,

--- a/src/renderer/src/AppWindow.tsx
+++ b/src/renderer/src/AppWindow.tsx
@@ -57,6 +57,10 @@ export function AppWindow(): JSX.Element {
 
   const switchOnboardingGame = async (target: 1 | 2): Promise<void> => {
     if (!settings) return
+    // Ensure a default profile exists for the target game before switching to
+    // it, so onboarding steps always operate against a real (possibly empty)
+    // profile rather than a null activeProfile.
+    await window.api.ensureProfileForGame(target)
     await window.api.setSetting('poeVersion', target)
     setSettings(await window.api.getSettings())
   }

--- a/src/renderer/src/app-window/onboarding-steps.tsx
+++ b/src/renderer/src/app-window/onboarding-steps.tsx
@@ -141,19 +141,16 @@ export function FilterFolderStep({
         stepNum={stepNum}
         totalSteps={totalSteps}
         title={prefix ? `Point to your ${prefix} filter folder` : 'Point to your filter folder'}
-        subtitle={`Choose your filter folder, generally ${folderHint}, so Scalpel can find your filters.`}
+        subtitle={`Choose your filter folder, generally ${folderHint}, so Scalpel can find your filters. You can skip this and set it up later from settings.`}
       />
       <FilterPicker settings={settings} onSettingsChange={onSettingsChange} mode="folder" />
-      <p className="text-[10px] text-text-dim flex items-start gap-1 m-0 ml-1 mt-1.5">
-        <Info
-          size={12}
-          theme="two-tone"
-          fill={['currentColor', 'rgba(255,255,255,0.2)']}
-          className="flex shrink-0 mt-[2px]"
-        />
-        <span>Use online filters? You still need to do this step - online filters live here too.</span>
-      </p>
-      <NavButtons onBack={onBack} onNext={onNext} onBackToSettings={onBackToSettings} />
+      <NavButtons
+        onBack={onBack}
+        onNext={onNext}
+        secondaryLabel="Skip for now"
+        onSecondary={onNext}
+        onBackToSettings={onBackToSettings}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/FilterPicker.tsx
+++ b/src/renderer/src/components/FilterPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { CloseSmall, Info } from '@icon-park/react'
 import type { FilterListEntry, GameVariant, RuntimeSettings } from '../../../shared/types'
 
@@ -49,6 +49,9 @@ export function FilterPicker({
   const fPath = settings.activeProfile?.filterPath ?? ''
   const gameVariant = (settings.poeVersion === 2 ? 2 : 1) as GameVariant
 
+  const settingsRef = useRef(settings)
+  settingsRef.current = settings
+
   // Listen for online filter changes
   useEffect(() => {
     const unsub = window.api.onOnlineFilterChanged((changed) => {
@@ -57,6 +60,10 @@ export function FilterPicker({
         for (const c of changed) next.add(c.name)
         return next
       })
+      const dir = settingsRef.current.activeProfile?.filterDir
+      if (dir) {
+        void window.api.scanFilterDir(dir).then(setFilters)
+      }
     })
     return unsub
   }, [])


### PR DESCRIPTION
Should fix the bug that was causing online filters to not appear. Likely root cause was it depended on the filterDir to exist