### PR TITLE
fix(update): apply protected installs transactionally

### DIFF
--- a/src/main/update/apply-update.test.ts
+++ b/src/main/update/apply-update.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { buildUpdateBatch, getUpdateLaunchSpec, type UpdateBatchPlan } from './apply-update'
+
+const plan = (overrides: Partial<UpdateBatchPlan> = {}): UpdateBatchPlan => ({
+  stagingDir: 'C:\\Users\\Test\\AppData\\Roaming\\scalpel\\update-staging',
+  userDataDir: 'C:\\Users\\Test\\AppData\\Roaming\\scalpel',
+  installDir: 'C:\\Program Files\\Scalpel',
+  resourcesDir: 'C:\\Program Files\\Scalpel\\resources',
+  exePath: 'C:\\Program Files\\Scalpel\\Scalpel.exe',
+  version: '1.0.1-rc1',
+  isFullUpgrade: false,
+  electronZip: 'C:\\staging\\electron.zip',
+  fullUpgradeAsar: 'C:\\staging\\app.asar.staged',
+  asarNew: 'C:\\staging\\app.asar.new',
+  pendingManifest: 'C:\\staging\\manifest.pending.json',
+  copyUnpacked: false,
+  asarUnpackedSrc: 'C:\\staging\\app.asar.unpacked',
+  asarUnpackedDest: 'C:\\Program Files\\Scalpel\\resources\\app.asar.unpacked',
+  ...overrides,
+})
+
+describe('buildUpdateBatch', () => {
+  it('checks the ASAR and manifest copies before declaring the update applied', () => {
+    const batch = buildUpdateBatch(plan())
+
+    expect(batch).toContain('copy /y "C:\\staging\\app.asar.new" "C:\\Program Files\\Scalpel\\resources\\app.asar"')
+    expect(batch.match(/if errorlevel 1 goto :apply_failed/g)).toHaveLength(2)
+    expect(batch.indexOf('just-updated.json')).toBeGreaterThan(batch.indexOf('install-manifest.json'))
+    expect(batch.indexOf('rmdir /s /q')).toBeGreaterThan(batch.indexOf('just-updated.json'))
+    expect(batch).toContain('start "" explorer.exe "C:\\Program Files\\Scalpel\\Scalpel.exe"')
+  })
+
+  it('preserves staging and relaunches the installed executable on failure', () => {
+    const batch = buildUpdateBatch(plan())
+    const failureBlock = batch.slice(batch.lastIndexOf('\r\n:apply_failed'))
+
+    expect(failureBlock).toContain('update-apply-error.json')
+    expect(failureBlock).toContain('start "" explorer.exe "C:\\Program Files\\Scalpel\\Scalpel.exe"')
+    expect(failureBlock).not.toContain('rmdir /s /q')
+    expect(failureBlock).not.toContain('just-updated.json')
+  })
+
+  it('checks full-upgrade extraction, executable move, ASAR, unpacked files, and manifest', () => {
+    const batch = buildUpdateBatch(plan({ isFullUpgrade: true, copyUnpacked: true }))
+
+    expect(batch).toContain('Expand-Archive')
+    expect(batch).toContain('move /y')
+    expect(batch).toContain('xcopy /y /e /i')
+    expect(batch.match(/if errorlevel 1 goto :apply_failed/g)).toHaveLength(5)
+  })
+})
+
+describe('getUpdateLaunchSpec', () => {
+  it('uses the packaged elevation helper on Windows', () => {
+    expect(
+      getUpdateLaunchSpec(
+        'C:\\Users\\Test\\apply-update.bat',
+        'C:\\Program Files\\Scalpel\\resources',
+        'win32',
+        true,
+        false,
+      ),
+    ).toEqual({
+      command: 'C:\\Program Files\\Scalpel\\resources\\elevate.exe',
+      args: ['cmd.exe', '/d', '/s', '/c', 'C:\\Users\\Test\\apply-update.bat'],
+      elevated: true,
+    })
+  })
+
+  it('falls back to cmd when the helper is unavailable', () => {
+    expect(getUpdateLaunchSpec('C:\\apply-update.bat', 'C:\\resources', 'win32', false, false)).toEqual({
+      command: 'cmd.exe',
+      args: ['/d', '/s', '/c', 'C:\\apply-update.bat'],
+      elevated: false,
+    })
+  })
+
+  it('does not elevate a writable per-user installation', () => {
+    expect(getUpdateLaunchSpec('C:\\apply-update.bat', 'C:\\resources', 'win32', true, true)).toEqual({
+      command: 'cmd.exe',
+      args: ['/d', '/s', '/c', 'C:\\apply-update.bat'],
+      elevated: false,
+    })
+  })
+})

