### PR TITLE
fix(hotkeys): restore Wayland macro focus gate (#493)

### DIFF
--- a/src/main/hotkeys-focus.test.ts
+++ b/src/main/hotkeys-focus.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Covers the async foreground-focus gate (hasPoeOrOverlayFocus) and the
 // contextual hotkey paths that consult it: chat commands, app macros,
@@ -158,8 +158,36 @@ beforeEach(() => {
 })
 
 describe('hasPoeOrOverlayFocus', () => {
-  it('rejects stale overlay target focus when the foreground title is not PoE', async () => {
+  let originalPlatform: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  })
+
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  it('rejects stale overlay target focus on Windows when the foreground title is not PoE', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
     mock.state.targetHasFocus = true
+
+    await expect(hasPoeOrOverlayFocus()).resolves.toBe(false)
+  })
+
+  it('accepts overlay target focus on Linux when active-win cannot read the foreground title', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    mock.state.targetHasFocus = true
+    mock.state.focusedVersion = null
+
+    await expect(hasPoeOrOverlayFocus()).resolves.toBe(true)
+  })
+
+  it('still rejects on Linux when neither active-win nor the overlay target reports focus', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    mock.state.targetHasFocus = false
+    mock.state.focusedVersion = null
+    mock.state.scalpelFocused = false
 
     await expect(hasPoeOrOverlayFocus()).resolves.toBe(false)
   })

--- a/src/main/hotkeys.ts
+++ b/src/main/hotkeys.ts
@@ -103,7 +103,12 @@ function fireTrigger(): void {
  *  "Path of Exile 2", while active-win gives us the exact foreground title. */
 export async function hasPoeOrOverlayFocus(): Promise<boolean> {
   if (isAnyScalpelBrowserWindowFocused()) return true
-  return (await detectFocusedPoeVersion()) !== null
+  if ((await detectFocusedPoeVersion()) !== null) return true
+  // active-win can't read the foreground title under Wayland/XWayland; on Linux
+  // the attached window's focus flag is the only reliable signal. Kept off
+  // Windows, where active-win is reliable and targetHasFocus can be stale
+  // (issues #18/#21). Issue #493.
+  return process.platform === 'linux' && OverlayController.targetHasFocus
 }
 
 function firePriceCheck(): void {


### PR DESCRIPTION
Attempt to fix issues popping up related to linux macros not working. adding fallback used for the default hotkeys since they work. Please test.