### PR TITLE
feat: add experimental update channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') || contains(github.ref_name, '-exp') }}
           files: |
             dist/v${{ steps.version.outputs.version }}/app.asar
             dist/v${{ steps.version.outputs.version }}/app.asar.unpacked.zip
@@ -100,6 +100,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: false
-          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') || contains(github.ref_name, '-exp') }}
           files: |
             dist/Scalpel.AppImage

--- a/messages/de.json
+++ b/messages/de.json
@@ -36,7 +36,7 @@
   "settings_channel_beta": "Beta",
   "settings_beta_warning": "Warnung: Beta-Versionen werden Dinge kaputt machen und allgemein nervig sein. Bitte tritt Discord bei, um mir zu sagen, was ich reparieren soll, und mir beim Leiden zuzusehen",
   "settings_channel_experimental": "Experimental",
-  "settings_experimental_warning": "Warning: Experimental is only for the bravest and most patient of souls. Your shit WILL break.",
+  "settings_experimental_warning": "Warnung: Experimental ist nur etwas für die mutigsten und geduldigsten Seelen. Dein Scheiß WIRD kaputtgehen.",
   "settings_join_discord": "Discord beitreten",
   "settings_preview_volume": "Lautstärke der Filterton-Vorschau",
   "settings_bug_reports": "Fehlerberichte",

--- a/messages/de.json
+++ b/messages/de.json
@@ -35,6 +35,8 @@
   "settings_channel_stable": "Stabil",
   "settings_channel_beta": "Beta",
   "settings_beta_warning": "Warnung: Beta-Versionen werden Dinge kaputt machen und allgemein nervig sein. Bitte tritt Discord bei, um mir zu sagen, was ich reparieren soll, und mir beim Leiden zuzusehen",
+  "settings_channel_experimental": "Experimental",
+  "settings_experimental_warning": "Warning: Experimental is only for the bravest and most patient of souls. Your shit WILL break.",
   "settings_join_discord": "Discord beitreten",
   "settings_preview_volume": "Lautstärke der Filterton-Vorschau",
   "settings_bug_reports": "Fehlerberichte",

--- a/messages/en.json
+++ b/messages/en.json
@@ -35,6 +35,8 @@
   "settings_channel_stable": "Stable",
   "settings_channel_beta": "Beta",
   "settings_beta_warning": "Warning: expect beta releases to break stuff and be generally annoying. Please join discord to tell me what to fix and watch me squirm",
+  "settings_channel_experimental": "Experimental",
+  "settings_experimental_warning": "Warning: Experimental is only for the bravest and most patient of souls. Your shit WILL break.",
   "settings_join_discord": "Join Discord",
   "settings_preview_volume": "Filter sound preview volume",
   "settings_bug_reports": "Bug reports",

--- a/messages/es.json
+++ b/messages/es.json
@@ -35,6 +35,8 @@
   "settings_channel_stable": "Estable",
   "settings_channel_beta": "Beta",
   "settings_beta_warning": "Advertencia: espera que las versiones beta rompan cosas y sean molestas en general. Únete a Discord para decirme qué arreglar y verme sufrir",
+  "settings_channel_experimental": "Experimental",
+  "settings_experimental_warning": "Warning: Experimental is only for the bravest and most patient of souls. Your shit WILL break.",
   "settings_join_discord": "Unirse a Discord",
   "settings_preview_volume": "Volumen de vista previa del sonido del filtro",
   "settings_bug_reports": "Informes de errores",

--- a/messages/es.json
+++ b/messages/es.json
@@ -36,7 +36,7 @@
   "settings_channel_beta": "Beta",
   "settings_beta_warning": "Advertencia: espera que las versiones beta rompan cosas y sean molestas en general. Únete a Discord para decirme qué arreglar y verme sufrir",
   "settings_channel_experimental": "Experimental",
-  "settings_experimental_warning": "Warning: Experimental is only for the bravest and most patient of souls. Your shit WILL break.",
+  "settings_experimental_warning": "Advertencia: Experimental es solo para las almas más valientes y pacientes. Tu mierda SÍ se va a romper.",
   "settings_join_discord": "Unirse a Discord",
   "settings_preview_volume": "Volumen de vista previa del sonido del filtro",
   "settings_bug_reports": "Informes de errores",

