### PR TITLE
Add AUR publishing CI/CD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,49 +1,43 @@
 name: Release
-
 on:
   push:
     tags:
       - 'v*'
-
+  workflow_dispatch:
+    inputs:
+      publish_git_aur:
+        description: "Publish scalpel-poe-git to AUR"
+        required: true
+        default: false
+        type: boolean
 permissions:
   contents: write
-
 jobs:
   release-win:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-
       - name: Install Python setuptools (needed by node-gyp)
         run: pip install setuptools
-
       - name: Install dependencies
         run: npm ci
-
       - name: Lint
         run: npm run lint
-
       - name: Test
         run: npm run test
-
       - name: Build
         run: npm run build
-
       - name: Pack ASAR
         run: node scripts/pack-asar.js
-
       - name: Build installer (no publish - we handle that separately)
         run: npx electron-builder --win --x64 --publish never
-
       - name: Extract version
         id: version
         shell: bash
-        run: echo "version=$(node -p 'require("./package.json").version')" >> $GITHUB_OUTPUT
-
+        run: echo "version=$(node -p 'require("./package.json").version')" >>$GITHUB_OUTPUT
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -54,16 +48,14 @@ jobs:
             dist/v${{ steps.version.outputs.version }}/app.asar.unpacked.zip
             dist/v${{ steps.version.outputs.version }}/manifest.json
             dist/Scalpel-Setup.exe
-
   release-linux:
+    needs: release-win
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-
       - name: Install Linux native build deps
         # uiohook-napi and electron-overlay-window's X11 backends link against
         # the X11/xcb dev headers. libfuse2 is the AppImage Type 2 runtime
@@ -74,26 +66,20 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            libxcb1-dev libxtst-dev libxss-dev libxkbfile-dev \
-            libx11-dev libxext-dev libxrandr-dev libxinerama-dev \
-            libxcursor-dev libxi-dev libxkbcommon-dev libfuse2
-
+              libxcb1-dev libxtst-dev libxss-dev libxkbfile-dev \
+              libx11-dev libxext-dev libxrandr-dev libxinerama-dev \
+              libxcursor-dev libxi-dev libxkbcommon-dev libfuse2
       - name: Install dependencies
         run: npm ci
-
       - name: Test
         run: npm run test
-
       - name: Build
         run: npm run build
-
       - name: Build AppImage
         run: npx electron-builder --linux AppImage --x64 --publish never
-
       - name: Extract version
         id: version
-        run: echo "version=$(node -p 'require("./package.json").version')" >> $GITHUB_OUTPUT
-
+        run: echo "version=$(node -p 'require("./package.json").version')" >>$GITHUB_OUTPUT
       - name: Append AppImage to GitHub Release
         # The Windows job creates the release with notes; this appends the
         # AppImage artifact. softprops/action-gh-release upserts on tag.
@@ -103,3 +89,66 @@ jobs:
           prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') || contains(github.ref_name, '-exp') }}
           files: |
             dist/Scalpel.AppImage
