### PR TITLE
fix(startup): guard overlay native compatibility

### DIFF
--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -1,7 +1,67 @@
 const path = require('node:path')
 const fs = require('node:fs')
 
+const REQUIRED_OVERLAY_VERSION = '4.1.0'
+const REQUIRED_NATIVE_EXPORTS = ['setTargetTitles', 'clearTarget', 'stopHook']
+
+function findNativeBinaries(dir) {
+  const binaries = []
+  if (!fs.existsSync(dir)) return binaries
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) binaries.push(...findNativeBinaries(fullPath))
+    else if (entry.isFile() && entry.name.endsWith('.node')) binaries.push(fullPath)
+  }
+  return binaries
+}
+
+function assertOverlayDependency(moduleDir) {
+  const packagePath = path.join(moduleDir, 'package.json')
+  const wrapperPath = path.join(moduleDir, 'dist', 'index.js')
+  if (!fs.existsSync(packagePath) || !fs.existsSync(wrapperPath)) {
+    throw new Error(`electron-overlay-window is incomplete in ${moduleDir}`)
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'))
+  if (packageJson.version !== REQUIRED_OVERLAY_VERSION) {
+    throw new Error(
+      `electron-overlay-window ${packageJson.version ?? 'unknown'} is installed; ${REQUIRED_OVERLAY_VERSION} is required`,
+    )
+  }
+
+  const wrapper = fs.readFileSync(wrapperPath, 'utf8')
+  for (const api of ['attachByTitles', 'setTargetTitles']) {
+    if (!wrapper.includes(`${api}(`)) {
+      throw new Error(`electron-overlay-window ${packageJson.version} JS wrapper is missing ${api}()`)
+    }
+  }
+
+  const binaries = findNativeBinaries(moduleDir)
+  const compatibleBinary = binaries.find((binaryPath) => {
+    const binary = fs.readFileSync(binaryPath)
+    return REQUIRED_NATIVE_EXPORTS.every((name) => binary.includes(Buffer.from(name)))
+  })
+  if (!compatibleBinary) {
+    throw new Error(
+      `electron-overlay-window ${packageJson.version} has no native addon with ${REQUIRED_NATIVE_EXPORTS.join('/')}`,
+    )
+  }
+
+  return compatibleBinary
+}
+
 exports.default = async function afterPack(context) {
+  const overlayDir = path.join(
+    context.appOutDir,
+    'resources',
+    'app.asar.unpacked',
+    'node_modules',
+    'electron-overlay-window',
+  )
+  const overlayBinary = assertOverlayDependency(overlayDir)
+  console.log(`[afterPack] Verified electron-overlay-window ${REQUIRED_OVERLAY_VERSION}: ${overlayBinary}`)
+
   // Remove app-update.yml (we use our own update system, not electron-updater)
   const ymlPath = path.join(context.appOutDir, 'resources', 'app-update.yml')
   if (fs.existsSync(ymlPath)) {
@@ -9,3 +69,5 @@ exports.default = async function afterPack(context) {
     console.log('[afterPack] Removed app-update.yml')
   }
 }
+
+exports.assertOverlayDependency = assertOverlayDependency

--- a/scripts/afterPack.test.mjs
+++ b/scripts/afterPack.test.mjs
@@ -1,0 +1,54 @@
+import { createRequire } from 'node:module'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const require = createRequire(import.meta.url)
+const { assertOverlayDependency } = require('./afterPack.js')
+
+const tempDirs = []
+
+function makeOverlayModule({ version = '4.1.0', wrapper = '', nativeStrings = [] } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'scalpel-overlay-dependency-'))
+  tempDirs.push(root)
+  mkdirSync(join(root, 'dist'), { recursive: true })
+  mkdirSync(join(root, 'build', 'Release'), { recursive: true })
+  writeFileSync(join(root, 'package.json'), JSON.stringify({ version }))
+  writeFileSync(join(root, 'dist', 'index.js'), wrapper)
+  writeFileSync(join(root, 'build', 'Release', 'overlay_window.node'), nativeStrings.join('\0'))
+  return root
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true })
+})
+
+describe('afterPack electron-overlay-window validation', () => {
+  it('accepts the compatible multi-title wrapper and native addon', () => {
+    const moduleDir = makeOverlayModule({
+      wrapper: 'attachByTitles() {} setTargetTitles() {}',
+      nativeStrings: ['setTargetTitles', 'clearTarget', 'stopHook'],
+    })
+
+    expect(assertOverlayDependency(moduleDir)).toContain('overlay_window.node')
+  })
+
+  it('rejects the stale single-title wrapper that caused startup failure', () => {
+    const moduleDir = makeOverlayModule({
+      version: '4.0.2',
+      wrapper: 'attachByTitle() {}',
+      nativeStrings: ['setTargetTitles', 'clearTarget', 'stopHook'],
+    })
+
+    expect(() => assertOverlayDependency(moduleDir)).toThrow('4.0.2 is installed; 4.1.0 is required')
+  })
+
+  it('rejects an old native addon behind a current wrapper', () => {
+    const moduleDir = makeOverlayModule({
+      wrapper: 'attachByTitles() {} setTargetTitles() {}',
+      nativeStrings: ['start', 'focusTarget'],
+    })
+
+    expect(() => assertOverlayDependency(moduleDir)).toThrow('has no native addon')
+  })
+})