--- a/src/main/update/select-release.test.ts
+++ b/src/main/update/select-release.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { selectListRelease } from './select-release'
+
+type Rel = { tag_name: string; assets: Array<{ name: string }> }
+
+const withManifest = (tag: string): Rel => ({
+  tag_name: tag,
+  assets: [{ name: 'manifest.json' }, { name: 'app.asar' }],
+})
+const noManifest = (tag: string): Rel => ({ tag_name: tag, assets: [{ name: 'app.asar' }] })
+
+describe('selectListRelease', () => {
+  it('experimental picks the newest installable release, including -exp tags', () => {
+    const releases = [withManifest('v0.9.14-exp.1'), withManifest('v0.9.13-rc3'), withManifest('v0.9.12')]
+    expect(selectListRelease('experimental', releases)?.tag_name).toBe('v0.9.14-exp.1')
+  })
+
+  it('beta skips -exp tags and picks the newest non-exp installable release', () => {
+    const releases = [withManifest('v0.9.14-exp.1'), withManifest('v0.9.13-rc3'), withManifest('v0.9.12')]
+    expect(selectListRelease('beta', releases)?.tag_name).toBe('v0.9.13-rc3')
+  })
+
+  it('experimental falls through to a newer non-exp build when it is newest', () => {
+    const releases = [withManifest('v0.9.15-rc1'), withManifest('v0.9.14-exp.1')]
+    expect(selectListRelease('experimental', releases)?.tag_name).toBe('v0.9.15-rc1')
+  })
+
+  it('both channels skip releases without a manifest.json asset', () => {
+    const releases = [noManifest('v0.9.14-exp.1'), noManifest('v0.9.13-rc3'), withManifest('v0.9.12')]
+    expect(selectListRelease('experimental', releases)?.tag_name).toBe('v0.9.12')
+    expect(selectListRelease('beta', releases)?.tag_name).toBe('v0.9.12')
+  })
+
+  it('the -exp match is case-insensitive and matches -experimental', () => {
+    const releases = [withManifest('v0.9.14-EXPERIMENTAL'), withManifest('v0.9.13')]
+    expect(selectListRelease('beta', releases)?.tag_name).toBe('v0.9.13')
+    expect(selectListRelease('experimental', releases)?.tag_name).toBe('v0.9.14-EXPERIMENTAL')
+  })
+
+  it('returns undefined when nothing is installable', () => {
+    expect(selectListRelease('beta', [noManifest('v0.9.14-exp.1')])).toBeUndefined()
+  })
+})

--- a/src/main/update/select-release.ts
+++ b/src/main/update/select-release.ts
@@ -1,0 +1,14 @@
+/** Pick the release for a list-based channel (beta/experimental) from the full
+ *  GitHub releases list (newest-first). Experimental takes the newest installable
+ *  release of any kind; beta excludes `-exp`-tagged builds so experimental-only
+ *  releases never reach beta users. */
+const hasManifest = (r: { assets: Array<{ name: string }> }): boolean =>
+  r.assets.some((a) => a.name === 'manifest.json')
+
+export function selectListRelease<T extends { tag_name: string; assets: Array<{ name: string }> }>(
+  channel: string,
+  releases: T[],
+): T | undefined {
+  if (channel === 'experimental') return releases.find(hasManifest)
+  return releases.find((r) => hasManifest(r) && !/-exp/i.test(r.tag_name))
+}

