### PR TITLE
feat: regex remote sister overlay

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
           cheatSheetPreview: resolve(__dirname, 'src/renderer/cheat-sheet-preview.html'),
           secondaryOverlayCanvas: resolve(__dirname, 'src/renderer/secondary-overlay-canvas.html'),
           whiteboard: resolve(__dirname, 'src/renderer/whiteboard.html'),
+          regexRemote: resolve(__dirname, 'src/renderer/regex-remote.html'),
           pinnedZone: resolve(__dirname, 'src/renderer/pinned-zone.html'),
           pluginOverlay: resolve(__dirname, 'src/renderer/plugin-overlay.html'),
         },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,6 +43,7 @@ import { join } from 'node:path'
 import { execSync } from 'node:child_process'
 import { uIOhook, UiohookKey } from 'uiohook-napi'
 import Store from 'electron-store'
+import { OverlayController } from 'electron-overlay-window'
 import {
   createOverlayWindow,
   hideOverlay,
@@ -114,6 +115,7 @@ import { registerWhiteboardOverlay, toggleWhiteboard } from './whiteboard'
 import { togglePluginOverlay } from './plugin-overlay'
 import { registerPinnedZoneOverlay, applyPinnedZoneEnabled } from './pinned-zone'
 import {
+  getOverlayAnchor,
   hideAllOnPoeBlur,
   restoreAllOnPoeFocus,
   isAnyScalpelWindowFocused,
@@ -123,6 +125,14 @@ import {
 } from './windowing'
 import { initAppMacrosRefresh, withPluginHotkeys } from './app-macros'
 import { runRegexMacroMigration } from './regex-macro-migration'
+import {
+  applyRegexPreset,
+  getRegexRemoteOverlay,
+  leftDockFracX,
+  registerRegexRemoteOverlay,
+  toggleRegexRemote,
+} from './regex-remote'
+import { detectPanelStateOnce, getCurrentPanelState } from './panel-detection'
 import type { AppSettings, CheatSheetsSettings, GameVariant, LegacyAppSettings, RegexPreset } from '../shared/types'
 import { initProfileStore } from './profiles/store'
 import {
@@ -554,6 +564,49 @@ app.whenReady().then(() => {
     setTimeout(restoreClip, 100)
   }
 
+  // The pad renders flush-left (squared left corners, no left border) ONLY when
+  // it's docked against the stash sidebar. The vendor dock floats beside the
+  // Buy/Sell modal, so it stays a rounded card. EPS absorbs integer-pixel
+  // rounding from the snap commit; an unknown anchor / no left panel -> rounded.
+  const REGEX_REMOTE_FLUSH_EPS = 0.01
+  function regexRemoteFlushLeft(anchor: { fracX: number } | null): boolean {
+    if (!anchor || !getCurrentPanelState().leftPanelOpen) return false
+    return Math.abs(anchor.fracX - leftDockFracX(OverlayController.targetBounds)) < REGEX_REMOTE_FLUSH_EPS
+  }
+  // Guards the async toggle path so a rapid double-press during the one-shot
+  // panel capture doesn't queue two show/hide cycles (which would flicker or
+  // leave the pad hidden).
+  let regexRemoteToggleBusy = false
+
+  ipcMain.handle('regex-remote:mount-state', () => regexRemoteFlushLeft(getOverlayAnchor('regex-remote')))
+
+  ipcMain.on('regex-remote:apply', (_event, presetId: string) => {
+    applyRegexPreset(presetId, {
+      getPresets: () => {
+        const key = store.get(PROFILE_VERSION_KEY) === 2 ? 'regexPresetsPoe2' : 'regexPresetsPoe1'
+        return store.get(key) ?? []
+      },
+      focusGame: () => {
+        try {
+          OverlayController.focusTarget()
+        } catch {}
+      },
+      paste: pasteRegexToSearch,
+      // Let focus settle on PoE before synthesizing Ctrl+F / Ctrl+V.
+      defer: (fn) => setTimeout(fn, 50),
+    })
+  })
+  ipcMain.on('regex-remote:close', () => getRegexRemoteOverlay()?.hide())
+  // The pad is always interactive, so clicking/dragging it gives it OS focus.
+  // Hand focus back to PoE when the user is done (cursor leaves the pad) so the
+  // pad doesn't retain focus -- otherwise isAnyScalpelWindowFocused() stays true
+  // and the PoE-blur hide (on minimize/alt-tab) bails, leaving the pad on screen.
+  ipcMain.on('regex-remote:hand-focus', () => {
+    try {
+      OverlayController.focusTarget()
+    } catch {}
+  })
+
   setAppMacroHandler((action, tag, presetId) => {
     if (action === 'pasteRegex') {
       if (currentRegex) pasteRegexToSearch(currentRegex)
@@ -578,6 +631,30 @@ app.whenReady().then(() => {
       if (main && !main.isDestroyed() && main.isVisible()) hideOverlay()
       getCheatSheetsOverlay()?.hide()
       toggleWhiteboard()
+      return
+    }
+    if (action === 'toggleRegexRemote') {
+      if (getRegexRemoteOverlay()?.isVisible()) {
+        toggleRegexRemote() // hide
+        return
+      }
+      if (regexRemoteToggleBusy) return // a capture+show is already in flight
+      regexRemoteToggleBusy = true
+      const main = getOverlayWindow()
+      if (main && !main.isDestroyed() && main.isVisible()) hideOverlay()
+      getCheatSheetsOverlay()?.hide()
+      // Capture fresh panel state so the pad mounts at the stash vs vendor dock,
+      // then show (repositionOnShow re-reads the context anchor) and push the
+      // flush state for the new dock -- the renderer only queries it once on
+      // mount, so a context switch (stash <-> vendor) needs this push.
+      void detectPanelStateOnce().finally(() => {
+        regexRemoteToggleBusy = false
+        toggleRegexRemote()
+        getRegexRemoteOverlay()?.send(
+          'regex-remote:mount-changed',
+          regexRemoteFlushLeft(getOverlayAnchor('regex-remote')),
+        )
+      })
       return
     }
     if (action.startsWith('plugin-overlay:')) {
@@ -624,6 +701,19 @@ app.whenReady().then(() => {
   setCheatSheetsBeforeShow(() => hideOverlay())
   applyCheatSheetHotkeys(getProfileBackedSetting(store, 'cheatSheets'))
   registerWhiteboardOverlay()
+  registerRegexRemoteOverlay({
+    onAnchorChanged: (anchor) => {
+      getRegexRemoteOverlay()?.send('regex-remote:mount-changed', regexRemoteFlushLeft(anchor))
+      // A user drag/resize focuses the pad (and a drag's mouseup never reaches
+      // the renderer, so the cursor-leave handoff can miss it). Hand focus back
+      // to PoE here too so the pad never sits holding OS focus after a move.
+      try {
+        OverlayController.focusTarget()
+      } catch {}
+    },
+    getTargetBounds: () => OverlayController.targetBounds,
+    getPanelState: () => getCurrentPanelState(),
+  })
   registerPinnedZoneOverlay({
     storedAnchor: () => getProfileBackedSetting(store, 'cheatSheets')?.pinnedAnchor,
     onAnchorChanged: (anchor) => patchCheatSheets({ pinnedAnchor: anchor }),

--- a/src/main/panel-detection/index.ts
+++ b/src/main/panel-detection/index.ts
@@ -4,7 +4,7 @@ import type { PanelState } from '../../shared/panel-state'
 import { getPoeVersion } from '../game-state'
 import { getWhiteboardOverlay } from '../whiteboard'
 import { PanelDetector } from './detector'
-import type { BitmapView } from './match'
+import { type BitmapView, matchPatchFuzzy, votePanels } from './match'
 import { PANEL_SAMPLES } from './panel-samples'
 
 let detector: PanelDetector | null = null
@@ -25,11 +25,13 @@ const MAX_CAPTURE_HEIGHT = 1080
 /** Capture the display the game is on and crop to the game-window rect, returning
  *  BGRA pixels with (0,0) at the window top-left. Null when the whiteboard (the
  *  only consumer) is hidden, the game isn't focused, or no usable frame is
- *  available. Physical-pixel assumptions are validated in-game. */
-async function captureGameWindow(): Promise<BitmapView | null> {
+ *  available. Physical-pixel assumptions are validated in-game.
+ *  Pass force=true to bypass the whiteboard-visibility gate (e.g. for on-demand
+ *  detection by other features); the focus and bounds checks are always enforced. */
+async function captureGameWindow(force = false): Promise<BitmapView | null> {
   // The distance overlay is the only consumer; skip the expensive screen grab
   // entirely while the whiteboard is hidden so normal play never pays for it.
-  if (!getWhiteboardOverlay()?.isVisible()) return null
+  if (!force && !getWhiteboardOverlay()?.isVisible()) return null
   if (!OverlayController.targetHasFocus) return null
   const tb = OverlayController.targetBounds
   if (!tb?.width || !tb.height) return null
@@ -103,6 +105,23 @@ export function startPanelDetection(): void {
     },
   })
   detector.start()
+}
+
+/** One-shot panel-state detection, bypassing the whiteboard-visibility gate the
+ *  continuous detector uses. Captures a single frame and fuzzy-matches the
+ *  sample patches (no stabilization fingerprint - this is a cold, on-demand
+ *  read). Updates and returns lastPanelState; returns the previous state
+ *  unchanged when samples are unavailable for the version or no frame could be
+ *  captured (e.g. PoE not focused). Intended for features that need fresh panel
+ *  state at a specific moment (e.g. a hotkey press) rather than continuously. */
+export async function detectPanelStateOnce(): Promise<PanelState> {
+  const samples = PANEL_SAMPLES[getPoeVersion()]
+  if (!samples) return lastPanelState
+  const frame = await captureGameWindow(true)
+  if (!frame) return lastPanelState
+  const matched = samples.map((s) => matchPatchFuzzy(frame, s))
+  lastPanelState = votePanels(samples, matched)
+  return lastPanelState
 }
 
 export function stopPanelDetection(): void {

--- a/src/main/regex-remote.test.ts
+++ b/src/main/regex-remote.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  applyRegexPreset,
+  bottomLeftSnapTarget,
+  leftDockFracX,
+  regexRemoteAnchor,
+  type RegexRemoteApplyDeps,
+} from './regex-remote'
+import type { RegexPreset } from '../shared/types'
+import { POE_SIDEBAR_RATIO } from '../shared/poe-geometry'
+
+vi.mock('./windowing', () => ({ registerSecondaryOverlay: vi.fn() }))
+
+function preset(over: Partial<RegexPreset>): RegexPreset {
+  return {
+    id: 'p1',
+    generator: 'maps',
+    tags: [],
+    avoid: [],
+    want: [],
+    wantMode: 'any',
+    qualifiers: {},
+    nightmare: false,
+    regex: 'abc',
+    ...over,
+  } as RegexPreset
+}
+
+function deps(over: Partial<RegexRemoteApplyDeps> = {}): {
+  d: RegexRemoteApplyDeps
+  focus: ReturnType<typeof vi.fn>
+  paste: ReturnType<typeof vi.fn>
+} {
+  const focus = vi.fn()
+  const paste = vi.fn()
+  const d: RegexRemoteApplyDeps = {
+    getPresets: () => [preset({ id: 'p1', regex: 'aaa' }), preset({ id: 'p2', regex: 'bbb' })],
+    focusGame: focus,
+    paste,
+    defer: (fn) => fn(),
+    ...over,
+  }
+  return { d, focus, paste }
+}
+
+describe('applyRegexPreset', () => {
+  it('focuses the game then pastes the matching preset regex', () => {
+    const { d, focus, paste } = deps()
+    applyRegexPreset('p2', d)
+    expect(focus).toHaveBeenCalledOnce()
+    expect(paste).toHaveBeenCalledWith('bbb')
+  })
+
+  it('no-ops on an unknown preset id', () => {
+    const { d, focus, paste } = deps()
+    applyRegexPreset('nope', d)
+    expect(focus).not.toHaveBeenCalled()
+    expect(paste).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when the matched preset has an empty regex', () => {
+    const { d, focus, paste } = deps({
+      getPresets: () => [preset({ id: 'p1', regex: '' })],
+    })
+    applyRegexPreset('p1', d)
+    expect(focus).not.toHaveBeenCalled()
+    expect(paste).not.toHaveBeenCalled()
+  })
+})
+
+describe('leftDockFracX', () => {
+  it('docks at the sidebar edge as a fraction of width (16:9)', () => {
+    expect(leftDockFracX({ width: 1920, height: 1080 })).toBeCloseTo((1080 * POE_SIDEBAR_RATIO) / 1920)
+  })
+  it('is aspect-independent (computed from actual bounds)', () => {
+    expect(leftDockFracX({ width: 2560, height: 1080 })).toBeCloseTo((1080 * POE_SIDEBAR_RATIO) / 2560)
+  })
+  it('falls back to a 16:9 estimate when bounds are missing or empty', () => {
+    const expected = POE_SIDEBAR_RATIO / (16 / 9)
+    expect(leftDockFracX(null)).toBeCloseTo(expected)
+    expect(leftDockFracX(undefined)).toBeCloseTo(expected)
+    expect(leftDockFracX({ width: 0, height: 0 })).toBeCloseTo(expected)
+  })
+})
+
+describe('bottomLeftSnapTarget', () => {
+  it('pins the bottom-left corner, growing upward when the window is taller', () => {
+    const dock = { x: 100, y: 200, width: 160, height: 400 } // bottom = 600
+    expect(bottomLeftSnapTarget(dock, { x: 0, y: 0, width: 180, height: 500 })).toEqual({
+      x: 100,
+      y: 100, // 200 + 400 - 500, so bottom stays 600
+      width: 180,
+      height: 500,
+    })
+  })
+  it('keeps the left edge at the dock x regardless of the current position', () => {
+    const dock = { x: 100, y: 200, width: 160, height: 400 }
+    const t = bottomLeftSnapTarget(dock, { x: 999, y: 999, width: 160, height: 400 })
+    expect(t.x).toBe(100)
+    expect(t.y).toBe(200) // same size -> unchanged top
+  })
+})
+
+describe('regexRemoteAnchor', () => {
+  const tb = { width: 1920, height: 1080 }
+  it('docks at the stash sidebar when the stash (left panel) is detected open', () => {
+    const a = regexRemoteAnchor({ leftPanelOpen: true, rightPanelOpen: true }, tb)
+    expect(a.fracX).toBeCloseTo((1080 * POE_SIDEBAR_RATIO) / 1920)
+  })
+  it('docks further right (vendor) when the left panel is not detected', () => {
+    const stashX = (1080 * POE_SIDEBAR_RATIO) / 1920
+    const a = regexRemoteAnchor({ leftPanelOpen: false, rightPanelOpen: true }, tb)
+    expect(a.fracX).toBeGreaterThan(stashX)
+  })
+  it('pins the stash dock to the XP bar but sits the vendor dock higher', () => {
+    const stash = regexRemoteAnchor({ leftPanelOpen: true, rightPanelOpen: true }, tb)
+    const vendor = regexRemoteAnchor({ leftPanelOpen: false, rightPanelOpen: true }, tb)
+    expect(stash.fracY + stash.fracH).toBeCloseTo(0.95)
+    expect(vendor.fracY).toBeLessThan(stash.fracY)
+  })
+})

--- a/src/main/regex-remote.ts
+++ b/src/main/regex-remote.ts
@@ -1,0 +1,119 @@
+import type { RegexPreset } from '../shared/types'
+import type { PanelState } from '../shared/panel-state'
+import { POE_SIDEBAR_RATIO } from '../shared/poe-geometry'
+import { registerSecondaryOverlay, type OverlayAnchor, type Rect, type SecondaryOverlay } from './windowing'
+
+export interface RegexRemoteApplyDeps {
+  /** Presets for the currently active game (caller picks the poe1/poe2 store). */
+  getPresets: () => RegexPreset[]
+  /** Hand OS focus back to the PoE window before keystrokes are synthesized. */
+  focusGame: () => void
+  /** Paste the regex into PoE's search (the existing pasteRegexToSearch flow). */
+  paste: (regex: string) => void
+  /** Defer the paste until after focus settles. Real wiring uses setTimeout;
+   *  tests pass a synchronous implementation. */
+  defer: (fn: () => void) => void
+}
+
+// ---- Overlay registration ---------------------------------------------------
+
+// The pad docks into the bottom-left corner: left edge flush with the stash
+// tab sidebar (see leftDockFracX), bottom edge just above the in-game XP bar.
+// XP_BAR_TOP_FRAC is the XP bar's top as a fraction of screen height (tunable
+// by eye); the pad's bottom sits there and it extends upward by DOCK_FRAC_H.
+const XP_BAR_TOP_FRAC = 0.95
+const DOCK_FRAC_W = 0.16
+const DOCK_FRAC_H = 0.4
+
+/** Horizontal dock position (fraction of PoE window width) matching the left
+ *  mount of the main Scalpel panel: its left edge sits at the right edge of
+ *  PoE's left sidebar, whose width is `gameHeight * POE_SIDEBAR_RATIO`. Derived
+ *  from PoE's bounds so it tracks the mount across aspect ratios. Falls back to
+ *  a 16:9 estimate when PoE isn't attached (bounds unavailable). */
+export function leftDockFracX(tb: { width: number; height: number } | null | undefined): number {
+  if (!tb || tb.width <= 0 || tb.height <= 0) return POE_SIDEBAR_RATIO / (16 / 9)
+  return (tb.height * POE_SIDEBAR_RATIO) / tb.width
+}
+
+/** Snap target that pins the pad's BOTTOM-LEFT corner: left edge at the dock X,
+ *  bottom edge at the dock's bottom (just above the XP bar). Resizing the pad
+ *  grows it upward instead of drifting the bottom. `defaultRect` is the dock's
+ *  full DIP rect; `cur` is the window's current size. */
+export function bottomLeftSnapTarget(defaultRect: Rect, cur: Rect): Rect {
+  return {
+    x: defaultRect.x,
+    y: defaultRect.y + defaultRect.height - cur.height,
+    width: cur.width,
+    height: cur.height,
+  }
+}
+
+// Vendor dock: the pad sits in the upper-right area beside PoE's Buy/Sell modal
+// (which is wider than the stash sidebar). Unlike the stash dock it is NOT
+// pinned to the XP bar - it sits higher so it doesn't cover the vendor search
+// box / flasks. Both fractions of the PoE window; tuned by eye for 16:9 -
+// adjust in-game.
+const VENDOR_DOCK_FRAC_X = 0.505
+const VENDOR_DOCK_FRAC_Y = 0.4
+
+/** The pad's left-edge dock X (fraction of PoE width) for the current context.
+ *  Empirically the panel detector reports leftPanelOpen=true at the stash (its
+ *  header matches the left-panel samples) and false at a vendor's Buy/Sell
+ *  window, so: stash -> sidebar-flush dock (leftDockFracX); vendor -> the wider
+ *  dock further right (VENDOR_DOCK_FRAC_X). */
+export function dockFracX(panel: PanelState, tb: { width: number; height: number } | null | undefined): number {
+  return panel.leftPanelOpen ? leftDockFracX(tb) : VENDOR_DOCK_FRAC_X
+}
+
+/** Context-aware dock anchor (see dockFracX for the stash-vs-vendor mapping).
+ *  Stash dock is pinned to the bottom (just above the XP bar); the vendor dock
+ *  sits higher in the upper-right beside the Buy/Sell modal. */
+export function regexRemoteAnchor(
+  panel: PanelState,
+  tb: { width: number; height: number } | null | undefined,
+): OverlayAnchor {
+  return {
+    fracX: dockFracX(panel, tb),
+    fracY: panel.leftPanelOpen ? XP_BAR_TOP_FRAC - DOCK_FRAC_H : VENDOR_DOCK_FRAC_Y,
+    fracW: DOCK_FRAC_W,
+    fracH: DOCK_FRAC_H,
+  }
+}
+
+let overlay: SecondaryOverlay | null = null
+
+export function registerRegexRemoteOverlay(opts: {
+  onAnchorChanged: (anchor: OverlayAnchor) => void
+  getTargetBounds: () => { width: number; height: number } | null | undefined
+  getPanelState: () => PanelState
+}): SecondaryOverlay {
+  if (overlay) return overlay
+  overlay = registerSecondaryOverlay({
+    id: 'regex-remote',
+    htmlEntry: 'regex-remote.html',
+    defaultAnchor: () => regexRemoteAnchor(opts.getPanelState(), opts.getTargetBounds()),
+    snapTarget: bottomLeftSnapTarget,
+    repositionOnShow: true,
+    onAnchorChanged: opts.onAnchorChanged,
+  })
+  return overlay
+}
+
+export function getRegexRemoteOverlay(): SecondaryOverlay | null {
+  return overlay
+}
+
+export function toggleRegexRemote(): void {
+  overlay?.toggle()
+}
+
+/** Resolve a preset by id for the active game and apply its regex to PoE's
+ *  search. Refocuses PoE first because a click on the pad window steals OS
+ *  focus, which would otherwise send the synthetic Ctrl+F / Ctrl+V to the pad.
+ *  No-ops on an unknown id or a preset with no regex. */
+export function applyRegexPreset(presetId: string, deps: RegexRemoteApplyDeps): void {
+  const preset = deps.getPresets().find((p) => p.id === presetId)
+  if (!preset?.regex) return
+  deps.focusGame()
+  deps.defer(() => deps.paste(preset.regex as string))
+}

--- a/src/main/window-broadcast.ts
+++ b/src/main/window-broadcast.ts
@@ -1,13 +1,15 @@
 import type { WebContents } from 'electron'
 import { getOverlayWindow } from './overlay'
 import { getAppWindow } from './app-window'
+import { getSecondaryOverlayWindows } from './windowing'
 
-/** Send a fire-and-forget event to both primary windows. Mirrors the
- *  plugin-hotkeys-changed notify pattern but targets overlay + app window.
- *  Skips destroyed windows (refs persist after teardown) and an optional
- *  sender so the originating window doesn't redundantly re-fetch. */
+/** Send a fire-and-forget event to the primary windows (overlay + app) and
+ *  every live secondary-overlay window. Skips destroyed windows (refs persist
+ *  after teardown) and an optional sender so the originating window doesn't
+ *  redundantly re-fetch. Channels not listened to by a given window are
+ *  harmless no-ops. */
 export function broadcastToWindows(channel: string, except?: WebContents | null): void {
-  for (const win of [getOverlayWindow(), getAppWindow()]) {
+  for (const win of [getOverlayWindow(), getAppWindow(), ...getSecondaryOverlayWindows()]) {
     if (!win || win.isDestroyed()) continue
     if (except && win.webContents === except) continue
     win.webContents.send(channel)

--- a/src/main/windowing/index.ts
+++ b/src/main/windowing/index.ts
@@ -49,6 +49,11 @@ export interface OverlaySpec {
    *  but couldn't be sent during window creation (renderer wasn't mounted
    *  yet, so webContents.send would silently drop them). */
   onFirstShow?: (win: BrowserWindow) => void
+  /** When true, re-apply the (resolved) anchor bounds on every show, not just at
+   *  window creation. For specs whose `defaultAnchor` is context-dependent and
+   *  must re-evaluate each time the window is shown. Default (false) keeps the
+   *  position the window last had. */
+  repositionOnShow?: boolean
 }
 
 /** Multiply an anchor against a rect, returning a rect in the same coordinate
@@ -325,6 +330,7 @@ function showState(state: OverlayState): void {
   // hold-to-move and re-triggers PoE-blur which causes overlay flicker).
   if (win.webContents.isLoading()) return
   if (win.isVisible()) return
+  if (state.spec.repositionOnShow) applyAnchorBounds(state)
   win.show()
 }
 
@@ -432,6 +438,27 @@ function maybeUpdateSnap(state: OverlayState): void {
   if (wantActive === state.snapGhostActive) return
   state.snapGhostActive = wantActive
   setSnapGhost(state.snapGhostActive ? target : null)
+}
+
+/** The current anchor (fractions of PoE's window) of a registered secondary
+ *  overlay's live window, or null if it doesn't exist yet or PoE isn't
+ *  attached. Lets owning modules detect where their window currently sits
+ *  (e.g. whether it's flush against a dock edge). */
+export function getOverlayAnchor(id: string): OverlayAnchor | null {
+  const state = overlays.get(id)
+  if (!state?.win || state.win.isDestroyed()) return null
+  return boundsToAnchor(state.win)
+}
+
+/** Every registered secondary-overlay window that currently exists (created
+ *  lazily on first show) and isn't destroyed. Used by broadcast/notify paths
+ *  that need to reach secondary overlays in addition to the primary windows. */
+export function getSecondaryOverlayWindows(): BrowserWindow[] {
+  const wins: BrowserWindow[] = []
+  for (const state of overlays.values()) {
+    if (state.win && !state.win.isDestroyed()) wins.push(state.win)
+  }
+  return wins
 }
 
 /** Subscribe to PoE attach/move/resize events and re-anchor every registered

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -224,6 +224,15 @@ export const api = {
     ipcRenderer.invoke('delete-regex-preset', id),
   reorderRegexPresets: (ids: string[]): Promise<import('../shared/types').RegexPreset[]> =>
     ipcRenderer.invoke('reorder-regex-presets', ids),
+  regexRemoteApply: (presetId: string): void => ipcRenderer.send('regex-remote:apply', presetId),
+  closeRegexRemote: (): void => ipcRenderer.send('regex-remote:close'),
+  regexRemoteHandFocus: (): void => ipcRenderer.send('regex-remote:hand-focus'),
+  regexRemoteMountState: (): Promise<boolean> => ipcRenderer.invoke('regex-remote:mount-state'),
+  onRegexRemoteMountChanged: (cb: (flush: boolean) => void): (() => void) => {
+    const handler = (_: Electron.IpcRendererEvent, flush: boolean): void => cb(flush)
+    ipcRenderer.on('regex-remote:mount-changed', handler)
+    return () => ipcRenderer.removeListener('regex-remote:mount-changed', handler)
+  },
 
   // Cheat sheets
   addCheatSheetFromFile: (categoryId: string): Promise<Array<{ id: string; ext: string }>> =>

--- a/src/renderer/regex-remote.html
+++ b/src/renderer/regex-remote.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scalpel Regex Remote</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        background: transparent;
+        font-family: 'Segoe UI', system-ui, sans-serif;
+        overflow: hidden;
+      }
+      #root {
+        width: 100vw;
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/regex-remote/main.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/src/components/regex-tool/RegexGenerator.tsx
+++ b/src/renderer/src/components/regex-tool/RegexGenerator.tsx
@@ -29,6 +29,10 @@ interface Props {
  *    1. Create a component matching the `GeneratorHandle` / `GeneratorProps` shape
  *    2. Add an entry to the per-version list it should appear in
  *    3. Add a case in the component-switch below (see `renderActiveGenerator`)
+ *    4. Mirror the new entry into `GENERATOR_ORDER` in
+ *       `../../regex-remote/RegexRemote.tsx` (the remote pad keeps its own copy
+ *       of these lists to avoid bundling this component tree; it silently omits
+ *       any generator missing from that copy)
  *  The registry drives the tab strip, localStorage key, and preset scoping.
  *  Generator availability is per-game: PoE1 uses Maps + Flasks + Custom;
  *  PoE2 uses Waystones + Custom (no flasks UI yet, no PoE1 maps). */

--- a/src/renderer/src/components/settings/utils.ts
+++ b/src/renderer/src/components/settings/utils.ts
@@ -48,6 +48,7 @@ export const APP_MACRO_DEFS = [
   { id: 'useSavedRegex', label: 'Use Saved Regex' },
   { id: 'closeOverlay', label: 'Close Overlay' },
   { id: 'toggleWhiteboard', label: 'Toggle Whiteboard' },
+  { id: 'toggleRegexRemote', label: 'Toggle Regex Remote' },
 ] as const
 
 export function generateClientCategoryId(): string {

--- a/src/renderer/src/regex-remote/RegexRemote.test.tsx
+++ b/src/renderer/src/regex-remote/RegexRemote.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RegexRemote } from './RegexRemote'
+import type { RegexPreset } from '../../../shared/types'
+
+function preset(over: Partial<RegexPreset>): RegexPreset {
+  return {
+    id: 'p1',
+    name: 'My Maps',
+    generator: 'maps',
+    avoid: [],
+    want: [],
+    wantMode: 'any',
+    qualifiers: {},
+    nightmare: false,
+    regex: 'aaa',
+    ...over,
+  }
+}
+
+const apply = vi.fn()
+
+beforeEach(() => {
+  apply.mockReset()
+  ;(window as unknown as { api: unknown }).api = {
+    getOverlayState: () => Promise.resolve({ poeVersion: 1, panelState: {}, gameBounds: null }),
+    getRegexPresets: () => Promise.resolve([]),
+    getSettings: () => Promise.resolve({ appMacros: [] }),
+    onRegexPresetsChanged: () => () => {},
+    regexRemoteApply: apply,
+    regexRemoteMountState: () => Promise.resolve(true),
+    onRegexRemoteMountChanged: () => () => {},
+  }
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('RegexRemote', () => {
+  it('renders the empty-state hint when there are no presets', async () => {
+    render(<RegexRemote />)
+    expect(await screen.findByText(/Save regex presets/i)).toBeInTheDocument()
+  })
+
+  it('groups presets by generator and applies on chip click', async () => {
+    window.api.getRegexPresets = () =>
+      Promise.resolve([
+        preset({ id: 'm1', name: 'High Tier', generator: 'maps' }),
+        preset({ id: 'c1', name: 'Vendor', generator: 'custom' }),
+      ])
+    render(<RegexRemote />)
+    expect(await screen.findByText('Maps')).toBeInTheDocument()
+    expect(screen.getByText('Custom')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('High Tier'))
+    expect(apply).toHaveBeenCalledWith('m1')
+  })
+
+  it('uses PoE2 generator order when poeVersion is 2', async () => {
+    window.api.getOverlayState = () =>
+      Promise.resolve({ poeVersion: 2, panelState: {}, gameBounds: null }) as ReturnType<
+        typeof window.api.getOverlayState
+      >
+    window.api.getRegexPresets = () =>
+      Promise.resolve([
+        preset({ id: 'w1', name: 'Red Maps', generator: 'waystones' }),
+        preset({ id: 'c2', name: 'My Custom', generator: 'custom' }),
+      ])
+    render(<RegexRemote />)
+    expect(await screen.findByText('Waystones')).toBeInTheDocument()
+    expect(screen.getByText('Custom')).toBeInTheDocument()
+    expect(screen.queryByText('Flasks')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/regex-remote/RegexRemote.tsx
+++ b/src/renderer/src/regex-remote/RegexRemote.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react'
+import type { RegexPreset, RuntimeSettings } from '../../../shared/types'
+import { Chrome } from '../secondary-overlay/Chrome'
+import { textColorForBg } from '../components/regex-tool/preset-colors'
+
+/** Generator display order + labels per game, for grouping the chips. This
+ *  duplicates the canonical lists in RegexGenerator.tsx (GENERATORS_POE1 /
+ *  GENERATORS_POE2), which aren't exported - importing them would pull the
+ *  whole generator component tree into this overlay's bundle. If you add a
+ *  generator there, add it here too or the pad will silently omit it. */
+const GENERATOR_ORDER: Record<1 | 2, Array<{ key: string; label: string }>> = {
+  1: [
+    { key: 'maps', label: 'Maps' },
+    { key: 'flasks', label: 'Flasks' },
+    { key: 'custom', label: 'Custom' },
+  ],
+  2: [
+    { key: 'waystones', label: 'Waystones' },
+    { key: 'custom', label: 'Custom' },
+  ],
+}
+
+export function RegexRemote(): JSX.Element {
+  const [version, setVersion] = useState<1 | 2>(1)
+  const [presets, setPresets] = useState<RegexPreset[]>([])
+  const [macros, setMacros] = useState<RuntimeSettings['appMacros']>([])
+  const [mounted, setMounted] = useState(true)
+
+  useEffect(() => {
+    void window.api.getOverlayState().then((s) => {
+      if (s.poeVersion === 1 || s.poeVersion === 2) setVersion(s.poeVersion)
+    })
+    void window.api.getSettings().then((s) => setMacros(s.appMacros ?? []))
+  }, [])
+
+  useEffect(() => {
+    const load = (): void => void window.api.getRegexPresets().then(setPresets)
+    load()
+    return window.api.onRegexPresetsChanged(load)
+  }, [])
+
+  useEffect(() => {
+    void window.api.regexRemoteMountState().then(setMounted)
+    return window.api.onRegexRemoteMountChanged(setMounted)
+  }, [])
+
+  // Clicking the pad gives it OS focus; hand focus back to PoE when the cursor
+  // leaves the window so the pad doesn't sit holding focus. Otherwise minimizing
+  // or alt-tabbing PoE won't hide the pad (the PoE-blur hide bails while a
+  // Scalpel window is focused), unlike the other secondary overlays.
+  useEffect(() => {
+    const handBack = (): void => window.api.regexRemoteHandFocus()
+    document.addEventListener('mouseleave', handBack)
+    return () => document.removeEventListener('mouseleave', handBack)
+  }, [])
+
+  const groups = GENERATOR_ORDER[version]
+    .map((g) => ({
+      ...g,
+      items: presets.filter((p) => (p.generator ?? 'maps') === g.key),
+    }))
+    .filter((g) => g.items.length > 0)
+
+  const boundHotkey = (id: string): string | undefined =>
+    macros.find((m) => m.action === 'useSavedRegex' && m.presetId === id)?.hotkey
+
+  return (
+    <Chrome
+      headerContent={<span className="text-text text-xs font-semibold">Regex Remote</span>}
+      onClose={() => window.api.closeRegexRemote()}
+      flushLeft={mounted}
+    >
+      {groups.length === 0 ? (
+        <div className="p-3 text-text-dim text-[11px] leading-snug">
+          Save regex presets in the Regex tab to use them here.
+        </div>
+      ) : (
+        <div className="flex-1 min-h-0 overflow-y-auto no-scrollbar p-2 flex flex-col gap-2">
+          {groups.map((g) => (
+            <div key={g.key} className="flex flex-col gap-1">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-text-dim px-1">{g.label}</div>
+              {g.items.map((p) => {
+                const hk = boundHotkey(p.id)
+                const tinted = !!p.color
+                return (
+                  <button
+                    key={p.id}
+                    onClick={() => window.api.regexRemoteApply(p.id)}
+                    className={`flex items-center justify-between gap-2 w-full text-left px-2 py-[6px] rounded text-[11px] font-medium cursor-pointer border-none${tinted ? '' : ' text-text'}`}
+                    style={{
+                      background: p.color ?? 'rgba(255,255,255,0.08)',
+                      color: tinted ? textColorForBg(p.color as string) : undefined,
+                    }}
+                  >
+                    <span className="truncate">{p.name || 'Untitled'}</span>
+                    {hk && <span className="text-[9px] opacity-70 shrink-0">{hk}</span>}
+                  </button>
+                )
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </Chrome>
+  )
+}

--- a/src/renderer/src/regex-remote/main.tsx
+++ b/src/renderer/src/regex-remote/main.tsx
@@ -1,0 +1,18 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import { RegexRemote } from './RegexRemote'
+import '../styles.css'
+import { bootstrapTheme } from '../shared/apply-theme'
+import { DiagnosticErrorBoundary, installRendererDiagnostics } from '../shared/diagnostics'
+
+void bootstrapTheme()
+installRendererDiagnostics('regex-remote')
+
+const root = document.getElementById('root')!
+createRoot(root).render(
+  <StrictMode>
+    <DiagnosticErrorBoundary source="regex-remote">
+      <RegexRemote />
+    </DiagnosticErrorBoundary>
+  </StrictMode>,
+)

--- a/src/renderer/src/secondary-overlay/Chrome.tsx
+++ b/src/renderer/src/secondary-overlay/Chrome.tsx
@@ -20,6 +20,11 @@ interface ChromeProps {
    *  Body content is always rendered regardless. */
   onMinimize?: () => void
   minimized?: boolean
+  /** When true, squares the left corners and removes the left border so the
+   *  card sits flush against a left dock (e.g. the regex remote pad when
+   *  mounted against PoE's stash sidebar). Existing consumers are unaffected
+   *  because this prop is optional and defaults to false. */
+  flushLeft?: boolean
 }
 
 /** Standard chrome for a secondary overlay window: rounded translucent card
@@ -39,11 +44,16 @@ export function Chrome({
   onClose,
   onMinimize,
   minimized,
+  flushLeft,
 }: ChromeProps): JSX.Element {
   const noDrag = { WebkitAppRegion: 'no-drag' } as React.CSSProperties
   const drag = { WebkitAppRegion: 'drag' } as React.CSSProperties
   return (
-    <div className="flex flex-col h-screen bg-bg-card-translucent rounded overflow-hidden border border-border">
+    <div
+      className={`flex flex-col h-screen bg-bg-card-translucent rounded overflow-hidden border border-border${
+        flushLeft ? ' rounded-l-none border-l-0' : ''
+      }`}
+    >
       <div
         className="flex items-center justify-between gap-2 px-2 py-1 border-b border-border bg-bg-solid-translucent shrink-0"
         style={drag}

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -10,6 +10,7 @@ export type DiagnosticSource =
   | 'renderer'
   | 'plugin'
   | 'plugin-overlay'
+  | 'regex-remote'
 
 export interface SerializedDiagnosticError {
   name?: string


### PR DESCRIPTION
A hotkey-toggled floating overlay that lists your saved regex presets as
clickable chips. Click one to paste its regex into the in-game search; it
auto-docks beside the stash or vendor panel.