--- a/src/main/experimental/index.ts
+++ b/src/main/experimental/index.ts
@@ -13,7 +13,7 @@ import {
   hydrateActiveProfileSettings,
 } from '../profiles/profile-settings'
 import { applyProfileHydrationSideEffects, broadcastSettingUpdates } from '../settings-write'
-import { createOverlayWindow, getOverlayAttachedVersion, retargetForGame } from '../overlay'
+import { createOverlayWindow, getOverlayAttachedVersion, retargetForGame, supportsMultiTitleOverlay } from '../overlay'
 
 /** Resolved once on first access from the store's updateChannel at that point.
  *  Changing updateChannel mid-session has no effect - the multi-window
@@ -81,6 +81,11 @@ export function getGameSwitchCoordinator(store: Store<AppSettings>): GameSwitchC
 export function getOverlayAttachStrategy(store: Store<AppSettings>): OverlayAttachStrategy {
   if (!cachedOverlay) {
     if (resolveEnabled(store)) {
+      if (!supportsMultiTitleOverlay()) {
+        throw new Error(
+          'Invalid electron-overlay-window runtime: the required attachByTitles/setTargetTitles API is missing.',
+        )
+      }
       // Wire hotkey switch eagerly so the first hotkey switch before
       // getGameSwitchCoordinator is called still uses the in-process path.
       wireExperimentalHotkeySwitch()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -277,16 +277,30 @@ if (!gotLock) {
 const installDir = IS_E2E ? process.cwd() : applyPendingUpdate()
 
 app.whenReady().then(() => {
-  if (!IS_E2E)
-    getOverlayAttachStrategy(store).createInitialOverlay((store.get(PROFILE_VERSION_KEY) as GameVariant) ?? 1)
-  setMainOverlayGetter(getOverlayWindow)
-  if (!IS_E2E) setOnLeaveScalpel(() => suspendHotkeys())
   createAppWindow(store)
-  if (!IS_E2E) createTray({ store, showAppWindow })
+  if (!IS_E2E) {
+    try {
+      createTray({ store, showAppWindow })
+    } catch (err) {
+      recordMainDiagnostic('tray-startup', err)
+      showAppWindow()
+    }
+  }
 
   registerScalpelInternalProtocol()
   registerScalpelPluginProtocol()
   registerCheatSheetProtocol()
+
+  setMainOverlayGetter(getOverlayWindow)
+  if (!IS_E2E) {
+    setOnLeaveScalpel(() => suspendHotkeys())
+    try {
+      getOverlayAttachStrategy(store).createInitialOverlay((store.get(PROFILE_VERSION_KEY) as GameVariant) ?? 1)
+    } catch (err) {
+      recordMainDiagnostic('overlay-startup', err)
+      showAppWindow()
+    }
+  }
 
   onFilterLoaded(() => {
     getOverlayWindow()?.webContents.send('filter-changed')

--- a/src/main/overlay.ts
+++ b/src/main/overlay.ts
@@ -299,6 +299,15 @@ export interface CreateOverlayOptions {
   onAttachedGameVariant?: (variant: 1 | 2) => void
 }
 
+/** The multi-title strategy requires the compatible JS wrapper and native fork.
+ *  Packaging validates the native side; this runtime check gives startup a
+ *  synchronous, diagnosable failure instead of calling a mismatched ABI. */
+export function supportsMultiTitleOverlay(): boolean {
+  return (
+    typeof OverlayController.attachByTitles === 'function' && typeof OverlayController.setTargetTitles === 'function'
+  )
+}
+
 export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayOptions): BrowserWindow {
   setPoeVersion(version)
   overlayAttachedVersion = version


### PR DESCRIPTION
## Summary

- fail packaging when the `electron-overlay-window` JavaScript wrapper and native addon are incompatible
- validate the multi-title overlay API synchronously before calling into native code
- create the app window and tray before overlay attachment, preserving a visible recovery path when startup fails

## Problem

A packaged Scalpel runtime was found with the single-title `electron-overlay-window` 4.0.2 JavaScript wrapper alongside the multi-title 4.1.0 native addon. The wrapper called the old `attachByTitle` contract while the native module expected the newer multi-title contract.

Calling that mismatched pair failed from the native callback during initial overlay creation. Because overlay attachment ran before the app window/tray recovery path, a `startInTray` launch could leave the Scalpel process tree running with no usable overlay, no tray icon, and no window from which to recover.

The dependency declaration already points at Scalpel's multi-title fork. The missing boundary was verification of the exact wrapper/native pair that electron-builder actually placed in the packaged application.

## Changes

### Packaging guard

`afterPack` now verifies the packaged `electron-overlay-window` module before an installer can be produced:

- package version is exactly `4.1.0`;
- the JavaScript wrapper contains `attachByTitles()` and `setTargetTitles()`;
- at least one packaged native addon exports `setTargetTitles`, `clearTarget`, and `stopHook`.

Packaging fails with a specific error if the package is incomplete, the wrapper is stale, or the native addon does not match the wrapper.

### Runtime and startup recovery

- The multi-title attach strategy checks the wrapper API synchronously and reports an explicit invalid-runtime error instead of entering the mismatched native call.
- The app window and tray are created before initial overlay attachment.
- Tray and overlay startup failures are recorded independently.
- If either startup step throws, Scalpel shows the app window so the process remains accessible and diagnosable instead of staying hidden.

## Reproduction

1. Package the application with the 4.0.2 single-title wrapper and a 4.1.0 multi-title native addon.
2. Start Scalpel with the multi-title overlay strategy and `startInTray` enabled.
3. Initial overlay attachment calls incompatible wrapper/native contracts and throws from the native callback.
4. Before this change, startup can remain process-only with no accessible tray or app window.
5. With this change, the incompatible package is rejected during `afterPack`; a runtime wrapper mismatch is also rejected synchronously, and startup retains a visible fallback.

## Compatibility

There is no plugin API change. A correctly packaged `electron-overlay-window` 4.1.0 dependency behaves as before. The intentional compatibility change is that stale or mixed wrapper/native packages now fail the build rather than producing an installer that can fail during startup.

## Verification

- `npm run lint` (no errors; four pre-existing warnings)
- `npm run format:check`
- `npm run typecheck`
- `scripts/afterPack.test.mjs`: 3 tests passed, covering the compatible pair and both mismatch directions
- full Vitest suite: 216 files passed; 2453 tests passed, 3 skipped
- `npm run build`
- Windows x64 electron-builder packaging completed successfully
- packaged `afterPack` verification confirmed `electron-overlay-window` 4.1.0 and its required native exports before NSIS generation