--- a/src/main/update/apply-update.ts
+++ b/src/main/update/apply-update.ts
@@ -1,0 +1,116 @@
+import { join } from 'node:path'
+
+export interface UpdateBatchPlan {
+  stagingDir: string
+  userDataDir: string
+  installDir: string
+  resourcesDir: string
+  exePath: string
+  version: string
+  isFullUpgrade: boolean
+  electronZip: string
+  fullUpgradeAsar: string
+  asarNew: string
+  pendingManifest: string
+  copyUnpacked: boolean
+  asarUnpackedSrc: string
+  asarUnpackedDest: string
+}
+
+export interface UpdateLaunchSpec {
+  command: string
+  args: string[]
+  elevated: boolean
+}
+
+function checked(command: string): string[] {
+  return [command, 'if errorlevel 1 goto :apply_failed']
+}
+
+/**
+ * Build the out-of-process Windows update transaction.
+ *
+ * The installed executable must be stopped before app.asar can be replaced. Every
+ * mutating step is checked so an ACL/AV/filesystem failure preserves the staged
+ * update and relaunches the known-good installed executable instead of reporting a
+ * false successful update.
+ */
+export function buildUpdateBatch(plan: UpdateBatchPlan): string {
+  const asarPath = join(plan.resourcesDir, 'app.asar')
+  const electronExe = join(plan.installDir, 'electron.exe')
+  const installedExe = plan.isFullUpgrade ? join(plan.installDir, 'Scalpel.exe') : plan.exePath
+  const localManifest = join(plan.userDataDir, 'install-manifest.json')
+  const justUpdated = join(plan.userDataDir, 'just-updated.json')
+  const applyError = join(plan.userDataDir, 'update-apply-error.json')
+  // The swap itself may run elevated for Program Files. Hand relaunch to the
+  // interactive desktop shell so Scalpel does not inherit the helper's High
+  // integrity token while a normally launched game is running at Medium.
+  const relaunch = `start "" explorer.exe "${installedExe}"`
+  const fallbackRelaunch = `start "" explorer.exe "${plan.exePath}"`
+
+  const lines = ['@echo off', 'setlocal', 'ping -n 3 127.0.0.1 > nul']
+
+  if (plan.isFullUpgrade) {
+    lines.push(
+      ...checked(
+        `powershell -NoProfile -Command "Expand-Archive -LiteralPath '${plan.electronZip}' -DestinationPath '${plan.installDir}' -Force"`,
+      ),
+      `if exist "${electronExe}" (`,
+      `  move /y "${electronExe}" "${plan.exePath}"`,
+      '  if errorlevel 1 goto :apply_failed',
+      ')',
+      ...checked(`copy /y "${plan.fullUpgradeAsar}" "${asarPath}" > nul`),
+    )
+  } else {
+    lines.push(...checked(`copy /y "${plan.asarNew}" "${asarPath}" > nul`))
+  }
+
+  if (plan.copyUnpacked) {
+    lines.push(...checked(`xcopy /y /e /i "${plan.asarUnpackedSrc}" "${plan.asarUnpackedDest}" > nul`))
+  }
+
+  lines.push(
+    ...checked(`copy /y "${plan.pendingManifest}" "${localManifest}" > nul`),
+    `> "${justUpdated}" echo {"version":"${plan.version}"}`,
+    `if exist "${applyError}" del /q "${applyError}"`,
+    `rmdir /s /q "${plan.stagingDir}"`,
+    relaunch,
+    'del "%~f0"',
+    'exit /b 0',
+    '',
+    ':apply_failed',
+    `> "${applyError}" echo {"version":"${plan.version}","message":"The staged update could not replace the installed files."}`,
+    fallbackRelaunch,
+    'del "%~f0"',
+    'exit /b 1',
+  )
+
+  return lines.join('\r\n')
+}
+
+/**
+ * Packaged Windows builds ship electron-builder's elevation helper. Use it only
+ * when a real write probe has shown that the current launch cannot replace files
+ * in the install directory; per-user installs keep the direct, prompt-free path.
+ */
+export function getUpdateLaunchSpec(
+  batPath: string,
+  resourcesDir: string,
+  platform: NodeJS.Platform,
+  elevateExists: boolean,
+  installWritable: boolean,
+): UpdateLaunchSpec {
+  if (platform === 'win32' && elevateExists && !installWritable) {
+    return {
+      command: join(resourcesDir, 'elevate.exe'),
+      args: ['cmd.exe', '/d', '/s', '/c', batPath],
+      elevated: true,
+    }
+  }
+
+  return {
+    command: 'cmd.exe',
+    args: ['/d', '/s', '/c', batPath],
+    elevated: false,
+  }
+}

