### PR TITLE
Fix appimage CI artefact name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,4 +102,4 @@ jobs:
           generate_release_notes: false
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
           files: |
-            dist/Scalpel-${{ steps.version.outputs.version }}.AppImage
+            dist/Scalpel.AppImage


### PR DESCRIPTION
Commit 2a2c0e0 locked the built appimage file name, but forgot to update it in the release CI