+  publish-aur:
+    needs: release-linux
+    if: ${{ github.event_name == 'push' && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
+    runs-on: ubuntu-latest
+    container: archlinux:latest
+    steps:
+      - name: Install packaging tools
+        run: |
+          pacman -Syu --noconfirm --needed \
+              base-devel \
+              curl \
+              git \
+              pacman-contrib
+      - uses: actions/checkout@v4
+      - name: Update AUR package metadata
+        run: scripts/update-aur-packages.sh --version "${GITHUB_REF_NAME#v}"
+      - name: Publish scalpel-poe-bin to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@4
+        with:
+          pkgname: scalpel-poe-bin
+          pkgbuild: packaging/aur/scalpel-poe-bin/PKGBUILD
+          assets: |
+            packaging/aur/scalpel-poe-bin/.SRCINFO
+            packaging/aur/scalpel-poe-bin/scalpel-poe.sh
+            packaging/aur/scalpel-poe-bin/scalpel-poe.desktop
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "chore: update scalpel-poe-bin to ${{ github.ref_name }}"
+          ssh_keyscan_types: rsa,ecdsa,ed25519
+      - name: Publish scalpel-poe to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@4
+        with:
+          pkgname: scalpel-poe
+          pkgbuild: packaging/aur/scalpel-poe/PKGBUILD
+          assets: |
+            packaging/aur/scalpel-poe/.SRCINFO
+            packaging/aur/scalpel-poe/scalpel-poe.sh
+            packaging/aur/scalpel-poe/scalpel-poe.desktop
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "chore: update scalpel-poe to ${{ github.ref_name }}"
+          ssh_keyscan_types: rsa,ecdsa,ed25519
+  publish-aur-git:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_git_aur }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Publish scalpel-poe-git to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4
+        with:
+          pkgname: scalpel-poe-git
+          pkgbuild: packaging/aur/scalpel-poe-git/PKGBUILD
+          assets: |
+            packaging/aur/scalpel-poe-git/.SRCINFO
+            packaging/aur/scalpel-poe-git/scalpel-poe.sh
+            packaging/aur/scalpel-poe-git/scalpel-poe.desktop
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "chore: publish scalpel-poe-git"
+          ssh_keyscan_types: rsa,ecdsa,ed25519

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
             dist/Scalpel.AppImage
   publish-aur:
     needs: release-linux
-    if: ${{ github.event_name == 'push' && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
+    if: ${{ github.event_name == 'push' && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') && !contains(github.ref_name, '-exp') }}
     runs-on: ubuntu-latest
     container: archlinux:latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
   contents: write
 jobs:
   release-win:
+    if: ${{ github.event_name == 'push' }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
@@ -49,6 +50,7 @@ jobs:
             dist/v${{ steps.version.outputs.version }}/manifest.json
             dist/Scalpel-Setup.exe
   release-linux:
+    if: ${{ github.event_name == 'push' }}
     needs: release-win
     runs-on: ubuntu-22.04
     steps:
@@ -101,12 +103,19 @@ jobs:
               base-devel \
               curl \
               git \
-              pacman-contrib
+              pacman-contrib \
+              sudo
+          useradd --create-home builder
+          echo "builder ALL=(ALL) NOPASSWD: ALL" >/etc/sudoers.d/builder
+          chmod 0440 /etc/sudoers.d/builder
       - uses: actions/checkout@v4
       - name: Update AUR package metadata
-        run: scripts/update-aur-packages.sh --version "${GITHUB_REF_NAME#v}"
+        run: |
+          chown -R builder:builder "$GITHUB_WORKSPACE"
+          VERSION="${GITHUB_REF_NAME#v}" sudo --preserve-env=GITHUB_WORKSPACE,VERSION -u builder \
+              bash -lc 'cd "$GITHUB_WORKSPACE" && scripts/update-aur-packages.sh --version "$VERSION"'
       - name: Publish scalpel-poe-bin to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@4
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: scalpel-poe-bin
           pkgbuild: packaging/aur/scalpel-poe-bin/PKGBUILD
@@ -120,7 +129,7 @@ jobs:
           commit_message: "chore: update scalpel-poe-bin to ${{ github.ref_name }}"
           ssh_keyscan_types: rsa,ecdsa,ed25519
       - name: Publish scalpel-poe to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@4
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: scalpel-poe
           pkgbuild: packaging/aur/scalpel-poe/PKGBUILD
@@ -139,7 +148,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Publish scalpel-poe-git to AUR
-        uses: KSXGitHub/github-actions-deploy-aur@v4
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
         with:
           pkgname: scalpel-poe-git
           pkgbuild: packaging/aur/scalpel-poe-git/PKGBUILD

--- a/packaging/aur/.gitignore
+++ b/packaging/aur/.gitignore
@@ -1,0 +1,21 @@
+# makepkg work directories from manual package tests
+*/src/
+*/pkg/
+
+# makepkg package/source outputs
+*/*.pkg.tar*
+*/*.src.tar*
+
+# downloaded release/source assets during manual tests
+*/*.AppImage
+*/*.asar
+*/*.zip
+*/*.tar.gz
+*/*.tar.xz
+*/*.tar.zst
+*/*.png
+*/LICENSE
+
+# logs / partial downloads
+*/*.log
+*/*.part

--- a/packaging/aur/scalpel-poe-bin/.SRCINFO
+++ b/packaging/aur/scalpel-poe-bin/.SRCINFO
@@ -1,0 +1,25 @@
+pkgbase = scalpel-poe-bin
+	pkgdesc = Path of Exile's First Fourth-Party Tool
+	pkgver = 0.9.8
+	pkgrel = 1
+	url = https://github.com/scalpelpoe/scalpel
+	arch = x86_64
+	license = AGPL-3.0-only
+	depends = fuse2
+	provides = scalpel-poe
+	conflicts = scalpel-poe
+	conflicts = scalpel-poe-git
+	noextract = Scalpel.AppImage
+	options = !strip
+	source = Scalpel.AppImage::https://github.com/scalpelpoe/scalpel/releases/download/v0.9.8/Scalpel.AppImage
+	source = scalpel-poe.png::https://github.com/scalpelpoe/scalpel/raw/v0.9.8/resources/icon.png
+	source = LICENSE::https://github.com/scalpelpoe/scalpel/raw/v0.9.8/LICENSE
+	source = scalpel-poe.sh
+	source = scalpel-poe.desktop
+	sha256sums = 99327b9a7f608edc92e672bb50f6b5fabaf6953a10b3d5f860a3f5de5205392b
+	sha256sums = 31db68f35fdeb9f2d8ad1fdf87784c4e590a8d715a18972a58e5870b160fd92e
+	sha256sums = 0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0
+	sha256sums = aec6807cc11a1f0f172577d5d24744d457c2d52fd51c4b92d1e6b8bfbb943b1f
+	sha256sums = be4904493f9322e59649768c209eeeed71ebf8f4f92321614967f749807794dc
+
+pkgname = scalpel-poe-bin

--- a/packaging/aur/scalpel-poe-bin/PKGBUILD
+++ b/packaging/aur/scalpel-poe-bin/PKGBUILD
@@ -1,0 +1,39 @@
+# Maintainer: Scalpel <scalpelpoe at gmail dot com>
+# Contributor: Kristofers Solo <dev at kristofers dot xyz>
+
+pkgname=scalpel-poe-bin
+pkgver=0.9.8
+pkgrel=1
+pkgdesc="Path of Exile's First Fourth-Party Tool"
+arch=("x86_64")
+url="https://github.com/scalpelpoe/scalpel"
+license=("AGPL-3.0-only")
+options=(!strip)
+depends=(
+    "fuse2"
+)
+provides=("scalpel-poe")
+conflicts=("scalpel-poe" "scalpel-poe-git")
+_upstream_version="${pkgver/_/-}"
+source=(
+    "Scalpel.AppImage::$url/releases/download/v$_upstream_version/Scalpel.AppImage"
+    "scalpel-poe.png::$url/raw/v$_upstream_version/resources/icon.png"
+    "LICENSE::$url/raw/v$_upstream_version/LICENSE"
+    "scalpel-poe.sh"
+    "scalpel-poe.desktop"
+)
+noextract=("Scalpel.AppImage")
+sha256sums=('99327b9a7f608edc92e672bb50f6b5fabaf6953a10b3d5f860a3f5de5205392b'
+    '31db68f35fdeb9f2d8ad1fdf87784c4e590a8d715a18972a58e5870b160fd92e'
+    '0d96a4ff68ad6d4b6f1f30f713b18d5184912ba8dd389f86aa7710db079abcb0'
+    'aec6807cc11a1f0f172577d5d24744d457c2d52fd51c4b92d1e6b8bfbb943b1f'
+    'be4904493f9322e59649768c209eeeed71ebf8f4f92321614967f749807794dc')
+
+package() {
+    install -Dm755 "Scalpel.AppImage" "$pkgdir/opt/scalpel-poe/Scalpel.AppImage"
+
+    install -Dm755 "$srcdir/scalpel-poe.sh" "$pkgdir/usr/bin/scalpel-poe"
+    install -Dm644 "$srcdir/scalpel-poe.desktop" "$pkgdir/usr/share/applications/scalpel-poe.desktop"
+    install -Dm644 "$srcdir/scalpel-poe.png" "$pkgdir/usr/share/pixmaps/scalpel-poe.png"
+    install -Dm644 "$srcdir/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/aur/scalpel-poe-bin/scalpel-poe.desktop
+++ b/packaging/aur/scalpel-poe-bin/scalpel-poe.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Scalpel
+Comment=Path of Exile's First Fourth-Party Tool
+Exec=scalpel-poe %U
+Terminal=false
+Type=Application
+Icon=scalpel-poe
+StartupWMClass=scalpel
+Categories=Game;

--- a/packaging/aur/scalpel-poe-bin/scalpel-poe.sh
+++ b/packaging/aur/scalpel-poe-bin/scalpel-poe.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export XDG_SESSION_TYPE=x11
+exec /opt/scalpel-poe/Scalpel.AppImage --ozone-platform=x11 "$@"

--- a/packaging/aur/scalpel-poe-git/.SRCINFO
+++ b/packaging/aur/scalpel-poe-git/.SRCINFO
@@ -1,0 +1,24 @@
+pkgbase = scalpel-poe-git
+	pkgdesc = Path of Exile's First Fourth-Party Tool
+	pkgver = 20260529
+	pkgrel = 1
+	url = https://github.com/scalpelpoe/scalpel
+	arch = x86_64
+	license = AGPL-3.0-only
+	makedepends = git
+	makedepends = nodejs-lts-jod
+	makedepends = npm
+	makedepends = python
+	depends = fuse2
+	provides = scalpel-poe
+	conflicts = scalpel-poe
+	conflicts = scalpel-poe-bin
+	options = !strip
+	source = git+https://github.com/scalpelpoe/scalpel.git
+	source = scalpel-poe.sh
+	source = scalpel-poe.desktop
+	sha256sums = SKIP
+	sha256sums = SKIP
+	sha256sums = SKIP
+
+pkgname = scalpel-poe-git

--- a/packaging/aur/scalpel-poe-git/PKGBUILD
+++ b/packaging/aur/scalpel-poe-git/PKGBUILD
@@ -1,0 +1,75 @@
+# Maintainer: Scalpel <scalpelpoe at gmail dot com>
+# Contributor: Kristofers Solo <dev at kristofers dot xyz>
+
+pkgname=scalpel-poe-git
+pkgver=0.9.9.rc2.0.ge858db3
+pkgrel=1
+pkgdesc="Path of Exile's First Fourth-Party Tool"
+arch=("x86_64")
+url="https://github.com/scalpelpoe/scalpel"
+license=("AGPL-3.0-only")
+options=(!strip)
+depends=(
+    "fuse2"
+)
+makedepends=(
+    "git"
+    "nodejs-lts-jod"
+    "npm"
+    "python"
+)
+provides=("scalpel-poe")
+conflicts=("scalpel-poe" "scalpel-poe-bin")
+source=(
+    "git+$url.git"
+    "scalpel-poe.sh"
+    "scalpel-poe.desktop"
+)
+sha256sums=("SKIP"
+    "SKIP"
+    "SKIP")
+
+_check_node_version() {
+    local major
+    major="$(node -p 'process.versions.node.split(".")[0]')"
+
+    if [[ "$major" != "22" ]]; then
+        echo "error: Node.js 22 is required, got $(node --version)" >&2
+        exit 1
+    fi
+}
+
+_enter_builddir() {
+    cd scalpel || return 1
+    _check_node_version || return 1
+}
+
+pkgver() {
+    _enter_builddir
+
+    git describe --tags --long | sed "s/^v//;s/-/./g"
+}
+
+prepare() {
+    _enter_builddir
+
+    npm ci
+}
+
+build() {
+    cd scalpel
+
+    npm run build
+    npx electron-builder --linux AppImage --x64 --publish never
+}
+
+package() {
+    cd scalpel
+
+    install -Dm755 "dist/Scalpel.AppImage" "$pkgdir/opt/scalpel-poe/Scalpel.AppImage"
+
+    install -Dm755 "$srcdir/scalpel-poe.sh" "$pkgdir/usr/bin/scalpel-poe"
+    install -Dm644 "$srcdir/scalpel-poe.desktop" "$pkgdir/usr/share/applications/scalpel-poe.desktop"
+    install -Dm644 resources/icon.png "$pkgdir/usr/share/pixmaps/scalpel-poe.png"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/aur/scalpel-poe-git/scalpel-poe.desktop
+++ b/packaging/aur/scalpel-poe-git/scalpel-poe.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Scalpel
+Comment=Path of Exile's First Fourth-Party Tool
+Exec=scalpel-poe %U
+Terminal=false
+Type=Application
+Icon=scalpel-poe
+StartupWMClass=scalpel
+Categories=Game;

--- a/packaging/aur/scalpel-poe-git/scalpel-poe.sh
+++ b/packaging/aur/scalpel-poe-git/scalpel-poe.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export XDG_SESSION_TYPE=x11
+exec /opt/scalpel-poe/Scalpel.AppImage --ozone-platform=x11 "$@"

--- a/packaging/aur/scalpel-poe/.SRCINFO
+++ b/packaging/aur/scalpel-poe/.SRCINFO
@@ -1,0 +1,24 @@
+pkgbase = scalpel-poe
+	pkgdesc = Path of Exile's First Fourth-Party Tool
+	pkgver = 0.9.8
+	pkgrel = 1
+	url = https://github.com/scalpelpoe/scalpel
+	arch = x86_64
+	license = AGPL-3.0-only
+	makedepends = git
+	makedepends = nodejs-lts-jod
+	makedepends = npm
+	makedepends = python
+	depends = fuse2
+	provides = scalpel-poe
+	conflicts = scalpel-poe-bin
+	conflicts = scalpel-poe-git
+	options = !strip
+	source = scalpel-poe-0.9.8.tar.gz::https://github.com/scalpelpoe/scalpel/archive/refs/tags/v0.9.8.tar.gz
+	source = scalpel-poe.sh
+	source = scalpel-poe.desktop
+	sha256sums = a2a1c632c8eb44a5bc0788b534531a3e1191ec7eb3cd1a6cb47811a6fd02e69a
+	sha256sums = aec6807cc11a1f0f172577d5d24744d457c2d52fd51c4b92d1e6b8bfbb943b1f
+	sha256sums = be4904493f9322e59649768c209eeeed71ebf8f4f92321614967f749807794dc
+
+pkgname = scalpel-poe

--- a/packaging/aur/scalpel-poe/PKGBUILD
+++ b/packaging/aur/scalpel-poe/PKGBUILD
@@ -1,0 +1,70 @@
+# Maintainer: Scalpel <scalpelpoe at gmail dot com>
+# Contributor: Kristofers Solo <dev at kristofers dot xyz>
+
+pkgname=scalpel-poe
+pkgver=0.9.8
+pkgrel=1
+pkgdesc="Path of Exile's First Fourth-Party Tool"
+arch=("x86_64")
+url="https://github.com/scalpelpoe/scalpel"
+license=("AGPL-3.0-only")
+options=(!strip)
+depends=(
+    "fuse2"
+)
+makedepends=(
+    "git"
+    "nodejs-lts-jod"
+    "npm"
+    "python"
+)
+provides=("scalpel-poe")
+conflicts=("scalpel-poe-bin" "scalpel-poe-git")
+_upstream_version="${pkgver/_/-}"
+source=(
+    "$pkgname-$_upstream_version.tar.gz::$url/archive/refs/tags/v$_upstream_version.tar.gz"
+    "scalpel-poe.sh"
+    "scalpel-poe.desktop"
+)
+sha256sums=('a2a1c632c8eb44a5bc0788b534531a3e1191ec7eb3cd1a6cb47811a6fd02e69a'
+    'aec6807cc11a1f0f172577d5d24744d457c2d52fd51c4b92d1e6b8bfbb943b1f'
+    'be4904493f9322e59649768c209eeeed71ebf8f4f92321614967f749807794dc')
+
+_check_node_version() {
+    local major
+    major="$(node -p 'process.versions.node.split(".")[0]')"
+
+    if [[ "$major" != "22" ]]; then
+        echo "error: Node.js 22 is required, got $(node --version)" >&2
+        exit 1
+    fi
+}
+
+_enter_builddir() {
+    cd "scalpel-$_upstream_version" || return 1
+    _check_node_version || return 1
+}
+
+prepare() {
+    _enter_builddir
+
+    npm ci
+}
+
+build() {
+    _enter_builddir
+
+    npm run build
+    npx electron-builder --linux AppImage --x64 --publish never
+}
+
+package() {
+    cd "scalpel-$_upstream_version"
+
+    install -Dm755 "dist/Scalpel.AppImage" "$pkgdir/opt/scalpel-poe/Scalpel.AppImage"
+
+    install -Dm755 "$srcdir/scalpel-poe.sh" "$pkgdir/usr/bin/scalpel-poe"
+    install -Dm644 "$srcdir/scalpel-poe.desktop" "$pkgdir/usr/share/applications/scalpel-poe.desktop"
+    install -Dm644 resources/icon.png "$pkgdir/usr/share/pixmaps/scalpel-poe.png"
+    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/packaging/aur/scalpel-poe/scalpel-poe.desktop
+++ b/packaging/aur/scalpel-poe/scalpel-poe.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Scalpel
+Comment=Path of Exile's First Fourth-Party Tool
+Exec=scalpel-poe %U
+Terminal=false
+Type=Application
+Icon=scalpel-poe
+StartupWMClass=scalpel
+Categories=Game;

--- a/packaging/aur/scalpel-poe/scalpel-poe.sh
+++ b/packaging/aur/scalpel-poe/scalpel-poe.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export XDG_SESSION_TYPE=x11
+exec /opt/scalpel-poe/Scalpel.AppImage --ozone-platform=x11 "$@"

--- a/scripts/update-aur-packages.sh
+++ b/scripts/update-aur-packages.sh
@@ -55,7 +55,7 @@ packages=(
 )
 
 is_prerelease_version() {
-    [[ "$1" =~ -(alpha|beta|rc)([.-]?[0-9]*)?$ ]]
+    [[ "$1" =~ -(alpha|beta|rc|exp)([.-]?[0-9]*)?$ ]]
 }
 
 assert_stable_version() {

--- a/scripts/update-aur-packages.sh
+++ b/scripts/update-aur-packages.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+latest_release_url="https://api.github.com/repos/scalpelpoe/scalpel/releases/latest"
+
+dry_run=0
+explicit_version=""
+
+usage() {
+    cat <<'EOF'
+Usage: update-aur-packages.sh [--dry-run] [--version VERSION]
+
+Updates release-based AUR package metadata:
+  - packaging/aur/scalpel-poe-bin
+  - packaging/aur/scalpel-poe
+
+Options:
+  --dry-run          Print commands without changing files
+  --version VERSION  Use VERSION instead of GitHub latest release
+EOF
+}
+
+while (($#)); do
+    case "$1" in
+    --dry-run)
+        dry_run=1
+        shift
+        ;;
+    --version)
+        if [[ $# -lt 2 || -z "${2:-}" ]]; then
+            echo "error: --version requires a value" >&2
+            exit 2
+        fi
+        explicit_version="$2"
+        shift 2
+        ;;
+    -h | --help)
+        usage
+        exit 0
+        ;;
+    *)
+        echo "error: unknown argument: $1" >&2
+        usage >&2
+        exit 2
+        ;;
+    esac
+done
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd -- "$script_dir/.." && pwd)"
+
+packages=(
+    "scalpel-poe-bin"
+    "scalpel-poe"
+)
+
+is_prerelease_version() {
+    [[ "$1" =~ -(alpha|beta|rc)([.-]?[0-9]*)?$ ]]
+}
+
+assert_stable_version() {
+    local version="$1"
+
+    if is_prerelease_version "$version"; then
+        echo "error: refusing to update AUR packages to prerelease $version" >&2
+        exit 1
+    fi
+}
+
+get_latest_stable_version() {
+    if [[ -n "$explicit_version" ]]; then
+        local version="${explicit_version#v}"
+        assert_stable_version "$version"
+        printf '%s\n' "$version"
+        return
+    fi
+
+    if [[ -n "${GITHUB_REF_NAME:-}" ]]; then
+        local version="${GITHUB_REF_NAME#v}"
+        assert_stable_version "$version"
+        printf '%s\n' "$version"
+        return
+    fi
+
+    local json
+    json="$(curl -fsSL \
+        -H 'Accept: application/vnd.github+json' \
+        -H 'User-Agent: scalpel-aur-updater' \
+        "$latest_release_url")"
+
+    local tag_name draft prerelease
+    tag_name="$(sed -nE 's/.*"tag_name"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' <<<"$json" | head -n1)"
+    draft="$(sed -nE 's/.*"draft"[[:space:]]*:[[:space:]]*(true|false).*/\1/p' <<<"$json" | head -n1)"
+    prerelease="$(sed -nE 's/.*"prerelease"[[:space:]]*:[[:space:]]*(true|false).*/\1/p' <<<"$json" | head -n1)"
+
+    if [[ -z "$tag_name" ]]; then
+        echo "error: failed to read latest release tag_name" >&2
+        exit 1
+    fi
+
+    if [[ "$draft" == "true" || "$prerelease" == "true" ]]; then
+        echo "error: latest release $tag_name is not stable" >&2
+        exit 1
+    fi
+
+    local version="${tag_name#v}"
+    assert_stable_version "$version"
+    printf '%s\n' "$version"
+}
+
+run() {
+    if ((dry_run)); then
+        printf '[dry-run]'
+        printf ' %q' "$@"
+        printf '\n'
+        return
+    fi
+
+    "$@"
+}
+
+update_pkgbuild() {
+    local package_dir="$1"
+    local version="$2"
+    local pkgver="${version//-/_}"
+    local pkgbuild="$package_dir/PKGBUILD"
+    local tmp
+
+    tmp="$(mktemp)"
+    sed -E \
+        -e "s/^pkgver=.*/pkgver=$pkgver/" \
+        -e 's/^pkgrel=.*/pkgrel=1/' \
+        "$pkgbuild" >"$tmp"
+
+    if cmp -s "$pkgbuild" "$tmp"; then
+        rm -f "$tmp"
+        return 1
+    fi
+
+    if ((dry_run)); then
+        echo "[dry-run] update $pkgbuild"
+        rm -f "$tmp"
+    else
+        mv "$tmp" "$pkgbuild"
+    fi
+
+    return 0
+}
+
+regenerate_metadata() {
+    local package_dir="$1"
+
+    (
+        cd "$package_dir"
+
+        run updpkgsums
+
+        if ((dry_run)); then
+            echo "[dry-run] makepkg --printsrcinfo > .SRCINFO"
+        else
+            makepkg --printsrcinfo >.SRCINFO
+        fi
+    )
+}
+
+version="$(get_latest_stable_version)"
+echo "Using stable release $version"
+
+for package in "${packages[@]}"; do
+    package_dir="$root_dir/packaging/aur/$package"
+
+    changed=0
+    if update_pkgbuild "$package_dir" "$version"; then
+        changed=1
+    fi
+
+    regenerate_metadata "$package_dir"
+
+    if ((changed)); then
+        echo "$package: updated PKGBUILD"
+    else
+        echo "$package: PKGBUILD already current"
+    fi
+done


### PR DESCRIPTION
## Summary

Add AUR publishing to the release workflow.

For stable releases, the workflow updates and publishes `scalpel-poe` and
`scalpel-poe-bin`.

`scalpel-poe-git` is not published on every release because it tracks the
repository directly. It can still be published manually from the workflow when
its packaging files change.

## AUR setup

The workflow requires an [AUR account](https://aur.archlinux.org/register).

During registration you will need to enter email, username, SSH public key
and bot protection answer. You can ask me for the answer for the last one.
Preferably, create a separate SSH key for AUR use, as described in the
[ArchWiki authentication guide](https://wiki.archlinux.org/title/AUR_submission_guidelines#Authentication).

Then you'll need to add the following repo secrets:

```text
AUR_SSH_PRIVATE_KEY=<key>
AUR_USERNAME=<username>
AUR_EMAIL=<email>
```

`AUR_SSH_PRIVATE_KEY` must be a private SSH key whose corresponding public key
is added to the AUR account.

`AUR_USERNAME` and `AUR_EMAIL` are used as the commit author for automated AUR
updates. They can technically be set to any values, but should preferably match
the username and email associated with the AUR account.