--- a/src/main/update/updater.ts
+++ b/src/main/update/updater.ts
@@ -15,6 +15,7 @@ import { app, type BrowserWindow, ipcMain } from 'electron'
 import { ELECTRON_RELEASES, GITHUB_RELEASES_API } from '@shared/endpoints'
 import type { InstallManifest } from '@shared/types'
 import { findBrickedMatch } from '@shared/version-match'
+import { buildUpdateBatch, getUpdateLaunchSpec } from './apply-update'
 import { selectListRelease } from './select-release'
 import { recordMainBreadcrumb, registerDiagnosticProvider } from '../diagnostics'
 import { stopHotkeyListener } from '../hotkeys'
@@ -465,7 +466,7 @@ ipcMain.on('save-overlay-state', (_event, state: Record<string, unknown>) => {
   }
 })
 
-ipcMain.handle('install-update', () => {
+ipcMain.handle('install-update', async () => {
   if (IS_DEV) return
   const stagingDir = getStagingDir()
   const asarNew = join(stagingDir, 'app.asar.new')
@@ -474,7 +475,6 @@ ipcMain.handle('install-update', () => {
   const pendingManifest = join(stagingDir, 'manifest.pending.json')
   const resourcesDir = process.resourcesPath || join(dirname(process.execPath), 'resources')
   const installDir = dirname(resourcesDir)
-  const asarPath = join(resourcesDir, 'app.asar')
   const asarUnpackedSrc = join(stagingDir, 'app.asar.unpacked')
   const asarUnpackedDest = join(resourcesDir, 'app.asar.unpacked')
   const exePath = process.execPath
@@ -494,60 +494,68 @@ ipcMain.handle('install-update', () => {
     return
   }
 
-  // Save the version we're updating to so we can show a banner after restart
+  let pendingVersion = updateAvailableVersion ?? 'unknown'
   try {
     const pending = JSON.parse(readFileSync(pendingManifest, 'utf8'))
-    writeFileSync(join(userDataDir, 'just-updated.json'), JSON.stringify({ version: pending.version }))
+    pendingVersion = pending.version
   } catch {
-    /* non-critical */
+    /* keep the last version reported by the update check */
   }
 
   const batPath = join(userDataDir, 'apply-update.bat')
-  // The batch runs with no console (DETACHED_PROCESS); `timeout` can exit immediately
-  // without a console, `ping` waits ~2s regardless.
-  const batLines = ['@echo off', 'ping -n 3 127.0.0.1 > nul']
-
-  if (isFullUpgrade) {
-    // Full Electron upgrade: extract the zip over the install directory, then copy asar.
-    // The zip contains electron.exe which needs to be renamed to match the installed exe name.
-    const electronExe = join(installDir, 'electron.exe')
-    batLines.push(
-      `powershell -NoProfile -Command "Expand-Archive -Path '${electronZip}' -DestinationPath '${installDir}' -Force"`,
-      `if exist "${electronExe}" (move /y "${electronExe}" "${exePath}")`,
-      `copy /y "${fullUpgradeAsar}" "${asarPath}"`,
-    )
-  } else {
-    // Asar-only update
-    batLines.push(`copy /y "${asarNew}" "${asarPath}"`)
-  }
-
-  // Copy unpacked native modules if present
-  if (existsSync(asarUnpackedSrc)) {
-    batLines.push(`xcopy /y /e /i "${asarUnpackedSrc}" "${asarUnpackedDest}"`)
-  }
-  // Update manifest
-  if (existsSync(pendingManifest)) {
-    batLines.push(`copy /y "${pendingManifest}" "${join(userDataDir, 'install-manifest.json')}"`)
-  }
-  // Clean up staging, relaunch, self-delete
-  batLines.push(
-    `rmdir /s /q "${stagingDir}"`,
-    `start "" "${isFullUpgrade ? join(installDir, 'Scalpel.exe') : exePath}"`,
-    `del "%~f0"`,
+  writeFileSync(
+    batPath,
+    buildUpdateBatch({
+      stagingDir,
+      userDataDir,
+      installDir,
+      resourcesDir,
+      exePath,
+      version: pendingVersion,
+      isFullUpgrade,
+      electronZip,
+      fullUpgradeAsar,
+      asarNew,
+      pendingManifest,
+      copyUnpacked: existsSync(asarUnpackedSrc),
+      asarUnpackedSrc,
+      asarUnpackedDest,
+    }),
   )
 
-  writeFileSync(batPath, batLines.join('\r\n'))
+  const elevatePath = join(resourcesDir, 'elevate.exe')
+  const writeProbePath = join(resourcesDir, `.scalpel-update-write-test-${process.pid}`)
+  let installWritable = false
+  try {
+    writeFileSync(writeProbePath, '')
+    unlinkSync(writeProbePath)
+    installWritable = true
+  } catch {
+    try {
+      unlinkSync(writeProbePath)
+    } catch {
+      /* probe was never created */
+    }
+  }
+  const launch = getUpdateLaunchSpec(batPath, resourcesDir, process.platform, existsSync(elevatePath), installWritable)
+  try {
+    const child = spawn(launch.command, launch.args, {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: true,
+    })
+    await new Promise<void>((resolve, reject) => {
+      child.once('spawn', resolve)
+      child.once('error', reject)
+    })
+    child.unref()
+  } catch (err) {
+    recordMainBreadcrumb(`updater: failed to launch apply helper: ${(err as Error).message}`)
+    console.error('[Updater] Failed to launch apply helper:', (err as Error).message)
+    return
+  }
 
-  // Run the batch detached with no console. DETACHED_PROCESS gives the child no
-  // console window at all, so nothing flashes. A VBS wrapper used to do the hiding,
-  // but AV heuristics flag app-written VBS as dropper behavior (#448).
-  spawn('cmd.exe', ['/c', batPath], {
-    detached: true,
-    stdio: 'ignore',
-    windowsHide: true,
-  }).unref()
-
-  recordMainBreadcrumb('updater: exit to apply update')
+  recordMainBreadcrumb(`updater: exit to apply update (${launch.elevated ? 'elevated' : 'direct'})`)
   stopHotkeyListener()
   app.exit(0)
 })


### PR DESCRIPTION
## Summary  - make update application transactional for protected install directories - probe whether the install directory is actually writable before deciding to elevate - use the packaged electron-builder elevation helper only when the install requires it - check every mutating step and write the success marker only after the transaction completes - preserve staging and write a structured error marker when application fails - relaunch through the interactive Explorer shell so a successful elevated helper does not pass a high-integrity token to the next app process  ## Root cause  The previous Windows apply script did not check the result of its copy, move, or directory replacement commands. In a protected installation such as Program Files, an unelevated apply could fail to replace the packaged application while still writing the success marker, deleting staging, and restarting the old executable.  ## Behavior  - writable installs continue without elevation - protected or non-writable installs use the packaged `elevate.exe` - generated filesystem paths are quoted in the apply script - required payload replacement and manifest-copy steps check `errorlevel` before the success marker is written - failure preserves the downloaded update for retry and records `update-apply-error.json` - success records `just-updated` only after the replacement completes - both success and failure relaunch through Explorer in the interactive user context  ## Verification  Exact branch head `a2d6942`, based directly on `v1.0.1-rc1`:  - `npm run format:check` - `npm run lint` (no errors; four warnings already present in the base) - `npm run typecheck` - focused `apply-update.test.ts`: 6 passed - full Vitest: 221 files, 2505 passed, 3 skipped - `npm run build` - `git diff --check v1.0.1-rc1..HEAD`  A fresh Windows x64 PR-only package was built from this exact head without the capture, overlay-startup, or combined integration branches. The local verifier lacks Visual Studio Build Tools and the symlink privilege needed by electron-builder's unrelated native rebuild/signing cache, so this validation reused the official Windows N-API prebuild and disabled executable signing/editing for the local artifact. The application payload itself was built from the unmodified PR head.  The package produced both `win-unpacked` and an NSIS installer. The unpacked payload contains `resources/elevate.exe` (107,520 bytes), and its compiled `app.asar` contains the write probe, elevated helper launch, checked apply-failure path, success/error markers, and Explorer relaunch logic.  The same updater change was also exercised against a protected Program Files installation in a local integration build: the staged transaction completed, the installed payload remained valid, and the restarted application returned to the interactive medium-integrity context.  This standalone result covers the updater scope independently; the PR is ready for review.  ## Scope  This change is independent from plugin capture APIs, overlay startup/native compatibility, application release metadata, and any plugin-specific behavior. It does not create a release or tag.