### PR TITLE
feat: add companion browser mode

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
           regexRemote: resolve(__dirname, 'src/renderer/regex-remote.html'),
           pinnedZone: resolve(__dirname, 'src/renderer/pinned-zone.html'),
           pluginOverlay: resolve(__dirname, 'src/renderer/plugin-overlay.html'),
+          // Companion browser mode: served by the HTTP server in companion mode
+          companion: resolve(__dirname, 'src/renderer/companion.html'),
         },
       },
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "scalpel",
-  "version": "0.9.12-rc1",
+  "version": "0.9.12-rc4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scalpel",
-      "version": "0.9.12-rc1",
+      "version": "0.9.12-rc4",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@types/ws": "^8.18.1",
         "active-win": "^9.0.0",
         "electron-overlay-window": "^4.0.2",
         "electron-store": "^8.2.0",
@@ -18,6 +19,7 @@
         "react-sortablejs": "^6.1.4",
         "sortablejs": "^1.15.7",
         "uiohook-napi": "^1.5.4",
+        "ws": "^8.21.0",
         "zustand": "^4.5.7"
       },
       "devDependencies": {
@@ -2808,6 +2810,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -4045,6 +4048,15 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -15072,10 +15084,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "main": "out/main/index.js",
   "scripts": {
     "dev": "npm run build:internal-assets && node scripts/sync-regex-data.js & electron-vite dev",
+    "dev:companion": "npm run build:internal-assets && electron-vite dev -- --companion-mode",
     "build": "npm run build:internal-assets && electron-vite build",
     "build:internal-assets": "node scripts/build-internal-assets.mjs",
     "build-tier-data": "node scripts/build-tier-data.js",
@@ -36,6 +37,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@types/ws": "^8.18.1",
     "active-win": "^9.0.0",
     "electron-overlay-window": "^4.0.2",
     "electron-store": "^8.2.0",
@@ -44,6 +46,7 @@
     "react-sortablejs": "^6.1.4",
     "sortablejs": "^1.15.7",
     "uiohook-napi": "^1.5.4",
+    "ws": "^8.21.0",
     "zustand": "^4.5.7"
   },
   "devDependencies": {

--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -8,4 +8,26 @@ exports.default = async function afterPack(context) {
     fs.unlinkSync(ymlPath)
     console.log('[afterPack] Removed app-update.yml')
   }
+
+  // Fix AppRun for Linux AppImage: the auto-generated AppRun tries to find a
+  // file named after $1 (the first CLI arg) when detecting APPDIR. This breaks
+  // when the first arg is a flag like --companion-mode instead of a filename.
+  // Replace the faulty APPDIR detection with a simple dirname-based one.
+  if (context.electronPlatformName !== 'linux') return
+  const appRunPath = path.join(context.appOutDir, 'AppRun')
+  if (!fs.existsSync(appRunPath)) return
+
+  const original = fs.readFileSync(appRunPath, 'utf8')
+  const fixed = original.replace(
+    // Replace the while-loop APPDIR detection block
+    /if \[ -z "\$APPDIR" \] ; then[\s\S]*?APPDIR="\$path"\nfi/,
+    `if [ -z "$APPDIR" ] ; then
+  APPDIR="$(dirname "$(readlink -f "$0")")"
+fi`
+  )
+
+  if (fixed !== original) {
+    fs.writeFileSync(appRunPath, fixed, 'utf8')
+    console.log('[afterPack] Patched AppRun APPDIR detection for flag-only invocations')
+  }
 }

--- a/src/main/companion/bridge-wiring.ts
+++ b/src/main/companion/bridge-wiring.ts
@@ -1,0 +1,52 @@
+/**
+ * Companion Bridge Wiring
+ *
+ * In companion mode (isCompanion=true):
+ *   - Sets a fake window via setCompanionWindow so evaluation.ts / trade.ts
+ *     route ALL their webContents.send calls through the bridge.
+ *     This includes overlay-data, price-check, setting-updated, etc.
+ *   - Does NOT add explicit setting/league listeners (fake window covers them).
+ *
+ * In normal mode (isCompanion=false):
+ *   - Does NOT set the fake window (real overlay window handles evaluation events).
+ *   - Adds explicit listeners for setting/league updates so browser clients
+ *     receive those changes even without the fake window.
+ */
+
+import { wsBridge } from './ws-bridge'
+
+export async function wireCompanionBridge(isCompanion: boolean): Promise<void> {
+  // ---- zone changes (both modes) -------------------------------------------
+  const { onZoneChanged } = await import('../client-log/zone-state')
+  onZoneChanged((zone) => wsBridge.push('zone-changed', zone))
+
+  // ---- filter loaded (both modes) ------------------------------------------
+  const { onFilterLoaded } = await import('../filter-state')
+  onFilterLoaded(() => wsBridge.push('filter-changed'))
+
+  // ---- rate-limit state (both modes) ---------------------------------------
+  const { onRateLimitUpdate } = await import('../trade/trade')
+  onRateLimitUpdate((state) => wsBridge.push('rate-limit', state))
+
+  if (isCompanion) {
+    // Companion mode: inject a fake window that forwards ALL webContents.send
+    // calls (overlay-data, price-check, setting-updated, league-updated, etc.)
+    // directly to the bridge. This avoids needing per-channel explicit listeners.
+    const { setCompanionWindow } = await import('../overlay')
+    setCompanionWindow({
+      isDestroyed: () => false,
+      webContents: {
+        send(channel: string, ...args: unknown[]): void {
+          wsBridge.push(channel, ...args)
+        },
+      },
+    })
+  } else {
+    // Normal mode: real overlay window handles evaluation events for Electron.
+    // Add explicit listeners only for setting/league so browser clients also
+    // receive those when connected alongside the normal overlay.
+    const { addCompanionSettingListener, addCompanionLeagueListener } = await import('../settings-write')
+    addCompanionSettingListener((key, value) => wsBridge.push('setting-updated', key, value))
+    addCompanionLeagueListener((league) => wsBridge.push('league-updated', league))
+  }
+}

--- a/src/main/companion/clipboard-watcher.ts
+++ b/src/main/companion/clipboard-watcher.ts
@@ -1,0 +1,92 @@
+/**
+ * Companion mode clipboard watcher.
+ *
+ * Polls the clipboard every 500ms. When the text changes to a valid PoE item,
+ * automatically triggers the price-check pipeline and pushes results to all
+ * connected WebSocket clients via the bridge.
+ *
+ * This replaces the hotkey flow for companion mode because:
+ *  - uiohook (X11 XRecord) cannot capture keypresses destined for
+ *    Wayland-native windows (like PoE running on Hyprland).
+ *  - globalShortcut via XWayland also does not intercept Wayland-native focus.
+ *  - The user simply presses Ctrl+C on an item in PoE; the watcher detects
+ *    the change and fires automatically.
+ */
+
+import { clipboard } from 'electron'
+import type Store from 'electron-store'
+import type { AppSettings, GameVariant } from '../../shared/types'
+import { getProfileBackedSetting } from '../profiles/profile-settings'
+
+let watchTimer: ReturnType<typeof setInterval> | null = null
+let lastClipboardText = ''
+
+export function startCompanionClipboardWatcher(store: Store<AppSettings>): void {
+  if (watchTimer) return
+
+  // Snapshot current clipboard so we don't fire on stale content at startup.
+  try {
+    lastClipboardText = clipboard.readText()
+  } catch {
+    lastClipboardText = ''
+  }
+
+  watchTimer = setInterval(async () => {
+    let text = ''
+    try {
+      text = clipboard.readText()
+    } catch {
+      return
+    }
+
+    if (text === lastClipboardText) return
+    lastClipboardText = text
+
+    if (!text.trim()) return
+
+    // Try to parse as a PoE item. Import lazily to avoid loading the full
+    // filter/trade stack at module initialisation time.
+    try {
+      const { parseItemText } = await import('../trade/clipboard')
+      const item = parseItemText(text)
+      if (!item) return
+
+      // Guard: if the active league is still empty (fresh install, leagues not
+      // fetched yet) wait up to 5 seconds for it to populate before giving up.
+      let league = getProfileBackedSetting(store, 'league') as string
+      if (!league) {
+        for (let i = 0; i < 10; i++) {
+          await new Promise((r) => setTimeout(r, 500))
+          league = getProfileBackedSetting(store, 'league') as string
+          if (league) break
+        }
+      }
+
+      // If still no league, write the first available one directly to the store
+      // so runPriceCheck (which reads league via getProfileBackedSetting) finds it.
+      if (!league) {
+        const poeVersion = (store.get('poeVersion') as GameVariant) ?? 2
+        const leagues = (store.get(poeVersion === 2 ? 'leaguesPoe2' : 'leaguesPoe1') as string[]) ?? []
+        if (leagues[0]) {
+          const { writeActiveProfileSetting } = await import('../profiles/profile-settings')
+          writeActiveProfileSetting(store, 'league', leagues[0])
+        }
+      }
+
+      // Item detected -- run the full price-check pipeline.
+      const { runPriceCheck } = await import('../evaluation')
+      await runPriceCheck(item, store)
+    } catch (err) {
+      console.error('[companion-clipboard] price check failed:', err)
+    }
+  }, 500)
+
+  console.log('[companion] Clipboard watcher started (500ms poll)')
+}
+
+export function stopCompanionClipboardWatcher(): void {
+  if (watchTimer) {
+    clearInterval(watchTimer)
+    watchTimer = null
+  }
+}

--- a/src/main/companion/server.ts
+++ b/src/main/companion/server.ts
@@ -1,0 +1,806 @@
+/**
+ * Companion HTTP + WebSocket Server
+ *
+ * Serves the companion renderer bundle over HTTP on localhost and
+ * multiplexes all window.api IPC calls over a single WebSocket connection.
+ *
+ * Protocol (JSON frames over WebSocket):
+ *
+ *   Client -> Server (invoke):
+ *     { type: 'invoke', id: number, method: string, args: unknown[] }
+ *   Server -> Client (invoke reply):
+ *     { type: 'reply', id: number, result: unknown }
+ *     { type: 'reply', id: number, error: string }
+ *
+ *   Client -> Server (send, fire-and-forget):
+ *     { type: 'send', method: string, args: unknown[] }
+ *
+ *   Server -> Client (push event from main process):
+ *     { type: 'event', channel: string, args: unknown[] }
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import { join } from 'node:path'
+import { readFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { WebSocketServer, type WebSocket } from 'ws'
+import type Store from 'electron-store'
+import type { AppSettings, FilterBlock, GameVariant, PoeItem } from '../../shared/types'
+import type { RegexPreset } from '../../shared/types'
+import type { ProfileSettingKey, ProfileSettingValue } from '../profiles/profile-settings'
+import { wsBridge } from './ws-bridge'
+
+// ---------------------------------------------------------------------------
+// MIME map for static file serving
+// ---------------------------------------------------------------------------
+const MIME: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.mjs': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.ttf': 'font/ttf',
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch table
+// ---------------------------------------------------------------------------
+type DispatchFn = (args: unknown[]) => Promise<unknown> | unknown
+
+function reg(table: Map<string, DispatchFn>, method: string, fn: DispatchFn): void {
+  table.set(method, fn)
+}
+
+async function buildDispatchTable(store: Store<AppSettings>): Promise<Map<string, DispatchFn>> {
+  const table = new Map<string, DispatchFn>()
+
+  // Import all business-logic modules once at table-build time.
+  const [
+    profileSettings,
+    manifestModule,
+    historyModule,
+    versionsModule,
+    filterStateModule,
+    iconCacheModule,
+    pricesModule,
+    settingsWriteModule,
+    learningModule,
+    tailBufferModule,
+    pluginManagerModule,
+    pluginStorageModule,
+    whiteboardModule,
+    leaguesModule,
+    filesModule,
+  ] = await Promise.all([
+    import('../profiles/profile-settings'),
+    import('../manifest'),
+    import('../history'),
+    import('../update/versions'),
+    import('../filter-state'),
+    import('../trade/icon-cache'),
+    import('../trade/prices'),
+    import('../settings-write'),
+    import('../learning/index'),
+    import('../client-log/tail-buffer'),
+    import('../plugins/manager'),
+    import('../plugins/storage'),
+    import('../whiteboard'),
+    import('../trade/leagues'),
+    import('../handlers/files'),
+  ])
+
+  // ----- settings / profiles -----
+  reg(table, 'get-settings', () => profileSettings.getEffectiveSettings(store))
+
+  reg(table, 'get-color-frequencies', () => filterStateModule.getColorFrequencies())
+
+  reg(table, 'list-profiles', () => profileSettings.listProfileSummaries(store))
+
+  reg(table, 'create-profile', (args) => {
+    const [input] = args as [{ name: string; gameVariant: 1 | 2; cloneFromId?: string }]
+    return profileSettings.createProfile(input)
+  })
+  reg(table, 'rename-profile', (args) => {
+    const [id, name] = args as [string, string]
+    return profileSettings.renameProfile(id, name)
+  })
+  reg(table, 'delete-profile', (args) => {
+    const [id] = args as [string]
+    profileSettings.deleteProfileAndChooseFallback(store, id)
+  })
+  reg(table, 'ensure-profile-for-game', (args) => {
+    const [variant] = args as [1 | 2]
+    profileSettings.ensureProfileForGame(store, variant)
+  })
+
+  reg(table, 'set-setting', (args) => {
+    const [key, value] = args as [keyof AppSettings, unknown]
+    settingsWriteModule.applySetting(store, key, value as AppSettings[typeof key], null)
+  })
+
+  reg(table, 'set-profile-setting-for-game', (args) => {
+    const [variant, key, value] = args as [GameVariant, ProfileSettingKey, ProfileSettingValue<ProfileSettingKey>]
+    return settingsWriteModule.applyProfileSettingForGame(store, variant, key, value, null)
+  })
+
+  reg(table, 'refresh-leagues', async () => {
+    // refreshLeagues takes (store, fetcher, options); pass store explicitly
+    return leaguesModule.refreshLeagues(
+      store,
+      undefined as unknown as Parameters<typeof leaguesModule.refreshLeagues>[1],
+      { force: true },
+    )
+  })
+
+  reg(table, 'get-regex-presets', () => {
+    const key = store.get('poeVersion') === 2 ? 'regexPresetsPoe2' : 'regexPresetsPoe1'
+    return store.get(key) ?? []
+  })
+  reg(table, 'save-regex-preset', (args) => {
+    const [preset] = args as [{ id: string; label: string; text: string }]
+    const key = store.get('poeVersion') === 2 ? 'regexPresetsPoe2' : 'regexPresetsPoe1'
+    const current = (store.get(key) ?? []) as RegexPreset[]
+    const idx = current.findIndex((p) => p.id === preset.id)
+    // biome-ignore lint/suspicious/noExplicitAny: preset shape varies at runtime
+    if (idx >= 0) current[idx] = preset as any
+    // biome-ignore lint/suspicious/noExplicitAny: preset shape varies at runtime
+    else current.push(preset as any)
+    store.set(key, current)
+    wsBridge.push('regex-presets-changed')
+    return current
+  })
+  reg(table, 'delete-regex-preset', (args) => {
+    const [id] = args as [string]
+    const key = store.get('poeVersion') === 2 ? 'regexPresetsPoe2' : 'regexPresetsPoe1'
+    const current = ((store.get(key) ?? []) as { id: string }[]).filter((p) => p.id !== id)
+    store.set(key, current)
+    wsBridge.push('regex-presets-changed')
+    return current
+  })
+
+  // ----- manifest -----
+  reg(table, 'get-manifest', () => manifestModule.getManifest())
+
+  // ----- files -----
+  reg(table, 'pick-filter-file', () => filesModule.pickFilterFile(store))
+  reg(table, 'pick-filter-dir', () => filesModule.pickFilterDir(store))
+  reg(table, 'scan-filter-dir', (args) => {
+    const [dir] = args as [string]
+    return filesModule.scanFilterDir(dir)
+  })
+  reg(table, 'scan-sound-files', (args) => {
+    const [dir] = args as [string]
+    return filesModule.scanSoundFiles(dir)
+  })
+  reg(table, 'get-sound-data-url', (args) => {
+    const [dir, filename] = args as [string, string]
+    return filesModule.getSoundDataUrl(dir, filename)
+  })
+
+  // ----- history / versions -----
+  reg(table, 'get-history', () => historyModule.getHistory())
+  reg(table, 'list-versions', () => {
+    const profile = profileSettings.getActiveProfile(store)
+    if (!profile?.filterPath) return []
+    return versionsModule.listVersions(profile.filterPath)
+  })
+  reg(table, 'create-checkpoint', (args) => {
+    const [label] = args as [string | undefined]
+    const profile = profileSettings.getActiveProfile(store)
+    if (!profile?.filterPath) return { ok: false, error: 'No filter loaded' }
+    versionsModule.saveVersion(profile.filterPath, true, label ?? 'Manual checkpoint')
+    return { ok: true }
+  })
+  reg(table, 'restore-version', async (args) => {
+    const [filename, itemJson] = args as [string, string | undefined]
+    const profile = profileSettings.getActiveProfile(store)
+    if (!profile?.filterPath) return { ok: false, error: 'No filter loaded' }
+    const result = versionsModule.restoreVersion(profile.filterPath, filename)
+    if (result.ok) {
+      filterStateModule.loadFilter(profile.filterPath)
+      historyModule.clearHistory()
+      if (itemJson) {
+        const { evaluateAndSend } = await import('../evaluation')
+        evaluateAndSend(JSON.parse(itemJson) as PoeItem)
+      }
+    }
+    return result
+  })
+  reg(table, 'delete-version', (args) => {
+    const [filename] = args as [string]
+    return versionsModule.deleteVersion(filename)
+  })
+  reg(table, 'undo-edit', async (args) => {
+    const [itemJson] = args as [string | undefined]
+    const profile = profileSettings.getActiveProfile(store)
+    if (!profile?.filterPath) return { ok: false, error: 'No filter loaded' }
+    const result = historyModule.undoLast(profile.filterPath)
+    if (result.ok) {
+      filterStateModule.loadFilter(profile.filterPath)
+      if (itemJson) {
+        const { evaluateAndSend } = await import('../evaluation')
+        evaluateAndSend(JSON.parse(itemJson) as PoeItem)
+      }
+    }
+    return result
+  })
+
+  // ----- prices -----
+  reg(table, 'get-icon-cache', () => {
+    const v = (store.get('poeVersion') ?? 2) as 1 | 2
+    return iconCacheModule.loadIconCache(v)
+  })
+  reg(table, 'get-uniques-for-base', (args) => {
+    const [baseType] = args as [string]
+    return pricesModule.getUniquesByBase()[baseType] ?? []
+  })
+  reg(table, 'refresh-prices', async () => {
+    const league = profileSettings.getProfileBackedSetting(store, 'league')
+    await pricesModule.refreshPrices(league)
+  })
+  reg(table, 'batch-lookup-prices', async (args) => {
+    const [baseTypes, league, uniqueTier] = args as [string[], string, boolean | undefined]
+    await pricesModule.refreshPrices(league)
+    const result: Record<string, { chaosValue: number; divineValue?: number } | null> = {}
+    for (const bt of baseTypes) {
+      result[bt] =
+        (uniqueTier ? pricesModule.lookupBestUniquePrice(bt) : undefined) ?? pricesModule.lookupPrice(bt, bt) ?? null
+    }
+    return result
+  })
+  reg(table, 'batch-lookup-ref-prices', async (args) => {
+    const [refs, league] = args as [Array<{ name: string; baseType?: string }>, string]
+    await pricesModule.refreshPrices(league)
+    const result: Record<string, { chaosValue: number; divineValue?: number } | null> = {}
+    for (const r of refs) {
+      result[r.name] = pricesModule.lookupPrice(r.name, r.baseType ?? r.name) ?? null
+    }
+    return result
+  })
+  reg(table, 'batch-lookup-div-card-prices', async (args) => {
+    const [cardNames, league] = args as [string[], string]
+    await pricesModule.refreshPrices(league)
+    const result: Record<string, { chaosValue: number; divineValue?: number } | null> = {}
+    for (const name of cardNames) {
+      result[name] = pricesModule.lookupDivCardPrice(name) ?? null
+    }
+    return result
+  })
+  reg(table, 'get-unique-visibility', async () => {
+    if (!filterStateModule.getCurrentFilter()) return {}
+    const pricesHandler = await import('../handlers/prices')
+    await pricesHandler.primeSearchableItemsCache(store)
+    const f = filterStateModule.getCurrentFilter()
+    if (!f) return {}
+    const result: Record<string, 'Show' | 'Hide'> = {}
+    for (const block of f.blocks) {
+      if (block.visibility !== 'Hide') continue
+      const hasUniqueCond = block.conditions.some((c) => c.type === 'Rarity' && c.values.includes('Unique'))
+      if (!hasUniqueCond) continue
+      for (const cond of block.conditions) {
+        if (cond.type === 'BaseType') {
+          for (const v of cond.values) result[v] = 'Hide'
+        }
+      }
+    }
+    return result
+  })
+  reg(table, 'get-div-card-tiers', () => {
+    const f = filterStateModule.getCurrentFilter()
+    if (!f) return { tierStyles: {}, cardTiers: {}, hiddenCards: {} }
+    const tierStyles: Record<string, { border: string; bg: string; text: string }> = {}
+    const cardTiers: Record<string, string> = {}
+    const hiddenCards: Record<string, boolean> = {}
+    const toRgba = (a: { values: string[] }): string => {
+      const [r, g, b, alpha] = a.values.map(Number)
+      return `rgba(${r ?? 0},${g ?? 0},${b ?? 0},${(alpha ?? 255) / 255})`
+    }
+    for (const block of f.blocks) {
+      if (!block.tierTag || block.tierTag.typePath !== 'divination') continue
+      const tier = block.tierTag.tier
+      const isHidden = block.visibility === 'Hide'
+      const border = block.actions.find((a) => a.type === 'SetBorderColor')
+      const bg = block.actions.find((a) => a.type === 'SetBackgroundColor')
+      const text = block.actions.find((a) => a.type === 'SetTextColor')
+      tierStyles[tier] = {
+        border: border ? toRgba(border) : 'transparent',
+        bg: bg ? toRgba(bg) : 'transparent',
+        text: text ? toRgba(text) : '#fff',
+      }
+      for (const cond of block.conditions) {
+        if (cond.type === 'BaseType') {
+          for (const v of cond.values) {
+            cardTiers[v] = tier
+            if (isHidden) hiddenCards[v] = true
+          }
+        }
+      }
+    }
+    return { tierStyles, cardTiers, hiddenCards }
+  })
+  reg(table, 'get-searchable-items', async () => {
+    const pricesHandler = await import('../handlers/prices')
+    await pricesHandler.primeSearchableItemsCache(store)
+    // Return empty; the cache is not directly exported; caller can use batch-lookup-prices
+    return []
+  })
+
+  // ----- trade -----
+  reg(table, 'trade-search', async (args) => {
+    const [item, statFilters, searchOptions] = args as [
+      {
+        name: string
+        baseType: string
+        itemClass: string
+        rarity: string
+        armour?: number
+        evasion?: number
+        energyShield?: number
+        ward?: number
+        block?: number
+        vaalGem?: boolean
+      },
+      Parameters<typeof import('../trade/trade').searchTrade>[2],
+      { listedTime?: string; priceOption?: string; statusOption?: string } | undefined,
+    ]
+    const { searchTrade, searchNeedsLogin } = await import('../trade/trade')
+    const league = profileSettings.getProfileBackedSetting(store, 'league')
+    const status = searchOptions?.statusOption ?? store.get('tradeStatus') ?? 'available'
+    const price =
+      searchOptions?.priceOption ?? profileSettings.getProfileBackedSetting(store, 'tradePriceOption') ?? 'chaos_divine'
+    const collapse = store.get('tradeCollapseListings') ?? true
+    const { session } = await import('electron')
+    const cookie = await session.defaultSession.cookies.get({ name: 'POESESSID' })
+    const loggedIn = searchNeedsLogin(statFilters as Parameters<typeof searchNeedsLogin>[0]) ? cookie.length > 0 : true
+    return searchTrade(league, item, statFilters as Parameters<typeof searchTrade>[2], {
+      tradeStatus: status,
+      tradePriceOption: price as string,
+      listedTime: searchOptions?.listedTime,
+      collapseListings: collapse as boolean,
+      loggedIn,
+    })
+  })
+  reg(table, 'bulk-exchange', async (args) => {
+    const [itemName, baseType, haveId] = args as [string, string, string | undefined]
+    const { searchBulkExchange, getBulkExchangeId } = await import('../trade/trade')
+    const league = profileSettings.getProfileBackedSetting(store, 'league')
+    const wantId = getBulkExchangeId(itemName, baseType)
+    if (!wantId) return { total: 0, listings: [], queryId: '' }
+    return searchBulkExchange(league, wantId, haveId ?? 'chaos')
+  })
+  reg(table, 'check-bulk-item', async (args) => {
+    const [itemName, baseType, itemClass, rarity] = args as [string, string, string, string | undefined]
+    const { isBulkExchangeItem } = await import('../trade/trade')
+    return isBulkExchangeItem(itemClass, itemName, baseType, rarity)
+  })
+  reg(table, 'map-regex-trade', async (args) => {
+    const [params] = args as [
+      {
+        tier: number
+        avoidTexts: string[]
+        wantTexts: string[]
+        wantMode: 'any' | 'all'
+        qualifiers: Record<string, number>
+        nightmare: boolean
+        originator: boolean
+        corrupted8mod: boolean
+      },
+    ]
+    const { searchMapsByRegex } = await import('../trade/trade')
+    const league = profileSettings.getProfileBackedSetting(store, 'league')
+    const tradeStatus = store.get('tradeStatus') ?? 'available'
+    const tradePriceOption = profileSettings.getProfileBackedSetting(store, 'tradePriceOption') ?? 'chaos_divine'
+    const collapse = store.get('tradeCollapseListings') ?? true
+    const result = await searchMapsByRegex(
+      league,
+      params.tier,
+      params.avoidTexts,
+      params.wantTexts,
+      params.wantMode,
+      params.qualifiers,
+      params.nightmare,
+      params.originator,
+      params.corrupted8mod,
+      tradeStatus as string,
+      tradePriceOption as string,
+      collapse as boolean,
+    )
+    return { ...result, league }
+  })
+  reg(table, 'fetch-more-listings', async (args) => {
+    const [queryId, ids] = args as [string, string[]]
+    const { fetchMoreListings } = await import('../trade/trade')
+    return fetchMoreListings(queryId, ids)
+  })
+  reg(table, 'poe-login', async () => {
+    // Open the real Electron login window so POESESSID lands in the Electron
+    // session (not the browser's session). The ipcMain handler for poe-login
+    // is registered by tradeHandlers.register(store) -- call it directly here.
+    const { BrowserWindow } = await import('electron')
+    const { POE_WEBSITE } = await import('../../shared/endpoints')
+    return new Promise<void>((resolve) => {
+      const LOGIN_TITLE = 'Login - Path of Exile'
+      const loginWindow = new BrowserWindow({
+        width: 800,
+        height: 700,
+        title: LOGIN_TITLE,
+        autoHideMenuBar: true,
+        webPreferences: { nodeIntegration: false, contextIsolation: true },
+      })
+      loginWindow.webContents.on('page-title-updated', (event) => {
+        event.preventDefault()
+        loginWindow.setTitle(LOGIN_TITLE)
+      })
+      loginWindow.loadURL(`${POE_WEBSITE}/login`)
+      loginWindow.webContents.on('did-navigate', (_event, url) => {
+        if (url.includes('pathofexile.com/my-account') || url === `${POE_WEBSITE}/`) {
+          loginWindow.close()
+        }
+      })
+      loginWindow.on('closed', () => resolve())
+    })
+  })
+  reg(table, 'poe-check-auth', async () => {
+    const { session } = await import('electron')
+    const cookie = await session.defaultSession.cookies.get({ name: 'POESESSID' })
+    return { loggedIn: cookie.length > 0 }
+  })
+  reg(table, 'poe-logout', async () => {
+    const { session } = await import('electron')
+    await session.defaultSession.cookies.remove('https://www.pathofexile.com', 'POESESSID')
+  })
+  reg(table, 'open-external', async (args) => {
+    const { shell } = await import('electron')
+    await shell.openExternal(args[0] as string)
+  })
+
+  // ----- overlay state (synthetic values for companion mode) -----
+  reg(table, 'get-overlay-state', () => ({
+    poeVersion: store.get('poeVersion') ?? 2,
+    gameBounds: null, // no overlay window in companion mode
+  }))
+
+  // ----- filter editing -----
+  reg(table, 'reload-filter', () => {
+    const f = filterStateModule.getCurrentFilter()
+    if (!f) return { ok: false, error: 'No filter loaded' }
+    filterStateModule.loadFilter(f.path)
+    return { ok: true }
+  })
+  reg(table, 'save-block-edit', async (args) => {
+    const [blockIndex, updatedBlock, itemJson] = args as [number, FilterBlock, string | undefined]
+    const f = filterStateModule.getCurrentFilter()
+    if (!f) return { ok: false, error: 'No filter loaded' }
+    try {
+      const { writeBlockEdit } = await import('../filter/writer')
+      const { captureSnapshot } = await import('../history')
+      captureSnapshot(f.path, 'block-edit', `Block edit #${blockIndex + 1}`, undefined)
+      writeBlockEdit(f, blockIndex, updatedBlock)
+      const profile = profileSettings.getActiveProfile(store)
+      if (profile?.filterPath) filterStateModule.loadFilter(profile.filterPath)
+      const fresh = filterStateModule.getCurrentFilter()
+      if (fresh && itemJson) {
+        const { evaluateAndSend } = await import('../evaluation')
+        evaluateAndSend(JSON.parse(itemJson) as PoeItem)
+      }
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, error: String(err) }
+    }
+  })
+  reg(table, 'move-item-tier', async (args) => {
+    const [baseType, from, to, itemJson] = args as [string, number, number, string]
+    const f = filterStateModule.getCurrentFilter()
+    if (!f) return { ok: false, error: 'No filter loaded' }
+    try {
+      const { moveBaseTypeBetweenTiers } = await import('../filter/writer')
+      const { captureSnapshot } = await import('../history')
+      captureSnapshot(f.path, 'tier-move', `Moved "${baseType}"`, baseType)
+      moveBaseTypeBetweenTiers(f, baseType, from, to)
+      const profile = profileSettings.getActiveProfile(store)
+      if (profile?.filterPath) filterStateModule.loadFilter(profile.filterPath)
+      if (itemJson) {
+        const fresh = filterStateModule.getCurrentFilter()
+        if (fresh) {
+          const { evaluateAndSend } = await import('../evaluation')
+          evaluateAndSend(JSON.parse(itemJson) as PoeItem)
+        }
+      }
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, error: String(err) }
+    }
+  })
+  reg(table, 'batch-move-item-tier', async (args) => {
+    const [baseTypes, from, to, itemJson] = args as [string[], number, number, string]
+    const f = filterStateModule.getCurrentFilter()
+    if (!f) return { ok: false, error: 'No filter loaded' }
+    try {
+      const { moveBaseTypeBetweenTiers } = await import('../filter/writer')
+      const { captureSnapshot } = await import('../history')
+      captureSnapshot(f.path, 'tier-move', `Batch moved ${baseTypes.length} items`, undefined)
+      for (const bt of baseTypes) moveBaseTypeBetweenTiers(f, bt, from, to)
+      const profile = profileSettings.getActiveProfile(store)
+      if (profile?.filterPath) filterStateModule.loadFilter(profile.filterPath)
+      if (itemJson) {
+        const fresh = filterStateModule.getCurrentFilter()
+        if (fresh) {
+          const { evaluateAndSend } = await import('../evaluation')
+          evaluateAndSend(JSON.parse(itemJson) as PoeItem)
+        }
+      }
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, error: String(err) }
+    }
+  })
+  reg(table, 'update-stack-thresholds', async (args) => {
+    const [oldBoundary, newBoundary, itemJson] = args as [number, number, string]
+    const f = filterStateModule.getCurrentFilter()
+    if (!f) return { ok: false, error: 'No filter loaded' }
+    try {
+      const { updateStackThresholds } = await import('../filter/writer')
+      updateStackThresholds(f, oldBoundary, newBoundary)
+      const profile = profileSettings.getActiveProfile(store)
+      if (profile?.filterPath) filterStateModule.loadFilter(profile.filterPath)
+      const { evaluateAndSend } = await import('../evaluation')
+      evaluateAndSend(JSON.parse(itemJson) as PoeItem)
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, error: String(err) }
+    }
+  })
+  reg(table, 'update-quality-thresholds', async (args) => {
+    const [oldBoundary, newBoundary, itemJson] = args as [number, number, string]
+    const f = filterStateModule.getCurrentFilter()
+    if (!f) return { ok: false, error: 'No filter loaded' }
+    try {
+      const { updateQualityThresholds } = await import('../filter/writer')
+      updateQualityThresholds(f, oldBoundary, newBoundary)
+      const profile = profileSettings.getActiveProfile(store)
+      if (profile?.filterPath) filterStateModule.loadFilter(profile.filterPath)
+      const { evaluateAndSend } = await import('../evaluation')
+      evaluateAndSend(JSON.parse(itemJson) as PoeItem)
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, error: String(err) }
+    }
+  })
+  reg(table, 'update-strand-thresholds', async (args) => {
+    const [oldBoundary, newBoundary, itemJson] = args as [number, number, string]
+    const f = filterStateModule.getCurrentFilter()
+    if (!f) return { ok: false, error: 'No filter loaded' }
+    try {
+      const { updateStrandThresholds } = await import('../filter/writer')
+      updateStrandThresholds(f, oldBoundary, newBoundary)
+      const profile = profileSettings.getActiveProfile(store)
+      if (profile?.filterPath) filterStateModule.loadFilter(profile.filterPath)
+      const { evaluateAndSend } = await import('../evaluation')
+      evaluateAndSend(JSON.parse(itemJson) as PoeItem)
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, error: String(err) }
+    }
+  })
+
+  // ----- learning -----
+  reg(table, 'reset-learning', (args) => {
+    const [scope] = args as [unknown]
+    learningModule.resetLearning(scope as 'all' | { rarity: string; itemClass: string })
+  })
+
+  // ----- client-log -----
+  reg(table, 'client-log:recent-lines', (args) => {
+    const [count] = args as [number | undefined]
+    return tailBufferModule.getRecentLogLines(count ?? 100)
+  })
+
+  // ----- plugins (subset usable without the overlay window) -----
+  reg(table, 'plugins:list-installed', () => pluginManagerModule.getInstalledPlugins())
+  reg(table, 'plugins:storage-get', (args) => {
+    const [pluginId, key] = args as [string, string]
+    return pluginStorageModule.getValue(pluginId, key)
+  })
+  reg(table, 'plugins:storage-set', (args) => {
+    const [pluginId, key, value] = args as [string, string, unknown]
+    pluginStorageModule.setValue(pluginId, key, value)
+  })
+  reg(table, 'plugins:storage-delete', (args) => {
+    const [pluginId, key] = args as [string, string]
+    pluginStorageModule.deleteValue(pluginId, key)
+  })
+  reg(table, 'plugins:storage-keys', (args) => {
+    const [pluginId] = args as [string]
+    return pluginStorageModule.listKeys(pluginId)
+  })
+
+  // ----- whiteboard (persistence) -----
+  reg(table, 'whiteboard:load', (args) => {
+    const [version, gameSize] = args as [1 | 2, { w: number; h: number }]
+    return whiteboardModule.loadLibrary(version, gameSize)
+  })
+  reg(table, 'whiteboard:save-active', (args) => {
+    const [version, state] = args as [1 | 2, Parameters<typeof whiteboardModule.saveLibrary>[1]]
+    whiteboardModule.saveLibrary(version, state)
+  })
+
+  return table
+}
+
+// ---------------------------------------------------------------------------
+// Message handling
+// ---------------------------------------------------------------------------
+interface InvokeFrame {
+  type: 'invoke'
+  id: number
+  method: string
+  args: unknown[]
+}
+interface SendFrame {
+  type: 'send'
+  method: string
+  args: unknown[]
+}
+type ClientFrame = InvokeFrame | SendFrame
+
+async function handleFrame(frame: ClientFrame, table: Map<string, DispatchFn>, ws: WebSocket): Promise<void> {
+  if (frame.type === 'invoke') {
+    const { id, method, args } = frame
+    try {
+      const fn = table.get(method)
+      if (!fn) {
+        ws.send(JSON.stringify({ type: 'reply', id, error: `Unknown method: ${method}` }))
+        return
+      }
+      const result = await fn(args)
+      ws.send(JSON.stringify({ type: 'reply', id, result: result ?? null }))
+    } catch (err) {
+      ws.send(JSON.stringify({ type: 'reply', id, error: String(err) }))
+    }
+    return
+  }
+
+  if (frame.type === 'send') {
+    const { method, args } = frame
+    const fn = table.get(method)
+    if (fn) void fn(args)
+    return
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Server lifecycle
+// ---------------------------------------------------------------------------
+let serverInstance: ReturnType<typeof createServer> | null = null
+let wssInstance: WebSocketServer | null = null
+
+export interface CompanionServerOptions {
+  store: Store<AppSettings>
+  port?: number
+  /** Absolute path to the companion renderer build output.
+   *  Defaults to out/renderer/companion/ next to the ASAR. */
+  staticDir?: string
+}
+
+export function startCompanionServer(opts: CompanionServerOptions): void {
+  if (serverInstance) return
+
+  const { store, port = 0 } = opts
+
+  const staticDir = opts.staticDir ?? (process.env.ELECTRON_RENDERER_URL ? null : join(__dirname, '../renderer'))
+
+  const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    res.setHeader('Access-Control-Allow-Origin', '*')
+    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204)
+      res.end()
+      return
+    }
+
+    if (process.env.ELECTRON_RENDERER_URL) {
+      const devBase = process.env.ELECTRON_RENDERER_URL.replace(/\/$/, '')
+      res.writeHead(302, { Location: `${devBase}/companion.html` })
+      res.end()
+      return
+    }
+
+    if (!staticDir) {
+      res.writeHead(503)
+      res.end('Companion build not available')
+      return
+    }
+
+    let urlPath = (req.url ?? '/').split('?')[0]
+    if (urlPath === '/') urlPath = '/companion.html'
+
+    const extMatch = urlPath.match(/\.[^./]+$/)
+    const ext = extMatch ? extMatch[0] : ''
+    const contentType = MIME[ext] ?? 'application/octet-stream'
+    const filePath = join(staticDir, urlPath)
+
+    try {
+      if (!existsSync(filePath)) {
+        const indexPath = join(staticDir, 'index.html')
+        if (existsSync(indexPath)) {
+          const data = await readFile(indexPath)
+          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' })
+          res.end(data)
+        } else {
+          res.writeHead(404)
+          res.end('Not found')
+        }
+        return
+      }
+      const data = await readFile(filePath)
+      res.writeHead(200, { 'Content-Type': contentType })
+      res.end(data)
+    } catch {
+      res.writeHead(500)
+      res.end()
+    }
+  })
+
+  const wss = new WebSocketServer({ server: httpServer })
+  wssInstance = wss
+
+  let tablePromise: Promise<Map<string, DispatchFn>> | null = null
+  function getTable(): Promise<Map<string, DispatchFn>> {
+    if (!tablePromise) tablePromise = buildDispatchTable(store)
+    return tablePromise
+  }
+
+  const onBridgeEvent = ({ channel, args }: { channel: string; args: unknown[] }): void => {
+    if (wss.clients.size === 0) return
+    const msg = JSON.stringify({ type: 'event', channel, args })
+    for (const client of wss.clients) {
+      if (client.readyState === client.OPEN) client.send(msg)
+    }
+  }
+  wsBridge.on('event', onBridgeEvent)
+
+  wss.on('connection', (ws: WebSocket) => {
+    // When a browser client connects in companion mode, push it into the settings
+    // view immediately -- the overlay App starts in 'idle' (hidden) by default
+    // and only shows after a hotkey fires, which never happens in companion mode.
+    ws.send(JSON.stringify({ type: 'event', channel: 'open-view', args: ['setup'] }))
+
+    ws.on('message', async (raw: Buffer) => {
+      let frame: ClientFrame
+      try {
+        frame = JSON.parse(raw.toString()) as ClientFrame
+      } catch {
+        return
+      }
+      const table = await getTable()
+      await handleFrame(frame, table, ws)
+    })
+    ws.on('error', (err) => console.error('[companion] WS error:', err.message))
+  })
+
+  httpServer.listen(port, '127.0.0.1', () => {
+    const addr = httpServer.address() as { port: number }
+    console.log(`[companion] Listening on http://127.0.0.1:${addr.port}`)
+  })
+
+  serverInstance = httpServer
+}
+
+export function stopCompanionServer(): void {
+  wssInstance?.close()
+  wssInstance = null
+  serverInstance?.close()
+  serverInstance = null
+}
+
+export function getCompanionPort(): number {
+  if (!serverInstance) return -1
+  const addr = serverInstance.address()
+  if (!addr || typeof addr === 'string') return -1
+  return addr.port
+}

