### PR TITLE
Fix AUR builds when global libvips is installed

### DIFF
--- a/packaging/aur/scalpel-poe-git/.SRCINFO
+++ b/packaging/aur/scalpel-poe-git/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = scalpel-poe-git
 	pkgdesc = Path of Exile's First Fourth-Party Tool
-	pkgver = 20260529
-	pkgrel = 1
+	pkgver = 0.9.14.rc2.2.gd276a86
+	pkgrel = 2
 	url = https://github.com/scalpelpoe/scalpel
 	arch = x86_64
 	license = AGPL-3.0-only

--- a/packaging/aur/scalpel-poe-git/PKGBUILD
+++ b/packaging/aur/scalpel-poe-git/PKGBUILD
@@ -2,8 +2,8 @@
 # Contributor: Kristofers Solo <dev at kristofers dot xyz>
 
 pkgname=scalpel-poe-git
-pkgver=0.9.9.rc2.0.ge858db3
-pkgrel=1
+pkgver=0.9.14.rc2.2.gd276a86
+pkgrel=2
 pkgdesc="Path of Exile's First Fourth-Party Tool"
 arch=("x86_64")
 url="https://github.com/scalpelpoe/scalpel"
@@ -40,8 +40,10 @@ _check_node_version() {
 }
 
 _enter_builddir() {
-    cd scalpel || return 1
+    cd "$srcdir/scalpel" || return 1
     _check_node_version || return 1
+
+    export SHARP_IGNORE_GLOBAL_LIBVIPS=1
 }
 
 pkgver() {
@@ -57,14 +59,14 @@ prepare() {
 }
 
 build() {
-    cd scalpel
+    _enter_builddir
 
     npm run build
     npx electron-builder --linux AppImage --x64 --publish never
 }
 
 package() {
-    cd scalpel
+    cd "$srcdir/scalpel"
 
     install -Dm755 "dist/Scalpel.AppImage" "$pkgdir/opt/scalpel-poe/Scalpel.AppImage"
 

--- a/packaging/aur/scalpel-poe/.SRCINFO
+++ b/packaging/aur/scalpel-poe/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = scalpel-poe
 	pkgdesc = Path of Exile's First Fourth-Party Tool
 	pkgver = 0.9.8
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/scalpelpoe/scalpel
 	arch = x86_64
 	license = AGPL-3.0-only

--- a/packaging/aur/scalpel-poe/PKGBUILD
+++ b/packaging/aur/scalpel-poe/PKGBUILD
@@ -3,7 +3,7 @@
 
 pkgname=scalpel-poe
 pkgver=0.9.8
-pkgrel=1
+pkgrel=2
 pkgdesc="Path of Exile's First Fourth-Party Tool"
 arch=("x86_64")
 url="https://github.com/scalpelpoe/scalpel"
@@ -41,8 +41,10 @@ _check_node_version() {
 }
 
 _enter_builddir() {
-    cd "scalpel-$_upstream_version" || return 1
+    cd "$srcdir/scalpel-$_upstream_version" || return 1
     _check_node_version || return 1
+
+    export SHARP_IGNORE_GLOBAL_LIBVIPS=1
 }
 
 prepare() {
@@ -59,7 +61,7 @@ build() {
 }
 
 package() {
-    cd "scalpel-$_upstream_version"
+    cd "$srcdir/scalpel-$_upstream_version"
 
     install -Dm755 "dist/Scalpel.AppImage" "$pkgdir/opt/scalpel-poe/Scalpel.AppImage"
 


### PR DESCRIPTION
This should fix the build failing during `npm ci` when `sharp` tries to build from source.