### PR TITLE
Use OS-agnostic temporary paths

### DIFF
--- a/src/main/baselines.test.ts
+++ b/src/main/baselines.test.ts
@@ -3,14 +3,16 @@ import { unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
-const MOCK_USER_DATA = vi.hoisted(() => `${require('node:os').tmpdir()}/scalpel-baselines-${Date.now()}`)
+const MOCK_USER_DATA = vi.hoisted(() =>
+  require('node:path').join(require('node:os').tmpdir(), `scalpel-baselines-${Date.now()}`),
+)
 vi.mock('electron', () => ({ app: { getPath: vi.fn(() => MOCK_USER_DATA) } }))
 
 import { getBaselineByLocalPath, saveBaseline } from './baselines'
 
 describe('getBaselineByLocalPath', () => {
   it('returns the content + meta for a matching local path', () => {
-    const localPath = `${MOCK_USER_DATA}/x/MyFilter-local.filter`
+    const localPath = join(MOCK_USER_DATA, 'x', 'MyFilter-local.filter')
     saveBaseline('MyFilter', '#name: MyFilter\nShow\n', '/online/abc', localPath)
     const found = getBaselineByLocalPath(localPath)
     expect(found).not.toBeNull()
@@ -20,11 +22,11 @@ describe('getBaselineByLocalPath', () => {
   })
 
   it('returns null for an unknown local path', () => {
-    expect(getBaselineByLocalPath(`${MOCK_USER_DATA}/x/nonexistent-local.filter`)).toBeNull()
+    expect(getBaselineByLocalPath(join(MOCK_USER_DATA, 'x', 'nonexistent-local.filter'))).toBeNull()
   })
 
   it('returns null when the matched meta has no baseline file (scan continues, finds nothing)', () => {
-    const localPath = `${MOCK_USER_DATA}/x/Orphan-local.filter`
+    const localPath = join(MOCK_USER_DATA, 'x', 'Orphan-local.filter')
     saveBaseline('Orphan', 'content', '/online/orphan', localPath)
     // Delete the .baseline file, leaving the orphaned .meta.json behind.
     const hash = createHash('md5').update('Orphan').digest('hex')

--- a/src/main/filter-state.test.ts
+++ b/src/main/filter-state.test.ts
@@ -3,7 +3,9 @@ import { tmpdir } from 'os'
 import { join } from 'path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const MOCK_USER_DATA = vi.hoisted(() => `${process.env.TEMP ?? process.cwd()}\\scalpel-filter-state-${Date.now()}`)
+const MOCK_USER_DATA = vi.hoisted(() =>
+  require('node:path').join(require('node:os').tmpdir(), `scalpel-filter-state-${Date.now()}`),
+)
 
 vi.mock('electron', () => ({
   app: { getPath: vi.fn(() => MOCK_USER_DATA) },

--- a/src/main/filter/sanitize.test.ts
+++ b/src/main/filter/sanitize.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const MOCK_USER_DATA = vi.hoisted(() => `${require('node:os').tmpdir()}/scalpel-sanitize-${Date.now()}`)
+const MOCK_USER_DATA = vi.hoisted(() =>
+  require('node:path').join(require('node:os').tmpdir(), `scalpel-sanitize-${Date.now()}`),
+)
 vi.mock('electron', () => ({ app: { getPath: vi.fn(() => MOCK_USER_DATA) } }))
 
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'


### PR DESCRIPTION
## Summary

Now using OS-agnostic path separators instead of hard-coded `\` or `/`.