--- a/src/main/companion/ws-bridge.ts
+++ b/src/main/companion/ws-bridge.ts
@@ -1,0 +1,28 @@
+/**
+ * WebSocket Event Bridge
+ *
+ * A lightweight in-process event bus that companion/server.ts subscribes to.
+ * Existing main-process code calls pushEvent() to fan out IPC push-events
+ * (things normally sent via webContents.send) to all connected WebSocket clients.
+ *
+ * This file has NO imports from Electron so it can be imported in tests.
+ */
+
+import { EventEmitter } from 'node:events'
+
+export interface WsBridgeEvent {
+  channel: string
+  args: unknown[]
+}
+
+class WsBridge extends EventEmitter {
+  /** Emit an event to all connected WS clients.
+   *  @param channel  The IPC channel name (e.g. 'overlay-data', 'zone-changed')
+   *  @param args     Zero or more serialisable arguments.
+   */
+  push(channel: string, ...args: unknown[]): void {
+    this.emit('event', { channel, args } satisfies WsBridgeEvent)
+  }
+}
+
+export const wsBridge = new WsBridge()

--- a/src/main/evaluation.ts
+++ b/src/main/evaluation.ts
@@ -38,6 +38,26 @@ import {
 } from './trade/prices'
 import { ensureStatsLoaded, matchItemMods } from './trade/trade'
 import { beginSession, decisionsForSession } from './learning'
