### PR TITLE
ci: add typecheck step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Format check
         run: npm run format:check
 
+      - name: Typecheck
+        run: npm run build:i18n && npm run typecheck
+
       - name: Test
         run: npm run test
 


### PR DESCRIPTION
## Why

CI runs lint, format-check, test, and build, but none of them type-check:

- biome (`lint`) doesn't resolve types
- vitest doesn't type-check
- `electron-vite build` uses esbuild, which transpiles without type-checking

So there is currently no type-safety gate in CI. PR #384 demonstrated the gap: a squash-merge produced a duplicate `import { Info }` (a `tsc` TS2300 error) that passed lint + build green and landed on main. Type errors from merge artifacts can only be caught at the CI-on-push layer.

## What

Adds a `Typecheck` step running `npm run build:i18n && npm run typecheck`.

The `build:i18n` prefix is required: the paraglide message files (`src/shared/paraglide/`) are gitignored and generated at build time. Tests pass without it only because the paraglide vite plugin generates them on the fly; `tsc` runs no vite plugins, so the step would otherwise fail on missing generated message functions.

Verified locally: `npm run typecheck` is green on current main.