--- a/src/main/update/select-release.ts
+++ b/src/main/update/select-release.ts
@@ -6,7 +6,7 @@ const hasManifest = (r: { assets: Array<{ name: string }> }): boolean =>
   r.assets.some((a) => a.name === 'manifest.json')
 
 export function selectListRelease<T extends { tag_name: string; assets: Array<{ name: string }> }>(
-  channel: string,
+  channel: 'beta' | 'experimental',
   releases: T[],
 ): T | undefined {
   if (channel === 'experimental') return releases.find(hasManifest)

--- a/src/main/update/updater.ts
+++ b/src/main/update/updater.ts
@@ -133,7 +133,9 @@ async function checkForUpdates(channel: string): Promise<void> {
 
   try {
     // Fetch release from GitHub API.
-    // Beta channel: fetch all releases (including pre-releases), pick the newest.
+    // Beta/experimental: fetch all releases (including pre-releases) and let
+    // selectListRelease pick (experimental = newest installable of any kind;
+    // beta = same but excludes `-exp`-tagged builds).
     // Stable channel: fetch only the latest non-pre-release.
     let release: { tag_name: string; assets: Array<{ name: string; browser_download_url: string }> }
     if (channel === 'beta' || channel === 'experimental') {

--- a/src/main/update/updater.ts
+++ b/src/main/update/updater.ts
@@ -15,6 +15,7 @@ import { app, type BrowserWindow, ipcMain } from 'electron'
 import { ELECTRON_RELEASES, GITHUB_RELEASES_API } from '../../shared/endpoints'
 import type { InstallManifest } from '../../shared/types'
 import { findBrickedMatch } from '../../shared/version-match'
+import { selectListRelease } from './select-release'
 import { recordMainBreadcrumb, registerDiagnosticProvider } from '../diagnostics'
 import { stopHotkeyListener } from '../hotkeys'
 
@@ -135,11 +136,11 @@ async function checkForUpdates(channel: string): Promise<void> {
     // Beta channel: fetch all releases (including pre-releases), pick the newest.
     // Stable channel: fetch only the latest non-pre-release.
     let release: { tag_name: string; assets: Array<{ name: string; browser_download_url: string }> }
-    if (channel === 'beta') {
+    if (channel === 'beta' || channel === 'experimental') {
       const releases = await fetchJson<
         Array<{ tag_name: string; prerelease: boolean; assets: Array<{ name: string; browser_download_url: string }> }>
       >(GITHUB_RELEASES_API.replace('/latest', ''))
-      const candidate = releases.find((r) => r.assets.some((a) => a.name === 'manifest.json'))
+      const candidate = selectListRelease(channel, releases)
       if (!candidate) {
         checking = false
         return

--- a/src/renderer/src/components/settings/GeneralTab.tsx
+++ b/src/renderer/src/components/settings/GeneralTab.tsx
@@ -141,7 +141,7 @@ export function GeneralTab({ settings, update, updateProfile, onShowOnboarding }
       <section>
         <label>{m.settings_update_channel()}</label>
         <div className="flex gap-1.5 mt-[6px]">
-          {(['stable', 'beta'] as const).map((ch) => (
+          {(['stable', 'beta', 'experimental'] as const).map((ch) => (
             <button
               key={ch}
               onClick={() => update('updateChannel', ch)}
@@ -149,13 +149,21 @@ export function GeneralTab({ settings, update, updateProfile, onShowOnboarding }
                 settings.updateChannel === ch ? 'bg-accent text-bg-solid' : 'text-text-dim'
               }`}
             >
-              {ch === 'stable' ? m.settings_channel_stable() : m.settings_channel_beta()}
+              {{
+                stable: m.settings_channel_stable,
+                beta: m.settings_channel_beta,
+                experimental: m.settings_channel_experimental,
+              }[ch]()}
             </button>
           ))}
         </div>
-        {settings.updateChannel === 'beta' && (
+        {settings.updateChannel !== 'stable' && (
           <div className="mt-2 flex flex-col gap-1.5">
-            <p className="text-[10px] text-text-dim">{m.settings_beta_warning()}</p>
+            <p className="text-[10px] text-text-dim">
+              {settings.updateChannel === 'experimental'
+                ? m.settings_experimental_warning()
+                : m.settings_beta_warning()}
+            </p>
             <a
               href="https://discord.com/invite/nUNcrmEAP5"
               target="_blank"

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -469,7 +469,7 @@ export interface AppSettings {
    *  in a real drop zone (not town, not hideout). */
   useCurrentZoneAreaLevel: boolean
   reloadOnSave: boolean
-  updateChannel: 'stable' | 'beta'
+  updateChannel: 'stable' | 'beta' | 'experimental'
   tradeStatus: 'securable' | 'online' | 'available'
   /** Maps to PoE trade `trade_filters.collapse.option`. When true, the API groups
    *  multiple listings from the same seller into one row. */


### PR DESCRIPTION
## Add an `experimental` update channel

Adds a third update channel, `experimental`, alongside `stable` and `beta`.