+import { wsBridge } from './companion/ws-bridge'
+
+/** Send channel+args to the overlay window AND the companion WS bridge.
+ *  In normal mode: sends to the real Electron overlay window AND the bridge.
+ *  In companion mode: the fake window's send() already calls wsBridge.push(),
+ *  so we avoid double-firing by only calling one or the other. */
+function broadcastEvent(channel: string, ...args: unknown[]): void {
+  const win = getOverlayWindow()
+  if (win) {
+    win.webContents.send(channel, ...args)
+    // The fake companion window's send() already pushes to the bridge.
+    // Only push directly when using the REAL overlay window.
+    if (!process.argv.includes('--companion-mode')) {
+      wsBridge.push(channel, ...args)
+    }
+  } else {
+    // No window at all -- push directly to bridge so browser clients still get it.
+    wsBridge.push(channel, ...args)
+  }
+}
 
 // ---- Tier group builder ----------------------------------------------------
 
@@ -201,8 +221,8 @@ export function evaluateAndSend(item: PoeItem): void {
           : lastCursorX != null && lastCursorX < screen.getPrimaryDisplay().workAreaSize.width / 2
             ? 'left'
             : 'right'
-    win.webContents.send('cursor-side', side)
-    win.webContents.send('overlay-data', payload)
+    broadcastEvent('cursor-side', side)
+    broadcastEvent('overlay-data', payload)
   }
 }
 
@@ -310,7 +330,7 @@ export async function preloadPriceCheck(item: PoeItem, store: Store<AppSettings>
 
   const divinePrice = lookupPrice('Divine Orb', 'Divine Orb')
   const chaosPerDivine = divinePrice?.chaosValue ?? 0
-  getOverlayWindow()?.webContents.send('price-check', {
+  broadcastEvent('price-check', {
     item,
     priceInfo,
     statFilters,
@@ -337,6 +357,19 @@ let consecutiveClipboardFailures = 0
  */
 async function captureItemFromClipboard(isElevated: () => boolean): Promise<PoeItem | null> {
   const restoreClip = snapshotClipboard()
+
+  // In companion mode PoE may not be running or focused, so we never inject
+  // Ctrl+C -- the user manually copied the item text before pressing the hotkey.
+  // Just read whatever is on the clipboard right now.
+  if (process.argv.includes('--companion-mode')) {
+    const item = readItemFromClipboard()
+    restoreClip()
+    if (!item) {
+      broadcastEvent('no-item-in-clipboard')
+      return null
+    }
+    return item
+  }
 
   clipboard.clear()
   await sendCtrlCToPoE()
@@ -367,9 +400,9 @@ async function captureItemFromClipboard(isElevated: () => boolean): Promise<PoeI
   if (!item) {
     consecutiveClipboardFailures++
     if (consecutiveClipboardFailures >= 3 && !isElevated()) {
-      getOverlayWindow()?.webContents.send('elevation-hint')
+      broadcastEvent('elevation-hint')
     }
-    getOverlayWindow()?.webContents.send('no-item-in-clipboard')
+    broadcastEvent('no-item-in-clipboard')
     showOverlay()
     return null
   }
@@ -387,15 +420,17 @@ async function captureItemFromClipboard(isElevated: () => boolean): Promise<PoeI
  *  and the user reopens the overlay from the correct game after restart. */
 async function ensureCorrectGameForHotkey(store: Store<AppSettings>): Promise<boolean> {
   if (OverlayController.targetHasFocus) return true
-  // User typing in an overlay text field -- swallow so single-key hotkeys
-  // don't stomp the input. Otherwise if the overlay window itself is focused
-  // (user clicked into it), refocus PoE so the subsequent Ctrl+C reaches the
-  // game window.
   if (isTypingInOverlay()) return false
-  if (getOverlayWindow()?.isFocused()) {
+  // In companion mode there is no native overlay window, so isFocused() would
+  // throw on the fake window. Skip this check -- just proceed.
+  const overlayWin = getOverlayWindow()
+  if (overlayWin && typeof overlayWin.isFocused === 'function' && overlayWin.isFocused()) {
     focusGameWindow()
     return true
   }
+  // In companion mode PoE may not be running at all; skip the game-focus
+  // version check so hotkeys still work for clipboard-based price checking.
+  if (process.argv.includes('--companion-mode')) return true
   const v = await detectFocusedPoeVersion()
   if (!v) return false
   if (v === getPoeVersion()) return true
@@ -413,7 +448,7 @@ async function ensureCorrectGameForHotkey(store: Store<AppSettings>): Promise<bo
 export async function runMainHotkeyFlow(store: Store<AppSettings>, isElevated: () => boolean): Promise<PoeItem | null> {
   const currentFilter = getCurrentFilter()
   if (!currentFilter) {
-    getOverlayWindow()?.webContents.send('no-filter-loaded')
+    broadcastEvent('no-filter-loaded')
     showOverlay()
     return null
   }
@@ -439,7 +474,7 @@ export function createHotkeyHandler(store: Store<AppSettings>, isElevated: () =>
       // Flag the next overlay-data as "came from the filter hotkey" so the renderer
       // forces the item view, even when the user was on pricecheck/audit with the
       // same item already loaded (cache hit -> no view change without this).
-      getOverlayWindow()?.webContents.send('filter-hotkey-open')
+      broadcastEvent('filter-hotkey-open')
       await runMainHotkeyFlow(store, isElevated)
     } catch (err) {
       console.error('[hotkey] Error during hotkey processing:', err)
@@ -452,7 +487,7 @@ export function createHotkeyHandler(store: Store<AppSettings>, isElevated: () =>
 /** Switch the overlay into price-check view and populate it with `item`. Shared by the
  *  clipboard hotkey path and UI-triggered lookups (e.g. clicking a sister overlay row). */
 export async function runPriceCheck(item: PoeItem, store: Store<AppSettings>): Promise<void> {
-  getOverlayWindow()?.webContents.send('price-check-open')
+  broadcastEvent('price-check-open')
   await preloadPriceCheck(item, store)
   showOverlay()
   if (getCurrentFilter()) evaluateAndSend(item)

--- a/src/main/handlers/files.ts
+++ b/src/main/handlers/files.ts
@@ -1,167 +1,190 @@
 import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
 import { basename, dirname, join } from 'node:path'
-import { BrowserWindow, dialog, ipcMain } from 'electron'
+import { app, BrowserWindow, dialog, ipcMain } from 'electron'
 import type Store from 'electron-store'
 import type { AppSettings, FilterListEntry } from '../../shared/types'
 import { getAppWindow } from '../app-window'
 import { setCloseOnClickOutside, showOverlay } from '../overlay'
 
-export function register(store: Store<AppSettings>): void {
-  const defaultFilterFolderForActiveGame = (): string => {
-    const suffix = store.get('poeVersion') === 2 ? ' 2' : ''
-    return `${process.env.USERPROFILE}\\Documents\\My Games\\Path of Exile${suffix}`
+function defaultFilterFolderForActiveGame(store: Store<AppSettings>): string {
+  const suffix = store.get('poeVersion') === 2 ? ' 2' : ''
+  const documents = process.env.USERPROFILE ? join(process.env.USERPROFILE, 'Documents') : app.getPath('documents')
+  return join(documents, 'My Games', `Path of Exile${suffix}`)
+}
+
+export async function pickFilterFile(
+  store: Store<AppSettings>,
+  sender: BrowserWindow | null = null,
+): Promise<string | null> {
+  const isOverlay = sender && sender !== getAppWindow()
+
+  const dialogOpts = {
+    title: 'Select your .filter file',
+    defaultPath: defaultFilterFolderForActiveGame(store),
+    filters: [{ name: 'PoE Filter', extensions: ['filter'] }],
+    properties: ['openFile'] as 'openFile'[],
   }
 
-  ipcMain.handle('pick-filter-file', async (event) => {
-    const sender = BrowserWindow.fromWebContents(event.sender)
-    const isOverlay = sender && sender !== getAppWindow()
+  // Suppress close-on-click-outside while the dialog is open so it doesn't
+  // kill the overlay when the dialog steals focus from PoE.
+  if (isOverlay) setCloseOnClickOutside(false)
 
-    const dialogOpts = {
-      title: 'Select your .filter file',
-      defaultPath: defaultFilterFolderForActiveGame(),
-      filters: [{ name: 'PoE Filter', extensions: ['filter'] }],
-      properties: ['openFile'] as 'openFile'[],
-    }
+  // Don't parent to overlay window - it can't host dialogs. Use app window or standalone.
+  const parent = !isOverlay && sender ? sender : undefined
+  const result = parent ? await dialog.showOpenDialog(parent, dialogOpts) : await dialog.showOpenDialog(dialogOpts)
 
-    // Suppress close-on-click-outside while the dialog is open so it doesn't
-    // kill the overlay when the dialog steals focus from PoE
-    if (isOverlay) setCloseOnClickOutside(false)
+  if (isOverlay) setCloseOnClickOutside(store.get('closeOnClickOutside'))
 
-    // Don't parent to overlay window - it can't host dialogs. Use app window or standalone.
-    const parent = !isOverlay && sender ? sender : undefined
-    const result = parent ? await dialog.showOpenDialog(parent, dialogOpts) : await dialog.showOpenDialog(dialogOpts)
-
-    // Restore close-on-click-outside setting
-    if (isOverlay) setCloseOnClickOutside(store.get('closeOnClickOutside'))
-
-    if (result.canceled || result.filePaths.length === 0) {
-      if (isOverlay) showOverlay()
-      return null
-    }
-
-    const path = result.filePaths[0]
+  if (result.canceled || result.filePaths.length === 0) {
     if (isOverlay) showOverlay()
-    return path
-  })
+    return null
+  }
 
-  ipcMain.handle('pick-filter-dir', async (event) => {
-    const sender = BrowserWindow.fromWebContents(event.sender)
-    const isOverlay = sender && sender !== getAppWindow()
-    if (isOverlay) setCloseOnClickOutside(false)
+  const path = result.filePaths[0]
+  if (isOverlay) showOverlay()
+  return path
+}
 
-    const parent = !isOverlay && sender ? sender : undefined
-    const dialogOpts = {
-      title: 'Select your Path of Exile filter folder',
-      defaultPath: defaultFilterFolderForActiveGame(),
-      properties: ['openDirectory'] as 'openDirectory'[],
-    }
-    const result = parent ? await dialog.showOpenDialog(parent, dialogOpts) : await dialog.showOpenDialog(dialogOpts)
+export async function pickFilterDir(
+  store: Store<AppSettings>,
+  sender: BrowserWindow | null = null,
+): Promise<string | null> {
+  const isOverlay = sender && sender !== getAppWindow()
+  if (isOverlay) setCloseOnClickOutside(false)
 
-    if (isOverlay) setCloseOnClickOutside(store.get('closeOnClickOutside'))
+  const parent = !isOverlay && sender ? sender : undefined
+  const dialogOpts = {
+    title: 'Select your Path of Exile filter folder',
+    defaultPath: defaultFilterFolderForActiveGame(store),
+    properties: ['openDirectory'] as 'openDirectory'[],
+  }
+  const result = parent ? await dialog.showOpenDialog(parent, dialogOpts) : await dialog.showOpenDialog(dialogOpts)
 
-    if (result.canceled || result.filePaths.length === 0) {
-      if (isOverlay) showOverlay()
-      return null
-    }
+  if (isOverlay) setCloseOnClickOutside(store.get('closeOnClickOutside'))
 
-    // Users sometimes pick the "OnlineFilters" subfolder instead of the Path of Exile
-    // folder that contains it. Walk back up so we scan the parent regardless.
-    let dir = result.filePaths[0]
-    if (basename(dir).toLowerCase() === 'onlinefilters') dir = dirname(dir)
+  if (result.canceled || result.filePaths.length === 0) {
     if (isOverlay) showOverlay()
-    return dir
-  })
+    return null
+  }
 
-  ipcMain.handle('scan-filter-dir', (_event, dir: string): FilterListEntry[] => {
-    if (!dir || !existsSync(dir)) return []
-    const entries: FilterListEntry[] = []
+  // Users sometimes pick the "OnlineFilters" subfolder instead of the Path of Exile
+  // folder that contains it. Walk back up so we scan the parent regardless.
+  let dir = result.filePaths[0]
+  if (basename(dir).toLowerCase() === 'onlinefilters') dir = dirname(dir)
+  if (isOverlay) showOverlay()
+  return dir
+}
 
-    // Scan top-level .filter files
+export function scanFilterDir(dir: string): FilterListEntry[] {
+  if (!dir || !existsSync(dir)) return []
+  const entries: FilterListEntry[] = []
+
+  // Scan top-level .filter files.
+  try {
+    for (const f of readdirSync(dir)) {
+      if (f.toLowerCase().endsWith('.filter')) {
+        entries.push({
+          path: join(dir, f),
+          name: basename(f, '.filter'),
+          online: false,
+        })
+      }
+    }
+  } catch {
+    /* ignore read errors */
+  }
+
+  // Scan OnlineFilters subfolder - files have no extension and random names.
+  // The real filter name is in the header: "#name:Filter Name".
+  let onlineDirName: string | undefined
+  try {
+    onlineDirName = readdirSync(dir).find((f) => f.toLowerCase() === 'onlinefilters')
+  } catch {
+    onlineDirName = undefined
+  }
+  const onlinePath = onlineDirName ? join(dir, onlineDirName) : null
+  if (onlinePath && existsSync(onlinePath)) {
     try {
-      for (const f of readdirSync(dir)) {
-        if (f.toLowerCase().endsWith('.filter')) {
-          entries.push({
-            path: join(dir, f),
-            name: basename(f, '.filter'),
-            online: false,
-          })
+      for (const f of readdirSync(onlinePath)) {
+        const fullPath = join(onlinePath, f)
+        // Skip directories and .filter files (those are local filters).
+        try {
+          const stat = statSync(fullPath)
+          if (stat.isDirectory()) continue
+        } catch {
+          continue
         }
+        let name = f
+        try {
+          const content = readFileSync(fullPath, 'utf-8')
+          for (const line of content.split('\n').slice(0, 15)) {
+            const match = line.match(/^#name:(.+)/)
+            if (match) {
+              name = match[1].trim()
+              break
+            }
+          }
+        } catch {
+          /* ignore read errors */
+        }
+        entries.push({ path: fullPath, name, online: true })
       }
     } catch {
       /* ignore read errors */
     }
+  }
 
-    // Scan OnlineFilters subfolder - files have no extension and random names.
-    // The real filter name is in the header: "#name:Filter Name"
-    const onlineDirName = readdirSync(dir).find((f) => f.toLowerCase() === 'onlinefilters')
-    const onlinePath = onlineDirName ? join(dir, onlineDirName) : null
-    if (onlinePath && existsSync(onlinePath)) {
-      try {
-        for (const f of readdirSync(onlinePath)) {
-          const fullPath = join(onlinePath, f)
-          // Skip directories and .filter files (those are local filters)
-          try {
-            const stat = statSync(fullPath)
-            if (stat.isDirectory()) continue
-          } catch {
-            continue
-          }
-          let name = f
-          try {
-            const content = readFileSync(fullPath, 'utf-8')
-            for (const line of content.split('\n').slice(0, 15)) {
-              const match = line.match(/^#name:(.+)/)
-              if (match) {
-                name = match[1].trim()
-                break
-              }
-            }
-          } catch {
-            /* ignore read errors */
-          }
-          entries.push({ path: fullPath, name, online: true })
-        }
-      } catch {
-        /* ignore read errors */
-      }
+  return entries
+}
+
+export function scanSoundFiles(dir: string): string[] {
+  if (!dir || !existsSync(dir)) return []
+  const soundExts = new Set(['.mp3', '.wav', '.ogg'])
+  const files: string[] = []
+  try {
+    for (const f of readdirSync(dir)) {
+      const ext = f.slice(f.lastIndexOf('.')).toLowerCase()
+      if (soundExts.has(ext)) files.push(f)
     }
-
-    return entries
-  })
-
-  ipcMain.handle('scan-sound-files', (_event, dir: string): string[] => {
-    if (!dir || !existsSync(dir)) return []
-    const soundExts = new Set(['.mp3', '.wav', '.ogg'])
-    const files: string[] = []
-    try {
-      for (const f of readdirSync(dir)) {
+    // Also scan sounds/ subfolder.
+    const soundsDir = join(dir, 'sounds')
+    if (existsSync(soundsDir)) {
+      for (const f of readdirSync(soundsDir)) {
         const ext = f.slice(f.lastIndexOf('.')).toLowerCase()
-        if (soundExts.has(ext)) files.push(f)
+        if (soundExts.has(ext)) files.push(`sounds/${f}`)
       }
-      // Also scan sounds/ subfolder
-      const soundsDir = join(dir, 'sounds')
-      if (existsSync(soundsDir)) {
-        for (const f of readdirSync(soundsDir)) {
-          const ext = f.slice(f.lastIndexOf('.')).toLowerCase()
-          if (soundExts.has(ext)) files.push(`sounds/${f}`)
-        }
-      }
-    } catch {
-      /* ignore */
     }
-    return files.sort()
-  })
+  } catch {
+    /* ignore */
+  }
+  return files.sort()
+}
 
-  ipcMain.handle('get-sound-data-url', (_event, dir: string, filename: string): string | null => {
-    try {
-      const fullPath = join(dir, filename)
-      if (!existsSync(fullPath)) return null
-      const data = readFileSync(fullPath)
-      const ext = filename.slice(filename.lastIndexOf('.') + 1).toLowerCase()
-      const mime = ext === 'ogg' ? 'audio/ogg' : ext === 'wav' ? 'audio/wav' : 'audio/mpeg'
-      return `data:${mime};base64,${data.toString('base64')}`
-    } catch {
-      return null
-    }
-  })
+export function getSoundDataUrl(dir: string, filename: string): string | null {
+  try {
+    const fullPath = join(dir, filename)
+    if (!existsSync(fullPath)) return null
+    const data = readFileSync(fullPath)
+    const ext = filename.slice(filename.lastIndexOf('.') + 1).toLowerCase()
+    const mime = ext === 'ogg' ? 'audio/ogg' : ext === 'wav' ? 'audio/wav' : 'audio/mpeg'
+    return `data:${mime};base64,${data.toString('base64')}`
+  } catch {
+    return null
+  }
+}
+
+export function register(store: Store<AppSettings>): void {
+  ipcMain.handle('pick-filter-file', async (event) =>
+    pickFilterFile(store, BrowserWindow.fromWebContents(event.sender)),
+  )
+
+  ipcMain.handle('pick-filter-dir', async (event) => pickFilterDir(store, BrowserWindow.fromWebContents(event.sender)))
+
+  ipcMain.handle('scan-filter-dir', (_event, dir: string): FilterListEntry[] => scanFilterDir(dir))
+
+  ipcMain.handle('scan-sound-files', (_event, dir: string): string[] => scanSoundFiles(dir))
+
+  ipcMain.handle('get-sound-data-url', (_event, dir: string, filename: string): string | null =>
+    getSoundDataUrl(dir, filename),
+  )
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -144,7 +144,19 @@ import {
   getProfileBackedSetting,
   hydrateActiveProfileSettings,
   writeActiveProfileSetting,
+  ensureProfileForGame,
 } from './profiles/profile-settings'
+import { startCompanionServer, getCompanionPort } from './companion/server'
+import { wireCompanionBridge } from './companion/bridge-wiring'
+import { startCompanionClipboardWatcher } from './companion/clipboard-watcher'
+import { setPoeVersion } from './game-state'
+import { loadTierData, refreshTierData } from './tier-data'
+
+// ---- Companion mode detection ----------------------------------------------
+// Launch with --companion-mode (or set SCALPEL_COMPANION=1) to skip the
+// overlay window and native input hook entirely, and instead start the
+// HTTP + WebSocket companion server for browser access.
+const IS_COMPANION = process.argv.includes('--companion-mode') || process.env.SCALPEL_COMPANION === '1'
 
 // ---- Linux display-server setup --------------------------------------------
 
@@ -157,7 +169,12 @@ if (
   process.env.WAYLAND_DISPLAY &&
   !process.argv.some((a) => a.startsWith('--ozone-platform='))
 ) {
-  app.relaunch({ args: [...process.argv.slice(1), '--ozone-platform=x11'] })
+  const extraArgs = []
+  // Preserve companion mode flag across the X11 relaunch
+  if (IS_COMPANION && !process.argv.includes('--companion-mode')) {
+    extraArgs.push('--companion-mode')
+  }
+  app.relaunch({ args: [...process.argv.slice(1), '--ozone-platform=x11', ...extraArgs] })
   app.exit(0)
 }
 
@@ -384,6 +401,18 @@ function createTray(): void {
     },
     { type: 'separator' },
     {
+      label: 'Open Companion in Browser',
+      click: () => {
+        const port = getCompanionPort()
+        if (port > 0) {
+          import('electron').then(({ shell }) => {
+            shell.openExternal(`http://127.0.0.1:${port}`)
+          })
+        }
+      },
+    },
+    { type: 'separator' },
+    {
       label: 'Settings',
       click: () => showAppWindow(),
     },
@@ -490,16 +519,63 @@ app.whenReady().then(() => {
   // Seed the overlay with the last-known game version so attachByTitle waits for
   // that window. The hotkey handler re-detects the focused PoE on every fire and
   // relaunches to swap versions if needed (ensureCorrectGameForHotkey).
-  if (!IS_E2E) createOverlayWindow((store.get(PROFILE_VERSION_KEY) as GameVariant) ?? 1)
+  if (!IS_E2E && !IS_COMPANION) createOverlayWindow((store.get(PROFILE_VERSION_KEY) as GameVariant) ?? 1)
+  // In companion mode createOverlayWindow (which calls setPoeVersion) is never
+  // called -- game-state stays at default 1 even for PoE2 profiles.
+  // Set it explicitly so trade searches hit the right endpoint.
+  if (IS_COMPANION) {
+    const companionVersion = (store.get(PROFILE_VERSION_KEY) as GameVariant) ?? 2
+    setPoeVersion(companionVersion)
+    // Also load tier data so filter panel mod matching works correctly.
+    loadTierData(companionVersion)
+      .then(() => refreshTierData(companionVersion))
+      .catch(() => {})
+  }
   // Let the secondary-overlay system know about the main overlay window so its
   // isAnyScalpelWindowFocused predicate can include it.
   setMainOverlayGetter(getOverlayWindow)
   // When focus leaves Scalpel via the PoE -> overlay -> other-app path
   // (which the PoE-blur handler can't catch), suspend hotkeys so they don't
   // fire in the destination app.
-  if (!IS_E2E) setOnLeaveScalpel(() => suspendHotkeys())
+  if (!IS_E2E && !IS_COMPANION) setOnLeaveScalpel(() => suspendHotkeys())
   createAppWindow(store)
   if (!IS_E2E) createTray()
+
+  // ---- Companion HTTP+WS server (always started; tray provides browser link) --
+  // Even in normal overlay mode, the companion server runs so users on Hyprland
+  // can open a browser tab as a fallback. In companion mode it is the primary UI.
+  startCompanionServer({ store, port: 0 })
+  // Wire events to the bridge so browser clients stay in sync regardless of mode.
+  wireCompanionBridge(IS_COMPANION).catch((err) => console.error('[companion] bridge wiring failed:', err))
+
+  // ---- Companion mode: auto-open browser and skip overlay live services -----
+  if (IS_COMPANION) {
+    // On fresh installs: fetch leagues first so the profile gets a real league,
+    // then ensure a profile exists. On subsequent runs the league is already set.
+    refreshLeagues(store, undefined as unknown as Parameters<typeof refreshLeagues>[1], { force: true })
+      .then(() => ensureProfileForGame(store, (store.get(PROFILE_VERSION_KEY) as GameVariant) ?? 2))
+      .catch(() => {})
+
+    // Minimal live services for companion (prices + manifest; no overlay window needed)
+    refreshManifest().catch(() => {})
+    refreshPrices(getProfileBackedSetting(store, 'league'))
+    setInterval(() => refreshPrices(getProfileBackedSetting(store, 'league')), 10 * 60 * 1000)
+
+    // Poll clipboard every 500ms. When a valid PoE item is detected, fire the
+    // price-check pipeline automatically -- no hotkey required, works on Wayland.
+    startCompanionClipboardWatcher(store)
+
+    // Auto-open the browser shortly after startup (port assigned by OS)
+    setTimeout(() => {
+      const port = getCompanionPort()
+      if (port > 0) {
+        import('electron').then(({ shell }) => {
+          shell.openExternal(`http://127.0.0.1:${port}`)
+        })
+        console.log(`[companion] Open in browser: http://127.0.0.1:${port}`)
+      }
+    }, 500)
+  }
 
   // Serve plugin-facing built-in modules (React, SDK) via a custom scheme so
   // plugins can import them without bundling their own copies.
@@ -745,7 +821,7 @@ app.whenReady().then(() => {
   // Apply close-on-click-outside setting
   setCloseOnClickOutside(store.get('closeOnClickOutside'))
 
-  if (!IS_E2E) startLiveServices()
+  if (!IS_E2E && !IS_COMPANION) startLiveServices()
 
   // Show onboarding/settings on first launch, otherwise respect startInTray.
   // E2E harness always shows the window so the Playwright test can interact.

--- a/src/main/overlay.ts
+++ b/src/main/overlay.ts
@@ -492,8 +492,23 @@ export function toggleOverlay(): void {
 }
 
 export function getOverlayWindow(): BrowserWindow | null {
+  // In companion mode, companionWindow is a structurally compatible fake window
+  // that forwards webContents.send to the WebSocket bridge.
+  if (companionWindow) return companionWindow as unknown as BrowserWindow
   return overlayWindow
 }
+
+/** Companion mode: inject a fake window so evaluation.ts and trade.ts
+ *  send events through the WebSocket bridge instead of to a real renderer.
+ *  The fake window is structurally compatible: only isDestroyed() and
+ *  webContents.send() are actually called on it at runtime. */
+export function setCompanionWindow(
+  win: { isDestroyed(): boolean; webContents: { send(c: string, ...a: unknown[]): void } } | null,
+): void {
+  companionWindow = win as unknown as BrowserWindow | null
+}
+
+let companionWindow: BrowserWindow | null = null
 
 /** Make PoE the OS foreground window so SendInput reaches it, not the overlay. */
 export function setGameFocusHandlers(onFocus: () => void, onBlur: () => void): void {

--- a/src/main/settings-write.ts
+++ b/src/main/settings-write.ts
@@ -34,6 +34,18 @@ import {
   type SettingChangeKey,
 } from './profiles/profile-settings'
 
+// Companion mode hook: extra listeners for setting/league updates that bypass
+// webContents.send (used when no overlay window exists, e.g. Hyprland).
+const settingUpdateListeners: Array<(key: SettingChangeKey, value: unknown) => void> = []
+const leagueUpdateListeners: Array<(league: string) => void> = []
+
+export function addCompanionSettingListener(cb: (key: SettingChangeKey, value: unknown) => void): void {
+  settingUpdateListeners.push(cb)
+}
+export function addCompanionLeagueListener(cb: (league: string) => void): void {
+  leagueUpdateListeners.push(cb)
+}
+
 export function broadcastSettingUpdate(sender: WebContents | null, key: SettingChangeKey, value: unknown): void {
   const csWin = getCheatSheetsOverlay()?.getWindow() ?? null
   const pinnedWin = getPinnedZoneOverlay()?.getWindow() ?? null
@@ -50,6 +62,7 @@ export function broadcastSettingUpdate(sender: WebContents | null, key: SettingC
       }
     })
     .catch(() => {})
+  for (const cb of settingUpdateListeners) cb(key, value)
 }
 
 function sideEffect(setting: ProfileChangedSetting, prevAppSettings?: AppSettings): void {
@@ -145,6 +158,7 @@ export function broadcastLeagueUpdate(sender: WebContents | null, league: string
       }
     })
     .catch(() => {})
+  for (const cb of leagueUpdateListeners) cb(league)
 }
 
 function capturePreviousSettings(store: Store<AppSettings>): RuntimeSettings {

--- a/src/renderer/companion.html
+++ b/src/renderer/companion.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Scalpel Companion</title>
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        /* Dark background so the panel is readable even before theme CSS loads */
+        background: #0e0e0e;
+        font-family: 'Segoe UI', system-ui, sans-serif;
+        color: #e0e0e0;
+        -webkit-app-region: no-drag;
+      }
+      #root {
+        width: 100vw;
+        min-height: 100vh;
+        overflow-y: auto;
+      }
+      /* Loading state shown before React mounts */
+      #companion-loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+        font-size: 14px;
+        opacity: 0.6;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root">
+      <div id="companion-loading">Connecting to Scalpel…</div>
+    </div>
+    <script type="module" src="/src/companion-main.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/src/companion-api.ts
+++ b/src/renderer/src/companion-api.ts
@@ -1,0 +1,468 @@
+/**
+ * Companion WebSocket API Shim
+ *
+ * Implements the same window.api interface as src/preload/index.ts, but
+ * over a WebSocket connection to the companion HTTP server instead of
+ * via Electron's contextBridge.
+ *
+ * The shim is injected into window.api before React mounts so all
+ * component code works without modification.
+ *
+ * Usage in companion renderer entry:
+ *   import { installCompanionApi } from './companion-api'
+ *   await installCompanionApi()  // connects + installs, resolves when ready
+ *   // then bootstrap React
+ *
+ * The WebSocket URL is read from window.COMPANION_WS_URL (injected by the
+ * server into the HTML) or defaults to ws://127.0.0.1:PORT derived from
+ * the current page URL.
+ */
+
+type UnsubFn = () => void
+
+// ---------------------------------------------------------------------------
+// Wire protocol types
+// ---------------------------------------------------------------------------
+interface ReplyFrame {
+  type: 'reply'
+  id: number
+  result?: unknown
+  error?: string
+}
+interface EventFrame {
+  type: 'event'
+  channel: string
+  args: unknown[]
+}
+type ServerFrame = ReplyFrame | EventFrame
+
+// ---------------------------------------------------------------------------
+// CompanionWsClient
+// ---------------------------------------------------------------------------
+class CompanionWsClient {
+  private ws: WebSocket | null = null
+  private nextId = 1
+  private pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>()
+  private listeners = new Map<string, Set<(...args: unknown[]) => void>>()
+  // Buffer events that arrive before any listener is registered for that channel.
+  // Drained (and cleared) the first time a listener registers for the channel.
+  private earlyEvents = new Map<string, unknown[][]>()
+  private url: string
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private intentionallyClosed = false
+
+  constructor(url: string) {
+    this.url = url
+  }
+
+  connect(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(this.url)
+      this.ws = ws
+
+      ws.addEventListener('open', () => {
+        console.log('[companion] WebSocket connected')
+        resolve()
+      })
+
+      ws.addEventListener('error', () => {
+        reject(new Error('[companion] WebSocket connection failed'))
+      })
+
+      ws.addEventListener('close', () => {
+        this.ws = null
+        if (!this.intentionallyClosed) this.scheduleReconnect()
+      })
+
+      ws.addEventListener('message', (evt: MessageEvent<string>) => {
+        let frame: ServerFrame
+        try {
+          frame = JSON.parse(evt.data) as ServerFrame
+        } catch {
+          return
+        }
+
+        if (frame.type === 'reply') {
+          const pending = this.pending.get(frame.id)
+          if (!pending) return
+          this.pending.delete(frame.id)
+          if (frame.error) {
+            pending.reject(new Error(frame.error))
+          } else {
+            pending.resolve(frame.result ?? null)
+          }
+          return
+        }
+
+        if (frame.type === 'event') {
+          const cbs = this.listeners.get(frame.channel)
+          if (cbs) {
+            for (const cb of cbs) {
+              try {
+                cb(...(frame.args as unknown[]))
+              } catch (err) {
+                console.error(`[companion] listener error on ${frame.channel}`, err)
+              }
+            }
+          } else {
+            // No listener yet -- buffer it. React subscribes during useEffect
+            // which fires after the first render, so WS messages sent immediately
+            // on connect can arrive before any listener is registered.
+            const buf = this.earlyEvents.get(frame.channel) ?? []
+            buf.push(frame.args as unknown[])
+            this.earlyEvents.set(frame.channel, buf)
+          }
+        }
+      })
+    })
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) return
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.connect().catch(() => this.scheduleReconnect())
+    }, 2000)
+  }
+
+  close(): void {
+    this.intentionallyClosed = true
+    this.ws?.close()
+  }
+
+  invoke<T = unknown>(method: string, ...args: unknown[]): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const id = this.nextId++
+      this.pending.set(id, {
+        resolve: (v) => resolve(v as T),
+        reject,
+      })
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+        this.pending.delete(id)
+        reject(new Error(`[companion] WebSocket not connected (method=${method})`))
+        return
+      }
+      this.ws.send(JSON.stringify({ type: 'invoke', id, method, args }))
+    })
+  }
+
+  send(method: string, ...args: unknown[]): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return
+    this.ws.send(JSON.stringify({ type: 'send', method, args }))
+  }
+
+  on(channel: string, cb: (...args: unknown[]) => void): UnsubFn {
+    if (!this.listeners.has(channel)) this.listeners.set(channel, new Set())
+    this.listeners.get(channel)!.add(cb)
+
+    // Drain any events that arrived before this listener was registered.
+    const buffered = this.earlyEvents.get(channel)
+    if (buffered?.length) {
+      this.earlyEvents.delete(channel)
+      // Use setTimeout(0) so the caller's useEffect cleanup runs before
+      // we replay -- prevents the subscriber from seeing stale state.
+      setTimeout(() => {
+        for (const args of buffered) {
+          try {
+            cb(...args)
+          } catch {}
+        }
+      }, 0)
+    }
+
+    return () => this.listeners.get(channel)?.delete(cb)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Detect companion server URL
+// ---------------------------------------------------------------------------
+function resolveWsUrl(): string {
+  // Injected by the server as a global in the HTML, or fallback to same host
+  const injected = (window as unknown as { COMPANION_WS_URL?: string }).COMPANION_WS_URL
+  if (injected) return injected
+  const { protocol, host } = window.location
+  const ws = protocol === 'https:' ? 'wss:' : 'ws:'
+  return `${ws}//${host}`
+}
+
+// ---------------------------------------------------------------------------
+// Build the window.api shim object
+// ---------------------------------------------------------------------------
+function buildApi(client: CompanionWsClient) {
+  const inv = <T = unknown>(method: string, ...args: unknown[]): Promise<T> => client.invoke<T>(method, ...args)
+  const snd = (method: string, ...args: unknown[]): void => client.send(method, ...args)
+  const sub = (channel: string, cb: (...a: unknown[]) => void): UnsubFn => client.on(channel, cb)
+
+  return {
+    // ----- manifest -----
+    getManifest: () => inv('get-manifest'),
+
+    // ----- settings -----
+    getSettings: () => inv('get-settings'),
+    setSetting: (key: string, value: unknown) => inv('set-setting', key, value),
+    setProfileSettingForGame: (variant: unknown, key: string, value: unknown) =>
+      inv('set-profile-setting-for-game', variant, key, value),
+    listProfiles: () => inv('list-profiles'),
+    createProfile: (input: unknown) => inv('create-profile', input),
+    renameProfile: (id: string, name: string) => inv('rename-profile', id, name),
+    duplicateProfile: (id: string, name: string) => inv('duplicate-profile', id, name),
+    deleteProfile: (id: string) => inv('delete-profile', id),
+    ensureProfileForGame: (variant: unknown) => inv('ensure-profile-for-game', variant),
+    setActiveProfile: (id: string, restartIfNeeded?: boolean) => inv('set-active-profile', id, restartIfNeeded),
+    refreshLeagues: () => inv('refresh-leagues'),
+    getRegexPresets: () => inv('get-regex-presets'),
+    saveRegexPreset: (preset: unknown) => inv('save-regex-preset', preset),
+    deleteRegexPreset: (id: string) => inv('delete-regex-preset', id),
+    reorderRegexPresets: (ids: string[]) => inv('reorder-regex-presets', ids),
+
+    // ----- files -----
+    pickFilterFile: () => inv('pick-filter-file'),
+    pickFilterDir: () => inv('pick-filter-dir'),
+    scanFilterDir: (dir: string) => inv('scan-filter-dir', dir),
+    scanSoundFiles: (dir: string) => inv('scan-sound-files', dir),
+    getSoundDataUrl: (dir: string, filename: string) => inv('get-sound-data-url', dir, filename),
+    importOnlineFilter: (...args: unknown[]) => inv('import-online-filter', ...args),
+    switchIngameFilter: (filterName: string, currentFilter?: string) =>
+      inv('switch-ingame-filter', filterName, currentFilter),
+
+    // ----- filter editing -----
+    getColorFrequencies: () => inv('get-color-frequencies'),
+    saveBlockEdit: (idx: number, block: unknown, itemJson?: string) => inv('save-block-edit', idx, block, itemJson),
+    reloadFilter: () => inv('reload-filter'),
+    getUniqueVisibility: () => inv('get-unique-visibility'),
+    lookupBaseType: (...args: unknown[]) => inv('lookup-base-type', ...args),
+    getUniquesForBase: (baseType: string) => inv('get-uniques-for-base', baseType),
+    getSearchableItems: () => inv('get-searchable-items'),
+    getDivCardTiers: () => inv('get-div-card-tiers'),
+    batchLookupDivCardPrices: (cardNames: string[], league: string) =>
+      inv('batch-lookup-div-card-prices', cardNames, league),
+    batchLookupPrices: (baseTypes: string[], league: string, uniqueTier?: boolean) =>
+      inv('batch-lookup-prices', baseTypes, league, uniqueTier),
+    batchLookupRefPrices: (refs: unknown[], league: string) => inv('batch-lookup-ref-prices', refs, league),
+    sisterOpenPriceCheck: (ref: unknown) => inv('sister-open-price-check', ref),
+    moveItemTier: (...args: unknown[]) => inv('move-item-tier', ...args),
+    batchMoveItemTier: (...args: unknown[]) => inv('batch-move-item-tier', ...args),
+    updateStackThresholds: (...args: unknown[]) => inv('update-stack-thresholds', ...args),
+    updateQualityThresholds: (...args: unknown[]) => inv('update-quality-thresholds', ...args),
+    updateStrandThresholds: (...args: unknown[]) => inv('update-strand-thresholds', ...args),
+    getHistory: () => inv('get-history'),
+    undoEdit: (itemJson?: string) => inv('undo-edit', itemJson),
+    listVersions: () => inv('list-versions'),
+    createCheckpoint: (label?: string) => inv('create-checkpoint', label),
+    restoreVersion: (filename: string, itemJson?: string) => inv('restore-version', filename, itemJson),
+    deleteVersion: (filename: string) => inv('delete-version', filename),
+
+    // ----- overlay state -----
+    getOverlayState: () => inv('get-overlay-state'),
+    getIconCache: () => inv('get-icon-cache'),
+    refreshPrices: () => inv('refresh-prices'),
+
+    // ----- trade -----
+    tradeSearch: (...args: unknown[]) => inv('trade-search', ...args),
+    bulkExchange: (...args: unknown[]) => inv('bulk-exchange', ...args),
+    checkBulkItem: (...args: unknown[]) => inv('check-bulk-item', ...args),
+    mapRegexTrade: (params: unknown) => inv('map-regex-trade', params),
+    fetchMoreListings: (queryId: string, ids: string[]) => inv('fetch-more-listings', queryId, ids),
+    visitHideout: (...args: unknown[]) => {
+      console.warn('[companion] visitHideout not available in companion mode')
+      return Promise.resolve('not-available')
+    },
+    whisperSeller: (...args: unknown[]) => {
+      console.warn('[companion] whisperSeller not available in companion mode')
+      return Promise.resolve('not-available')
+    },
+    poeLogin: () => inv('poe-login'),
+    poeCheckAuth: () => inv('poe-check-auth'),
+    poeLogout: () => inv('poe-logout'),
+    openExternal: (url: string) => inv('open-external', url),
+
+    // ----- online sync -----
+    checkForOnlineUpdate: () => inv('check-online-update'),
+    quickUpdateFilter: () => inv('quick-update-filter'),
+    mergeOnlineFilter: (...args: unknown[]) => inv('merge-online-filter', ...args),
+
+    // ----- updater -----
+    downloadUpdate: () => inv('download-update'),
+    installUpdate: () => inv('install-update'),
+    getUpdateState: () => inv('get-update-state'),
+    devFakeUpdate: (version: string) => inv('dev-fake-update', version),
+
+    // ----- diagnostics -----
+    reportRendererError: (payload: unknown) => snd('diagnostics:renderer-error', payload),
+    createBugReport: () => inv('diagnostics:create-report'),
+    showBugReport: (reportPath: string) => inv('diagnostics:show-report', reportPath),
+
+    // ----- app window (no-ops in companion mode) -----
+    setAppWindowMode: () => {},
+    openDevTools: () => {},
+    closeOverlay: () => snd('close-overlay'),
+    reportPanelRect: () => {}, // no-op: no panel rect tracking in browser
+    lockInteractive: () => {},
+    unlockInteractive: () => {},
+    suspendHotkeys: () => {},
+    resumeHotkeys: () => {},
+    setOverlayInputFocused: () => {},
+    suspendInputHook: () => Promise.resolve(),
+    resumeInputHook: () => Promise.resolve(),
+    reportRegex: () => {},
+    recordPrefObservation: (...args: unknown[]) => snd('record-pref-observation', ...args),
+    resetLearning: (scope: unknown) => inv('reset-learning', scope),
+    regexRemoteMountState: () => Promise.resolve(null),
+    regexRemoteApply: () => {},
+    closeRegexRemote: () => {},
+    regexRemoteHandFocus: () => {},
+
+    // ----- cheat sheets (secondary overlay -- no-ops) -----
+    addCheatSheetFromFile: (...args: unknown[]) => inv('cheat-sheet:add-from-file', ...args),
+    addCheatSheetFromUrl: (...args: unknown[]) => inv('cheat-sheet:add-from-url', ...args),
+    removeCheatSheet: (...args: unknown[]) => inv('cheat-sheet:remove', ...args),
+    removeCheatSheetCategory: (id: string) => inv('cheat-sheet:remove-category', id),
+    listCheatSheetPrefabs: () => inv('cheat-sheet:list-prefabs'),
+    importCheatSheetPrefab: (slug: string) => inv('cheat-sheet:import-prefab', slug),
+    pinnedZoneSetVisible: () => {},
+    pinnedZoneSetContentHeight: () => {},
+    closeCheatSheets: () => {},
+    minimizeCheatSheets: () => {},
+    restoreCheatSheets: () => {},
+    openSettingsTab: () => {},
+    showCheatSheetPreview: () => {},
+    hideCheatSheetPreview: () => {},
+    respondGameSwitch: () => {},
+    saveOverlayState: () => {},
+
+    // ----- clipboard -----
+    clipboardReadImage: () => inv('clipboard:read-image'),
+
+    // ----- client log -----
+    getRecentLogLines: (count?: number) => inv('client-log:recent-lines', count),
+
+    // ----- plugins -----
+    listInstalledPlugins: () => inv('plugins:list-installed'),
+    listUnpackedPlugins: () => inv('plugins:list-unpacked'),
+    getInstalledPlugin: (id: string) => inv('plugins:get-installed', id),
+    pluginStorageGet: (id: string, key: string) => inv('plugins:storage-get', id, key),
+    pluginStorageSet: (id: string, key: string, value: unknown) => inv('plugins:storage-set', id, key, value),
+    pluginStorageDelete: (id: string, key: string) => inv('plugins:storage-delete', id, key),
+    pluginStorageKeys: (id: string) => inv('plugins:storage-keys', id),
+    pluginRegisterHotkey: (...args: unknown[]) => inv('plugins:register-hotkey', ...args),
+    pluginListRegisteredHotkeys: () => inv('plugins:list-registered-hotkeys'),
+    pluginRegisterTab: (...args: unknown[]) => inv('plugins:register-tab', ...args),
+    pluginUnregisterTab: (id: string) => inv('plugins:unregister-tab', id),
+    pluginListRegisteredTabs: () => inv('plugins:list-registered-tabs'),
+    pluginInstallUnpacked: () => inv('plugins:install-unpacked'),
+    pluginFetchRegistry: () => inv('plugins:fetch-registry'),
+    pluginInstallFromRegistry: (entry: unknown) => inv('plugins:install-from-registry', entry),
+    pluginUninstall: (id: string) => inv('plugins:uninstall', id),
+    pluginUnregisterHotkey: (id: string) => inv('plugins:unregister-hotkey', id),
+    pluginTriggerMainHotkey: () => inv('plugins:trigger-main-hotkey'),
+    pluginShowOverlay: () => inv('plugins:show-overlay'),
+    pluginRegisterOverlay: (...args: unknown[]) => inv('plugins:register-overlay', ...args),
+    pluginOpenOverlay: (id: string) => inv('plugins:open-overlay', id),
+    pluginCloseOverlay: (id: string) => inv('plugins:close-overlay', id),
+
+    // ----- game config -----
+    gameConfigRead: () => inv('plugins:game-config-read'),
+    gameConfigWrite: (content: string) => inv('plugins:game-config-write', content),
+
+    // ----- whiteboard -----
+    whiteboard: {
+      load: (version: 1 | 2, gameSize: { w: number; h: number }) => inv('whiteboard:load', version, gameSize),
+      saveActive: (version: 1 | 2, state: unknown) => snd('whiteboard:save-active', version, state),
+      saveAsSnapshot: (version: 1 | 2, payload: unknown) => inv('whiteboard:save-as-snapshot', version, payload),
+      deleteSnapshot: (version: 1 | 2, payload: unknown) => inv('whiteboard:delete-snapshot', version, payload),
+      renameSnapshot: (version: 1 | 2, payload: unknown) => inv('whiteboard:rename-snapshot', version, payload),
+      requestClose: () => {},
+      setMode: () => {},
+      reportToolbarRects: () => {},
+      clearToolbarRect: () => {},
+      requestShownState: () => {},
+      onPleaseFlush: (cb: () => void) => sub('whiteboard:please-flush', cb),
+      onShown: (cb: () => void) => sub('whiteboard:shown', cb),
+      onHidden: (cb: () => void) => sub('whiteboard:hidden', cb),
+    },
+
+    // ----- push event subscriptions (same names as preload) -----
+    onDevDiagnosticError: (cb: (...a: unknown[]) => void) => sub('diagnostics:dev-error', cb),
+    onIconCacheUpdated: (cb: (...a: unknown[]) => void) => sub('icon-cache-updated', cb),
+    onRegexRemoteMountChanged: (cb: (...a: unknown[]) => void) => sub('regex-remote:mount-changed', cb),
+    onCheatSheetFocusCategory: (cb: (...a: unknown[]) => void) => sub('cheat-sheet:focus-category', cb),
+    onSecondaryOverlaySnapGhost: (cb: (...a: unknown[]) => void) => sub('secondary-overlay-canvas:snap-ghost', cb),
+    onCheatSheetPreview: (cb: (...a: unknown[]) => void) => sub('cheat-sheet-preview:render', cb),
+    onOverlayData: (cb: (...a: unknown[]) => void) => sub('overlay-data', cb),
+    onCursorSide: (cb: (...a: unknown[]) => void) => sub('cursor-side', cb),
+    onNoFilterLoaded: (cb: (...a: unknown[]) => void) => sub('no-filter-loaded', cb),
+    onNoItemInClipboard: (cb: (...a: unknown[]) => void) => sub('no-item-in-clipboard', cb),
+    onOpenSettings: (cb: (...a: unknown[]) => void) => sub('open-settings', cb),
+    onOpenView: (cb: (...a: unknown[]) => void) => sub('open-view', cb),
+    onOpenLinkPending: (cb: (...a: unknown[]) => void) => sub('open-link-pending', cb),
+    onOverlayHide: (cb: (...a: unknown[]) => void) => sub('overlay-hide', cb),
+    onSettingUpdated: (cb: (...a: unknown[]) => void) => sub('setting-updated', cb),
+    onLeagueUpdated: (cb: (...a: unknown[]) => void) => sub('league-updated', cb),
+    onSkipAnimation: (cb: (...a: unknown[]) => void) => sub('skip-animation', cb),
+    onPoeVersion: (cb: (...a: unknown[]) => void) => sub('poe-version', cb),
+    onZoneChanged: (cb: (...a: unknown[]) => void) => sub('zone-changed', cb),
+    onLogLine: (cb: (...a: unknown[]) => void) => {
+      // Also send subscribe/unsubscribe signals
+      snd('client-log:subscribe')
+      const unsub = sub('client-log:line', cb)
+      return () => {
+        snd('client-log:unsubscribe')
+        unsub()
+      }
+    },
+    onGameConfigChange: (cb: (...a: unknown[]) => void) => {
+      snd('plugins:game-config-watch')
+      const unsub = sub('plugins:game-config-changed', cb)
+      return () => {
+        snd('plugins:game-config-unwatch')
+        unsub()
+      }
+    },
+    onOverlayDetach: (cb: (...a: unknown[]) => void) => sub('overlay-detach', cb),
+    onOverlayReattach: (cb: (...a: unknown[]) => void) => sub('overlay-reattach', cb),
+    onPriceCheckOpen: (cb: (...a: unknown[]) => void) => sub('price-check-open', cb),
+    onFilterHotkeyOpen: (cb: (...a: unknown[]) => void) => sub('filter-hotkey-open', cb),
+    onGameSwitchPrompt: (cb: (...a: unknown[]) => void) => sub('game-switch-prompt', cb),
+    onPriceCheck: (cb: (...a: unknown[]) => void) => sub('price-check', cb),
+    onGameBounds: (cb: (...a: unknown[]) => void) => sub('game-bounds', cb),
+    onElevationHint: (cb: (...a: unknown[]) => void) => sub('elevation-hint', cb),
+    onRateLimit: (cb: (...a: unknown[]) => void) => sub('rate-limit', cb),
+    onTradePenalty: (cb: (...a: unknown[]) => void) => sub('trade-penalty', cb),
+    onOnlineFilterChanged: (cb: (...a: unknown[]) => void) => sub('online-filter-changed', cb),
+    onFilterChanged: (cb: (...a: unknown[]) => void) => sub('filter-changed', cb),
+    onUpdateAvailable: (cb: (...a: unknown[]) => void) => sub('update-available', cb),
+    onUpdateDownloadProgress: (cb: (...a: unknown[]) => void) => sub('update-download-progress', cb),
+    onUpdateDownloaded: (cb: (...a: unknown[]) => void) => sub('update-downloaded', cb),
+    onUpdateRescinded: (cb: (...a: unknown[]) => void) => sub('update-rescinded', cb),
+    onUpdateApplied: (cb: (...a: unknown[]) => void) => sub('update-applied', cb),
+    onBrickedRelease: (cb: (...a: unknown[]) => void) => sub('bricked-release', cb),
+    onPluginMacro: (cb: (...a: unknown[]) => void) => sub('plugin-macro', cb),
+    onPluginInstalled: (cb: (...a: unknown[]) => void) => sub('plugin-installed', cb),
+    onPluginUninstalled: (cb: (...a: unknown[]) => void) => sub('plugin-uninstalled', cb),
+    onPluginHotkeysChanged: (cb: (...a: unknown[]) => void) => sub('plugin-hotkeys-changed', cb),
+    onPluginTabsChanged: (cb: (...a: unknown[]) => void) => sub('plugin-tabs-changed', cb),
+    onRegexPresetsChanged: (cb: (...a: unknown[]) => void) => sub('regex-presets-changed', cb),
+    onPluginOverlayInit: (cb: (...a: unknown[]) => void) => sub('plugin-overlay:init', cb),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public: install the shim
+// ---------------------------------------------------------------------------
+let _client: CompanionWsClient | null = null
+
+export async function installCompanionApi(): Promise<void> {
+  const url = resolveWsUrl()
+  const client = new CompanionWsClient(url)
+  _client = client
+  await client.connect()
+
+  const api = buildApi(client)
+  // Install as window.api to match the Electron preload contract
+  ;(window as unknown as { api: typeof api }).api = api
+}
+
+export function getCompanionClient(): CompanionWsClient | null {
+  return _client
+}

--- a/src/renderer/src/companion-main.tsx
+++ b/src/renderer/src/companion-main.tsx
@@ -1,0 +1,55 @@
+/**
+ * Companion renderer entry point.
+ *
+ * 1. Installs the WebSocket-backed window.api shim.
+ * 2. Bootstraps the theme (reads settings via the shim, applies CSS vars).
+ * 3. Mounts the same overlay App component as the Electron renderer.
+ *
+ * The importmap from index.html is NOT present here because the companion
+ * build doesn't use scalpel-internal:// protocol URIs. React is bundled
+ * normally by Vite.
+ */
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './overlay'
+import './styles.css'
+import { installCompanionApi } from './companion-api'
+import { applyCachedVars, bootstrapTheme } from './shared/apply-theme'
+import { DiagnosticErrorBoundary, installRendererDiagnostics } from './shared/diagnostics'
+
+// Apply cached theme immediately to avoid flash
+applyCachedVars()
+installRendererDiagnostics('companion')
+
+async function main(): Promise<void> {
+  // Connect to the main process over WebSocket and expose window.api
+  try {
+    await installCompanionApi()
+  } catch (err) {
+    const loadingEl = document.getElementById('companion-loading')
+    if (loadingEl) {
+      loadingEl.textContent = 'Could not connect to Scalpel. Make sure the app is running with companion mode enabled.'
+      loadingEl.style.color = '#ff6b6b'
+    }
+    console.error('[companion] Failed to connect:', err)
+    // Retry silently after 3s -- the WsClient will reconnect on its own
+    setTimeout(main, 3000)
+    return
+  }
+
+  // Reconcile theme with persisted settings
+  void bootstrapTheme()
+
+  const root = document.getElementById('root')!
+  // Remove the loading placeholder
+  root.innerHTML = ''
+  createRoot(root).render(
+    <StrictMode>
+      <DiagnosticErrorBoundary source="companion">
+        <App />
+      </DiagnosticErrorBoundary>
+    </StrictMode>,
+  )
+}
+
+void main()

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -2,6 +2,7 @@ export type DiagnosticSource =
   | 'main'
   | 'app'
   | 'overlay'
+  | 'companion'
   | 'whiteboard'
   | 'cheat-sheets'
   | 'cheat-sheet-preview'


### PR DESCRIPTION
## Summary

This PR adds a companion browser mode for Scalpel.

The idea is to make it possible to use Scalpel in a regular browser window instead of relying on the overlay. I mainly made this because I use Hyprland, and overlays can be pretty troublesome there.

## Why

On Hyprland, the normal overlay behavior does not work very well for me, so I wanted a way to still use Scalpel without depending on overlays.

This browser mode is mostly meant as a workaround for that. So far, I have mainly been using it for price checking.

## Current state

This is still pretty experimental.

I do not really recommend merging it as-is yet, because I have not fully tested everything. Some parts seem to work, but other parts may be broken. For example, filters do not seem to work correctly right now.

## Notes

A good amount of this code was generated with help from an LLM, so it is possible I accidentally broke something or introduced issues I did not notice.

I also cannot test on Windows right now, so I am not sure if this affects Windows users or not.

I am opening this PR mostly to share the idea and get feedback.

I would probably not merge this right away unless maintainers are okay with treating it as experimental. It may be better to use this as a starting point for discussion or future improvements.
