### PR TITLE
Filter section editor, loot simulator, and FilterBlade bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Path of Exile's first ever fourth-party tool. An overlay to edit your filter, pr
 
 - **Cross Game Support** - One tool, both games. Switch from PoE1 to PoE2 and back by using your hotkey. If you're in the wrong game it will prompt you to restart.
 - **Filter Editor** - Edit your loot filter in-game quickly and precisely (like a Scalpel, get it)
+- **Filter Section Browser** - Browse NeverSink `$type` / `$tier` sections, toggle Show/Hide, drag BaseTypes between tiers, and add rules
+- **Loot Simulator** - Preview how selected BaseTypes look and sound against your active filter
 - **Price Checker** - A price checker that works like you'd expect, when it works. But better. Sometimes.
 - **Regex** - Generate, save and hotkey regex strings. Maps/Waystones, Flask & Custom for now. More coming. Powered by [poe.re](https://poe.re)
 - **Economy Audit** - Bulk retier items based on current market prices from poe.ninja

--- a/src/main/filter/loot-sim.test.ts
+++ b/src/main/filter/loot-sim.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import type { FilterFile } from '@shared/types'
+import { extractAlertFromChain, simulateLootDrops } from './loot-sim'
+
+function filter(blocks: FilterFile['blocks']): FilterFile {
+  return { path: 't.filter', blocks, rawLines: [] }
+}
+
+describe('extractAlertFromChain', () => {
+  it('later alert sound wins', () => {
+    const alert = extractAlertFromChain([
+      {
+        id: '1',
+        visibility: 'Show',
+        conditions: [],
+        actions: [{ type: 'PlayAlertSound', values: ['1', '100'] }],
+        continue: true,
+        lineStart: 1,
+        lineEnd: 2,
+      },
+      {
+        id: '2',
+        visibility: 'Show',
+        conditions: [],
+        actions: [{ type: 'PlayAlertSound', values: ['6', '300'] }],
+        continue: false,
+        lineStart: 3,
+        lineEnd: 4,
+      },
+    ])
+    expect(alert).toEqual({ kind: 'builtin', value: '6', volume: '300' })
+  })
+})
+
+describe('simulateLootDrops', () => {
+  it('marks matching Show currency as shown with label actions', () => {
+    const f = filter([
+      {
+        id: '1',
+        visibility: 'Show',
+        conditions: [
+          { type: 'Class', operator: '=', values: ['Stackable Currency'] },
+          { type: 'BaseType', operator: '==', values: ['Divine Orb'], explicitOperator: true },
+        ],
+        actions: [
+          { type: 'SetTextColor', values: ['255', '0', '0', '255'] },
+          { type: 'SetBackgroundColor', values: ['255', '255', '255', '255'] },
+          { type: 'PlayAlertSound', values: ['6', '300'] },
+        ],
+        continue: false,
+        lineStart: 1,
+        lineEnd: 6,
+        tierTag: { typePath: 'currency', tier: 's' },
+      },
+      {
+        id: '2',
+        visibility: 'Hide',
+        conditions: [{ type: 'Class', operator: '=', values: ['Stackable Currency'] }],
+        actions: [],
+        continue: false,
+        lineStart: 7,
+        lineEnd: 9,
+      },
+    ])
+
+    const result = simulateLootDrops(
+      f,
+      {
+        pool: [{ name: 'Divine Orb', baseType: 'Divine Orb', itemClass: 'Stackable Currency', rarity: 'Normal' }],
+        count: 5,
+        seed: 42,
+      },
+      2,
+    )
+    expect(result.drops).toHaveLength(5)
+    expect(result.shown).toBe(5)
+    expect(result.hidden).toBe(0)
+    expect(result.drops[0].alert.kind).toBe('builtin')
+    expect(result.drops[0].blocks?.[0].actions.some((a) => a.type === 'SetTextColor')).toBe(true)
+  })
+})

--- a/src/main/filter/loot-sim.ts
+++ b/src/main/filter/loot-sim.ts
@@ -1,0 +1,100 @@
+import type { FilterBlock, FilterFile } from '@shared/types'
+import type { LootSimAlert, LootSimDrop, LootSimRequest, LootSimResult } from '@shared/contracts/loot-sim'
+import { defaultPoeItem } from '@shared/poe-item'
+import { findMatchingBlocks } from './matcher'
+
+export type { LootSimAlert, LootSimDrop, LootSimRequest, LootSimResult }
+
+/** Effective alert sound from a Continue chain (later writer wins). */
+export function extractAlertFromChain(blocks: FilterBlock[]): LootSimAlert {
+  let alert: LootSimAlert = { kind: 'none' }
+  for (const block of blocks) {
+    for (const action of block.actions) {
+      if (action.type === 'PlayAlertSound' || action.type === 'PlayAlertSoundPositional') {
+        if (action.values.length === 0) {
+          alert = { kind: 'none' }
+        } else {
+          alert = { kind: 'builtin', value: action.values[0], volume: action.values[1] ?? '300' }
+        }
+      } else if (action.type === 'CustomAlertSound' || action.type === 'CustomAlertSoundOptional') {
+        if (action.values.length === 0) {
+          alert = { kind: 'none' }
+        } else {
+          alert = { kind: 'custom', value: action.values[0], volume: action.values[1] ?? '300' }
+        }
+      }
+    }
+  }
+  return alert
+}
+
+function resolveMatchChain(filter: FilterFile, item: PoeItem): FilterBlock[] {
+  const matches = findMatchingBlocks(filter, item)
+  if (matches.length === 0) return []
+  const primaryIdx = matches.findIndex((m) => m.isFirstMatch)
+  const chain = primaryIdx >= 0 ? matches.slice(0, primaryIdx + 1) : matches
+  return chain.map((m) => m.block)
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+/** Simulate N ground drops from a pool against the active filter. */
+export function simulateLootDrops(filter: FilterFile, req: LootSimRequest, poeVersion: 1 | 2): LootSimResult {
+  const pool = req.pool.filter((p) => p.baseType.trim())
+  if (pool.length === 0 || req.count <= 0) return { drops: [], shown: 0, hidden: 0 }
+
+  const rand = mulberry32(req.seed ?? Date.now())
+  const drops: LootSimDrop[] = []
+  let shown = 0
+  let hidden = 0
+
+  for (let i = 0; i < req.count; i++) {
+    const pick = pool[Math.floor(rand() * pool.length)]
+    const rarity =
+      pick.rarity === 'Unique' || pick.rarity === 'Gem' || pick.rarity === 'Currency' ? pick.rarity : 'Normal'
+    const item = defaultPoeItem(
+      {
+        baseType: pick.baseType,
+        name: pick.name || pick.baseType,
+        itemClass: pick.itemClass || 'Stackable Currency',
+        rarity,
+        itemLevel: req.areaLevel,
+      },
+      poeVersion,
+    )
+    const chain = resolveMatchChain(filter, item)
+    const primary = [...chain].reverse().find((b) => !b.continue) ?? chain[chain.length - 1]
+    const isHidden = !primary || primary.visibility === 'Hide'
+    if (isHidden) hidden++
+    else shown++
+
+    drops.push({
+      id: `drop-${i}-${pick.baseType}`,
+      name: pick.name || pick.baseType,
+      baseType: pick.baseType,
+      itemClass: pick.itemClass,
+      hidden: isHidden,
+      blocks: chain.length
+        ? chain.map((b) => ({
+            visibility: b.visibility,
+            actions: b.actions,
+            continue: b.continue,
+          }))
+        : null,
+      alert: chain.length ? extractAlertFromChain(chain) : { kind: 'none' },
+      x: 8 + rand() * 84,
+      y: 10 + rand() * 75,
+    })
+  }
+
+  return { drops, shown, hidden }
+}

--- a/src/main/filter/sections.test.ts
+++ b/src/main/filter/sections.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import type { FilterFile } from '@shared/types'
+import { buildFilterSections } from './sections'
+
+function filter(blocks: FilterFile['blocks']): FilterFile {
+  return { path: 'x.filter', blocks, rawLines: [] }
+}
+
+describe('buildFilterSections', () => {
+  it('groups NeverSink tiers into Currency / Emotions sections', () => {
+    const sections = buildFilterSections(
+      filter([
+        {
+          id: '1',
+          visibility: 'Show',
+          conditions: [{ type: 'BaseType', operator: '=', values: ['Divine Orb', 'Mirror of Kalandra'] }],
+          actions: [
+            { type: 'SetTextColor', values: ['255', '0', '0', '255'] },
+            { type: 'SetBackgroundColor', values: ['255', '255', '255', '255'] },
+            { type: 'SetBorderColor', values: ['255', '0', '0', '255'] },
+          ],
+          continue: false,
+          lineStart: 1,
+          lineEnd: 5,
+          tierTag: { typePath: 'currency', tier: 's' },
+        },
+        {
+          id: '2',
+          visibility: 'Hide',
+          conditions: [{ type: 'BaseType', operator: '=', values: ['Exalted Orb'] }],
+          actions: [],
+          continue: false,
+          lineStart: 6,
+          lineEnd: 8,
+          tierTag: { typePath: 'currency', tier: 'd' },
+        },
+        {
+          id: '3',
+          visibility: 'Show',
+          conditions: [{ type: 'BaseType', operator: '=', values: ['Diluted Liquid Fear'] }],
+          actions: [],
+          continue: false,
+          lineStart: 9,
+          lineEnd: 11,
+          tierTag: { typePath: 'currency->emotions', tier: 's' },
+        },
+      ]),
+    )
+
+    expect(sections.map((s) => s.typePath)).toEqual(['currency', 'currency->emotions'])
+    expect(sections[0].title).toBe('Currency')
+    expect(sections[0].tiers.map((t) => t.tier)).toEqual(['s', 'd'])
+    expect(sections[0].tiers[0].label).toBe('S tier')
+    expect(sections[0].tiers[0].baseTypes).toEqual(['Divine Orb', 'Mirror of Kalandra'])
+    expect(sections[0].tiers[0].previewActions.some((a) => a.type === 'SetTextColor')).toBe(true)
+    expect(sections[0].shownCount).toBe(1)
+    expect(sections[1].title).toBe('Emotions (Delirium)')
+  })
+
+  it('skips untagged and empty Continue decorators', () => {
+    const sections = buildFilterSections(
+      filter([
+        {
+          id: '1',
+          visibility: 'Show',
+          conditions: [],
+          actions: [],
+          continue: true,
+          lineStart: 1,
+          lineEnd: 2,
+          tierTag: { typePath: 'decorators', tier: 'beam' },
+        },
+        {
+          id: '2',
+          visibility: 'Show',
+          conditions: [{ type: 'BaseType', operator: '=', values: ['Gold'] }],
+          actions: [],
+          continue: false,
+          lineStart: 3,
+          lineEnd: 4,
+        },
+      ]),
+    )
+    expect(sections).toEqual([])
+  })
+})

--- a/src/main/filter/sections.ts
+++ b/src/main/filter/sections.ts
@@ -49,32 +49,12 @@ const TYPE_TITLES: Record<string, string> = {
   ut: 'UT',
 }
 
-const TIER_ORDER = [
-  's',
-  'a',
-  'b',
-  'c',
-  'd',
-  'e',
-  'f',
-  't1',
-  't2',
-  't3',
-  't4',
-  't5',
-  't6',
-  't7',
-  't8',
-  't9',
-  't10',
-]
+const TIER_ORDER = ['s', 'a', 'b', 'c', 'd', 'e', 'f', 't1', 't2', 't3', 't4', 't5', 't6', 't7', 't8', 't9', 't10']
 
 function titleForTypePath(typePath: string): string {
   if (TYPE_TITLES[typePath]) return TYPE_TITLES[typePath]
   const leaf = typePath.split('->').pop() ?? typePath
-  return leaf
-    .replace(/[-_]+/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase())
+  return leaf.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
 function labelForTier(tier: string): string {

--- a/src/main/filter/sections.ts
+++ b/src/main/filter/sections.ts
@@ -1,0 +1,187 @@
+import type { FilterAction, FilterBlock, FilterFile } from '@shared/types'
+import type { FilterSection, FilterSectionTier } from '@shared/contracts/filter-sections'
+
+export type { FilterSection, FilterSectionTier }
+
+const TYPE_TITLES: Record<string, string> = {
+  currency: 'Currency',
+  'currency->emotions': 'Emotions (Delirium)',
+  'currency->leveling': 'Campaign currency',
+  gold: 'Gold',
+  uniques: 'Uniques',
+  gems: 'Gems',
+  'gems-': 'Gems (extra)',
+  fragments: 'Fragments',
+  'fragments-': 'Fragments (extra)',
+  waystones: 'Waystones',
+  'waystone-': 'Waystones (extra)',
+  jewels: 'Jewels',
+  'jewels-': 'Jewels (extra)',
+  exoticbases: 'Exotic bases',
+  exoticmods: 'Exotic mods',
+  artifact: 'Artifacts',
+  relics: 'Relics',
+  verisium: 'Verisium',
+  chancing: 'Chancing',
+  leveling: 'Leveling',
+  'leveling-': 'Leveling (extra)',
+  rare: 'Rares',
+  'rare-': 'Rares (extra)',
+  sockets: 'Sockets',
+  'sockets-': 'Sockets (extra)',
+  maplike: 'Map-like',
+  'maplike-': 'Map-like (extra)',
+  endgame: 'Endgame',
+  'endgame-': 'Endgame (extra)',
+  special: 'Special',
+  'special-': 'Special (extra)',
+  anyremaining: 'Any remaining',
+  hidelayer: 'Hide layer',
+  conditionalhide: 'Conditional hide',
+  questlikeexception: 'Quest exceptions',
+  miscmapitemsextra: 'Misc map items',
+  xenotiering: 'Xeno tiering',
+  legacytemp: 'Legacy / temp',
+  decorators: 'Decorators',
+  'decorators-': 'Decorators (extra)',
+  rr: 'RR',
+  'rr-': 'RR (extra)',
+  ut: 'UT',
+}
+
+const TIER_ORDER = [
+  's',
+  'a',
+  'b',
+  'c',
+  'd',
+  'e',
+  'f',
+  't1',
+  't2',
+  't3',
+  't4',
+  't5',
+  't6',
+  't7',
+  't8',
+  't9',
+  't10',
+]
+
+function titleForTypePath(typePath: string): string {
+  if (TYPE_TITLES[typePath]) return TYPE_TITLES[typePath]
+  const leaf = typePath.split('->').pop() ?? typePath
+  return leaf
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function labelForTier(tier: string): string {
+  const t = tier.toLowerCase()
+  if (/^[a-z]$/.test(t)) return `${t.toUpperCase()} tier`
+  if (t.startsWith('supply')) return `Supplies: ${tier.replace(/^supplies?/i, '').replace(/^[-_]?/, '') || 'general'}`
+  if (t.includes('wisdom')) return 'Wisdom scrolls'
+  if (t.includes('jeweller')) return "Jeweller's"
+  return tier.replace(/[-_]+/g, ' ').toUpperCase()
+}
+
+function tierSortKey(tier: string): number {
+  const t = tier.toLowerCase()
+  const idx = TIER_ORDER.indexOf(t)
+  if (idx >= 0) return idx
+  if (t.startsWith('supply')) return 100 + t.length
+  return 200
+}
+
+function rgbaFromAction(action: FilterAction | undefined, fallback: string): string {
+  if (!action || action.values.length < 3) return fallback
+  const [r, g, b] = action.values.map(Number)
+  const a = action.values[3] != null ? Number(action.values[3]) / 255 : 1
+  return `rgba(${r},${g},${b},${a})`
+}
+
+function previewActionsOf(block: FilterBlock): FilterAction[] {
+  const keep = new Set(['SetTextColor', 'SetBorderColor', 'SetBackgroundColor', 'SetFontSize'])
+  return block.actions.filter((a) => keep.has(a.type)).map((a) => ({ type: a.type, values: [...a.values] }))
+}
+
+function styleFromBlock(block: FilterBlock): { text: string; bg: string; border: string } {
+  const byType = new Map(block.actions.map((a) => [a.type, a]))
+  return {
+    text: rgbaFromAction(byType.get('SetTextColor'), 'rgba(200,200,200,1)'),
+    bg: rgbaFromAction(byType.get('SetBackgroundColor'), 'rgba(0,0,0,0.6)'),
+    border: rgbaFromAction(byType.get('SetBorderColor'), 'transparent'),
+  }
+}
+
+function baseTypesOf(block: FilterBlock): string[] {
+  return block.conditions.filter((c) => c.type === 'BaseType').flatMap((c) => c.values)
+}
+
+/**
+ * Group NeverSink-tagged blocks into FilterBlade-style sections.
+ * Untagged / Continue-only decorator rows are skipped.
+ */
+export function buildFilterSections(filter: FilterFile): FilterSection[] {
+  const byType = new Map<string, FilterSectionTier[]>()
+
+  filter.blocks.forEach((block, blockIndex) => {
+    const tag = block.tierTag
+    if (!tag) return
+    // Skip pure Continue decorator rows with no BaseType — they aren't tier lists.
+    const baseTypes = baseTypesOf(block)
+    if (block.continue && baseTypes.length === 0) return
+
+    const tier: FilterSectionTier = {
+      tier: tag.tier,
+      label: labelForTier(tag.tier),
+      blockIndex,
+      visibility: block.visibility,
+      previewLabel: baseTypes[0] ?? labelForTier(tag.tier),
+      previewActions: previewActionsOf(block),
+      style: styleFromBlock(block),
+      baseTypes,
+      itemCount: baseTypes.length,
+    }
+    const list = byType.get(tag.typePath) ?? []
+    list.push(tier)
+    byType.set(tag.typePath, list)
+  })
+
+  const sections: FilterSection[] = []
+  for (const [typePath, tiers] of byType) {
+    tiers.sort((a, b) => tierSortKey(a.tier) - tierSortKey(b.tier) || a.blockIndex - b.blockIndex)
+    const shownCount = tiers.filter((t) => t.visibility === 'Show').length
+    sections.push({
+      typePath,
+      title: titleForTypePath(typePath),
+      tiers,
+      shownCount,
+      totalCount: tiers.length,
+    })
+  }
+
+  // Prefer familiar NeverSink top-level groups first, then alpha.
+  const PRIORITY = [
+    'currency',
+    'currency->emotions',
+    'currency->leveling',
+    'gold',
+    'uniques',
+    'fragments',
+    'waystones',
+    'gems',
+    'jewels',
+    'rare',
+    'exoticbases',
+  ]
+  sections.sort((a, b) => {
+    const ai = PRIORITY.indexOf(a.typePath)
+    const bi = PRIORITY.indexOf(b.typePath)
+    if (ai >= 0 || bi >= 0) return (ai === -1 ? 999 : ai) - (bi === -1 ? 999 : bi)
+    return a.title.localeCompare(b.title)
+  })
+
+  return sections
+}

--- a/src/main/filter/writer.test.ts
+++ b/src/main/filter/writer.test.ts
@@ -1,11 +1,13 @@
-import { mkdtempSync, readFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import type { FilterBlock } from '@shared/types'
 import { parseFilterFile } from './parser'
 import {
+  addBaseTypeToTier,
   detectIndent,
+  insertSectionRule,
   moveBaseTypeBetweenTiers,
   renderFilterSelective,
   serializeBlock,
@@ -180,5 +182,52 @@ describe('renderFilterSelective removedBlocks', () => {
     })
     const line = serializeBlock(b, '\t').find((l) => l.includes('BaseType'))
     expect(line).toContain('"Weird#Name"')
+  })
+})
+
+describe('addBaseTypeToTier / insertSectionRule', () => {
+  it('adds a BaseType onto an existing tier', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wadd-'))
+    const p = join(dir, 'o.filter')
+    const content = [
+      'Show # $type->currency $tier->s',
+      '\tBaseType == "Divine Orb"',
+      '\tSetFontSize 45',
+      '',
+    ].join('\n')
+    writeFileSync(p, content, 'utf-8')
+    const file = parseFilterFile(p, readFileSync(p, 'utf-8'))
+    addBaseTypeToTier(file, 0, 'Mirror of Kalandra')
+    const out = readFileSync(p, 'utf-8')
+    expect(out).toContain('"Divine Orb"')
+    expect(out).toContain('"Mirror of Kalandra"')
+  })
+
+  it('inserts a new section rule before the first tier', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'wins-'))
+    const p = join(dir, 'o.filter')
+    const content = [
+      'Show # $type->currency $tier->s',
+      '\tClass Currency',
+      '\tBaseType == "Divine Orb"',
+      '\tSetFontSize 45',
+      '\tSetTextColor 255 0 0 255',
+      '',
+    ].join('\n')
+    writeFileSync(p, content, 'utf-8')
+    const file = parseFilterFile(p, readFileSync(p, 'utf-8'))
+    insertSectionRule(file, {
+      typePath: 'currency',
+      tier: 'custom',
+      baseType: 'Chaos Orb',
+      beforeBlockIndex: 0,
+      copyStyleFromIndex: 0,
+    })
+    const reloaded = parseFilterFile(p, readFileSync(p, 'utf-8'))
+    expect(reloaded.blocks.length).toBeGreaterThanOrEqual(2)
+    expect(reloaded.blocks[0].tierTag).toEqual({ typePath: 'currency', tier: 'custom' })
+    expect(reloaded.blocks[0].conditions.some((c) => c.type === 'BaseType' && c.values.includes('Chaos Orb'))).toBe(
+      true,
+    )
   })
 })

--- a/src/main/filter/writer.test.ts
+++ b/src/main/filter/writer.test.ts
@@ -189,12 +189,7 @@ describe('addBaseTypeToTier / insertSectionRule', () => {
   it('adds a BaseType onto an existing tier', () => {
     const dir = mkdtempSync(join(tmpdir(), 'wadd-'))
     const p = join(dir, 'o.filter')
-    const content = [
-      'Show # $type->currency $tier->s',
-      '\tBaseType == "Divine Orb"',
-      '\tSetFontSize 45',
-      '',
-    ].join('\n')
+    const content = ['Show # $type->currency $tier->s', '\tBaseType == "Divine Orb"', '\tSetFontSize 45', ''].join('\n')
     writeFileSync(p, content, 'utf-8')
     const file = parseFilterFile(p, readFileSync(p, 'utf-8'))
     addBaseTypeToTier(file, 0, 'Mirror of Kalandra')

--- a/src/main/filter/writer.ts
+++ b/src/main/filter/writer.ts
@@ -121,6 +121,94 @@ export function moveBaseTypeBetweenTiers(
   filterFile.rawLines = lines
 }
 
+/** Append a BaseType to an existing tier block and write to disk. */
+export function addBaseTypeToTier(filterFile: FilterFile, blockIndex: number, baseType: string): void {
+  const block = filterFile.blocks[blockIndex]
+  if (!block) throw new Error('Block not found')
+  const name = baseType.trim()
+  if (!name) throw new Error('BaseType name required')
+  const lines = [...filterFile.rawLines]
+  addBaseTypeToRawLines(lines, block, name)
+  writeFileSync(filterFile.path, lines.join(filterFile.eol ?? '\n'), 'utf-8')
+  filterFile.rawLines = lines
+}
+
+/**
+ * Insert a new Show rule into a NeverSink section (FilterBlade-style "Add rule").
+ * Places it just before `beforeBlockIndex` (usually the first tier of the section)
+ * so it wins over later Hide rules for the same BaseType.
+ */
+export function insertSectionRule(
+  filterFile: FilterFile,
+  opts: {
+    typePath: string
+    tier: string
+    baseType: string
+    beforeBlockIndex: number
+    visibility?: FilterBlock['visibility']
+    copyStyleFromIndex?: number
+  },
+): number {
+  const { typePath, tier, baseType } = opts
+  const name = baseType.trim()
+  if (!name) throw new Error('BaseType name required')
+  const tierId = tier.trim().replace(/\s+/g, '').toLowerCase() || 'custom'
+  if (!typePath.trim()) throw new Error('Section typePath required')
+
+  const before = filterFile.blocks[opts.beforeBlockIndex]
+  if (!before) throw new Error('Insert position not found')
+
+  const indent = detectIndent(filterFile.rawLines)
+  const eol = filterFile.eol ?? '\n'
+  const styleSrc =
+    opts.copyStyleFromIndex != null ? filterFile.blocks[opts.copyStyleFromIndex] : filterFile.blocks[opts.beforeBlockIndex]
+
+  const classCond = styleSrc?.conditions.find((c) => c.type === 'Class')
+  const actions = (styleSrc?.actions ?? [])
+    .filter((a) =>
+      ['SetTextColor', 'SetBorderColor', 'SetBackgroundColor', 'SetFontSize', 'PlayAlertSound', 'PlayEffect', 'MinimapIcon'].includes(
+        a.type,
+      ),
+    )
+    .map((a) => ({ ...a, values: [...a.values] }))
+
+  const newBlock: FilterBlock = {
+    id: `new-${Date.now()}`,
+    visibility: opts.visibility ?? 'Show',
+    conditions: [
+      ...(classCond ? [{ ...classCond, values: [...classCond.values] }] : []),
+      { type: 'BaseType', operator: '==', values: [name], explicitOperator: true },
+    ],
+    actions:
+      actions.length > 0
+        ? actions
+        : [
+            { type: 'SetFontSize', values: ['40'] },
+            { type: 'SetTextColor', values: ['255', '255', '255', '255'] },
+            { type: 'SetBorderColor', values: ['255', '255', '255', '255'] },
+            { type: 'SetBackgroundColor', values: ['0', '0', '0', '200'] },
+          ],
+    continue: false,
+    lineStart: 0,
+    lineEnd: 0,
+    inlineComment: `$type->${typePath} $tier->${tierId}`,
+    tierTag: { typePath, tier: tierId },
+  }
+
+  const blockLines = serializeBlock(newBlock, indent)
+  const insertAt = (() => {
+    const leading = before.leadingComment ? before.leadingComment.split('\n').length : 0
+    return before.lineStart - 1 - leading
+  })()
+
+  const lines = [...filterFile.rawLines]
+  lines.splice(insertAt, 0, ...blockLines, '')
+  writeFileSync(filterFile.path, lines.join(eol), 'utf-8')
+  filterFile.rawLines = lines
+  // Caller must reload/parse — return approximate index hint
+  return opts.beforeBlockIndex
+}
+
 function removeBaseTypeFromRawLines(lines: string[], block: FilterBlock, baseType: string): void {
   const escaped = escapeRegex(baseType)
   for (let i = block.lineStart - 1; i < block.lineEnd; i++) {

--- a/src/main/filter/writer.ts
+++ b/src/main/filter/writer.ts
@@ -161,14 +161,22 @@ export function insertSectionRule(
   const indent = detectIndent(filterFile.rawLines)
   const eol = filterFile.eol ?? '\n'
   const styleSrc =
-    opts.copyStyleFromIndex != null ? filterFile.blocks[opts.copyStyleFromIndex] : filterFile.blocks[opts.beforeBlockIndex]
+    opts.copyStyleFromIndex != null
+      ? filterFile.blocks[opts.copyStyleFromIndex]
+      : filterFile.blocks[opts.beforeBlockIndex]
 
   const classCond = styleSrc?.conditions.find((c) => c.type === 'Class')
   const actions = (styleSrc?.actions ?? [])
     .filter((a) =>
-      ['SetTextColor', 'SetBorderColor', 'SetBackgroundColor', 'SetFontSize', 'PlayAlertSound', 'PlayEffect', 'MinimapIcon'].includes(
-        a.type,
-      ),
+      [
+        'SetTextColor',
+        'SetBorderColor',
+        'SetBackgroundColor',
+        'SetFontSize',
+        'PlayAlertSound',
+        'PlayEffect',
+        'MinimapIcon',
+      ].includes(a.type),
     )
     .map((a) => ({ ...a, values: [...a.values] }))
 

--- a/src/main/filterblade-bridge.test.ts
+++ b/src/main/filterblade-bridge.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import {
+  filterBladeUrl,
+  isLinkedLocalFilterPath,
+  listFilterBladeCandidates,
+  poeFilterIdFromOnlinePath,
+  poeItemFilterUrl,
+  resolveFilterBladeLink,
+  scoreFilterBladeCandidate,
+} from './filterblade-bridge'
+import { poeItemFilterLadderUrl } from '@shared/endpoints'
+
+describe('scoreFilterBladeCandidate', () => {
+  it('scores NeverSink / FilterBlade names highly', () => {
+    expect(scoreFilterBladeCandidate("NeverSink's filter - Semi-Strict")).toBeGreaterThan(
+      scoreFilterBladeCandidate('My Custom Filter'),
+    )
+    expect(scoreFilterBladeCandidate('Soft', '# NeverSink PoE2')).toBeGreaterThan(1)
+  })
+})
+
+describe('listFilterBladeCandidates / resolveFilterBladeLink', () => {
+  function seedOnline(names: Array<{ id: string; name: string; extra?: string }>): string {
+    const root = mkdtempSync(join(tmpdir(), 'scalpel-fb-'))
+    const online = join(root, 'OnlineFilters')
+    mkdirSync(online, { recursive: true })
+    for (const n of names) {
+      writeFileSync(join(online, n.id), `#name:${n.name}\n${n.extra ?? ''}\nShow\n  BaseType "Gold"\n`, 'utf8')
+    }
+    return root
+  }
+
+  it('lists and ranks OnlineFilters entries', () => {
+    const dir = seedOnline([
+      { id: 'aaa', name: 'Random Vendor Filter' },
+      { id: 'bbb', name: "NeverSink's filter 2 - Semi-Strict", extra: '# NeverSink' },
+    ])
+    const list = listFilterBladeCandidates(dir)
+    expect(list[0].name).toContain('NeverSink')
+    expect(list).toHaveLength(2)
+  })
+
+  it('returns needsSync when OnlineFilters is empty', () => {
+    const root = mkdtempSync(join(tmpdir(), 'scalpel-fb-empty-'))
+    mkdirSync(join(root, 'OnlineFilters'), { recursive: true })
+    const result = resolveFilterBladeLink(root)
+    expect(result.ok).toBe(false)
+    expect(result.needsSync).toBe(true)
+  })
+
+  it('resolves a local linked path for the top candidate', () => {
+    const dir = seedOnline([{ id: 'xyz', name: 'NeverSink Soft' }])
+    const result = resolveFilterBladeLink(dir)
+    expect(result.ok).toBe(true)
+    expect(result.linked?.localName).toBe('NeverSink Soft-local')
+    expect(result.linked?.alreadyLinked).toBe(false)
+  })
+
+  it('maps OnlineFilters path to PoE item-filter URL', () => {
+    const dir = seedOnline([{ id: 'rkY4jLfX', name: '9lives' }])
+    const list = listFilterBladeCandidates(dir)
+    const id = poeFilterIdFromOnlinePath(list[0].path)
+    expect(id).toBe('rkY4jLfX')
+    expect(poeItemFilterUrl(id!)).toBe('https://www.pathofexile.com/item-filter/rkY4jLfX')
+  })
+})
+
+describe('helpers', () => {
+  it('detects -local filter paths', () => {
+    expect(isLinkedLocalFilterPath('C:\\x\\Foo-local.filter')).toBe(true)
+    expect(isLinkedLocalFilterPath('C:\\x\\Foo.filter')).toBe(false)
+  })
+
+  it('builds FilterBlade and PoE ladder URLs per game', () => {
+    expect(filterBladeUrl(2)).toContain('Poe2')
+    expect(filterBladeUrl(1)).toContain('game=Poe')
+    expect(poeItemFilterLadderUrl(2)).toContain('PoE2')
+    expect(poeItemFilterLadderUrl(1)).toContain('PoE1')
+  })
+})

--- a/src/main/filterblade-bridge.ts
+++ b/src/main/filterblade-bridge.ts
@@ -1,0 +1,169 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { basename, join } from 'node:path'
+import { filterBladeUrl, poeItemFilterUrl } from '@shared/endpoints'
+
+export { filterBladeUrl, poeItemFilterUrl }
+
+/** OnlineFilters file basename is GGG's item-filter id (no extension). */
+export function poeFilterIdFromOnlinePath(onlinePath: string | null | undefined): string | null {
+  if (!onlinePath) return null
+  const id = basename(onlinePath).replace(/\.filter$/i, '').trim()
+  return id || null
+}
+
+/**
+ * FilterBlade / NeverSink bridge helpers.
+ *
+ * FilterBlade has no public filter-download API Scalpel can call. Custom builds
+ * land in PoE's OnlineFilters folder after the user Syncs from filterblade.xyz.
+ * These helpers detect those online entries and prepare a Scalpel `-local` link.
+ */
+
+export interface FilterBladeCandidate {
+  path: string
+  name: string
+  /** Higher = more likely a NeverSink / FilterBlade filter. */
+  score: number
+}
+
+const NAME_HINTS = [
+  /neversink/i,
+  /\bns[-_ ]/i,
+  /filterblade/i,
+  /semi[-\s]?strict/i,
+  /very[-\s]?strict/i,
+  /\buber\b/i,
+  /\bsoft\b/i,
+  /\bstrict\b/i,
+]
+
+const CONTENT_HINTS = [/#\s*neversink/i, /neversink/i, /filterblade/i, /nsfilter/i]
+
+/** Score how likely an online filter is a NeverSink / FilterBlade export. */
+export function scoreFilterBladeCandidate(name: string, contentHead = ''): number {
+  let score = 0
+  for (const re of NAME_HINTS) {
+    if (re.test(name)) score += 3
+  }
+  for (const re of CONTENT_HINTS) {
+    if (re.test(contentHead)) score += 2
+  }
+  // Generic online filters still linkable — small base score so Scan & Link
+  // can import whatever the user just synced even if naming is custom.
+  if (score === 0 && name.trim()) score = 1
+  return score
+}
+
+function readHead(path: string, maxLines = 40): string {
+  try {
+    return readFileSync(path, 'utf-8').split(/\r?\n/).slice(0, maxLines).join('\n')
+  } catch {
+    return ''
+  }
+}
+
+function readOnlineName(fullPath: string, fallback: string): string {
+  const head = readHead(fullPath, 15)
+  for (const line of head.split('\n')) {
+    const match = line.match(/^#name:(.+)/)
+    if (match) return match[1].trim()
+  }
+  return fallback
+}
+
+/** List OnlineFilters entries ranked for FilterBlade / NeverSink linking. */
+export function listFilterBladeCandidates(filterDir: string): FilterBladeCandidate[] {
+  const results: FilterBladeCandidate[] = []
+  if (!filterDir || !existsSync(filterDir)) return results
+  let onlineDirName: string | undefined
+  try {
+    onlineDirName = readdirSync(filterDir).find((f) => f.toLowerCase() === 'onlinefilters')
+  } catch {
+    return results
+  }
+  if (!onlineDirName) return results
+  const onlinePath = join(filterDir, onlineDirName)
+  if (!existsSync(onlinePath)) return results
+
+  for (const f of readdirSync(onlinePath)) {
+    if (f.toLowerCase().endsWith('.filter')) continue
+    const fullPath = join(onlinePath, f)
+    try {
+      if (statSync(fullPath).isDirectory()) continue
+    } catch {
+      continue
+    }
+    const name = readOnlineName(fullPath, f)
+    const head = readHead(fullPath)
+    const score = scoreFilterBladeCandidate(name, head)
+    if (score <= 0) continue
+    results.push({ path: fullPath, name, score })
+  }
+
+  return results.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+}
+
+export interface LinkFilterBladeResult {
+  ok: boolean
+  error?: string
+  /** True when OnlineFilters is empty — user still needs to Sync from FilterBlade. */
+  needsSync?: boolean
+  candidates?: Array<{ name: string; path: string; score: number }>
+  linked?: {
+    onlineName: string
+    onlinePath: string
+    localPath: string
+    localName: string
+    alreadyLinked: boolean
+  }
+}
+
+/**
+ * Pick the best OnlineFilters candidate (or a named one) and describe the
+ * `-local` path Scalpel should use. Does not write files — the IPC handler
+ * performs importOnlineFilter / conflict checks.
+ */
+export function resolveFilterBladeLink(
+  filterDir: string,
+  preferName?: string | null,
+): LinkFilterBladeResult {
+  const candidates = listFilterBladeCandidates(filterDir)
+  if (candidates.length === 0) {
+    return {
+      ok: false,
+      needsSync: true,
+      error:
+        'No online filters found. Follow a shared filter on pathofexile.com (or Sync from FilterBlade), select it once in-game, then Scan & Link again.',
+      candidates: [],
+    }
+  }
+
+  let chosen = candidates[0]
+  if (preferName) {
+    const match = candidates.find((c) => c.name === preferName || c.name.toLowerCase() === preferName.toLowerCase())
+    if (match) chosen = match
+  }
+
+  const safeName = chosen.name.replace(/[<>:"/\\|?*]/g, '_')
+  const localName = `${safeName}-local`
+  const localPath = join(filterDir, `${localName}.filter`)
+  const alreadyLinked = existsSync(localPath)
+
+  return {
+    ok: true,
+    candidates: candidates.map((c) => ({ name: c.name, path: c.path, score: c.score })),
+    linked: {
+      onlineName: chosen.name,
+      onlinePath: chosen.path,
+      localPath,
+      localName,
+      alreadyLinked,
+    },
+  }
+}
+
+/** True when the active Scalpel filter path looks like a linked `-local` copy. */
+export function isLinkedLocalFilterPath(filterPath: string | null | undefined): boolean {
+  if (!filterPath) return false
+  return basename(filterPath, '.filter').endsWith('-local')
+}

--- a/src/main/filterblade-bridge.ts
+++ b/src/main/filterblade-bridge.ts
@@ -7,7 +7,9 @@ export { filterBladeUrl, poeItemFilterUrl }
 /** OnlineFilters file basename is GGG's item-filter id (no extension). */
 export function poeFilterIdFromOnlinePath(onlinePath: string | null | undefined): string | null {
   if (!onlinePath) return null
-  const id = basename(onlinePath).replace(/\.filter$/i, '').trim()
+  const id = basename(onlinePath)
+    .replace(/\.filter$/i, '')
+    .trim()
   return id || null
 }
 
@@ -123,10 +125,7 @@ export interface LinkFilterBladeResult {
  * `-local` path Scalpel should use. Does not write files — the IPC handler
  * performs importOnlineFilter / conflict checks.
  */
-export function resolveFilterBladeLink(
-  filterDir: string,
-  preferName?: string | null,
-): LinkFilterBladeResult {
+export function resolveFilterBladeLink(filterDir: string, preferName?: string | null): LinkFilterBladeResult {
   const candidates = listFilterBladeCandidates(filterDir)
   if (candidates.length === 0) {
     return {

--- a/src/main/handlers/editing.ts
+++ b/src/main/handlers/editing.ts
@@ -1,10 +1,14 @@
 import { ipcMain } from 'electron'
 import type Store from 'electron-store'
-import type { AppSettings, FilterAction, FilterBlock, FilterChange, PoeItem } from '@shared/types'
+import type { AppSettings, FilterAction, FilterBlock, FilterChange, LootSimRequest, PoeItem } from '@shared/types'
 import { evaluateAndSend } from '../evaluation'
 import { describeIntent } from '../filter/intent-describe'
 import { getIntents, record } from '../filter/intent-recorder'
+import { simulateLootDrops } from '../filter/loot-sim'
+import { buildFilterSections } from '../filter/sections'
 import {
+  addBaseTypeToTier,
+  insertSectionRule,
   moveBaseTypeBetweenTiers,
   updateQualityThresholds,
   updateStackThresholds,
@@ -12,6 +16,7 @@ import {
   writeBlockEdit,
 } from '../filter/writer'
 import { getCurrentFilter, loadFilter } from '../filter-state'
+import { getPoeVersion } from '../game-state'
 import { captureSnapshot } from '../history'
 import { reloadFilterInGame } from '../overlay'
 import { getProfileBackedSetting } from '../profiles/profile-settings'
@@ -79,6 +84,157 @@ function describeBlockEdit(oldBlock: FilterBlock, newBlock: FilterBlock): string
 // ---- IPC handlers ----------------------------------------------------------
 
 export function register(store: Store<AppSettings>): void {
+  ipcMain.handle('get-filter-sections', () => {
+    const path = getProfileBackedSetting(store, 'filterPath') as string | undefined
+    if (path) {
+      const current = getCurrentFilter()
+      if (!current || current.path !== path) {
+        try {
+          loadFilter(path)
+        } catch (err) {
+          return { ok: false as const, error: String(err), sections: [] }
+        }
+      }
+    }
+    const currentFilter = getCurrentFilter()
+    if (!currentFilter) return { ok: false as const, error: 'No filter loaded', sections: [] }
+    return { ok: true as const, path: currentFilter.path, sections: buildFilterSections(currentFilter) }
+  })
+
+  ipcMain.handle(
+    'set-section-tier-visibility',
+    (_event, blockIndex: number, visibility: FilterBlock['visibility']) => {
+      const currentFilter = getCurrentFilter()
+      if (!currentFilter) return { ok: false, error: 'No filter loaded' }
+      const oldBlock = currentFilter.blocks[blockIndex]
+      if (!oldBlock) return { ok: false, error: 'Block not found' }
+      if (oldBlock.visibility === visibility) return { ok: true }
+      try {
+        const updatedBlock: FilterBlock = { ...oldBlock, visibility }
+        const tier = oldBlock.tierTag?.tier ?? `block #${blockIndex + 1}`
+        captureSnapshot(
+          currentFilter.path,
+          'block-edit',
+          `${oldBlock.visibility} → ${visibility} (${tier})`,
+          undefined,
+        )
+        if (oldBlock.tierTag) {
+          record({
+            type: 'set-visibility',
+            target: { typePath: oldBlock.tierTag.typePath, tier: oldBlock.tierTag.tier },
+            payload: { visibility },
+            timestamp: Date.now(),
+          })
+        }
+        writeBlockEdit(currentFilter, blockIndex, updatedBlock)
+        const path = getProfileBackedSetting(store, 'filterPath')
+        if (path) loadFilter(path)
+        reloadFilterInGame()
+        return { ok: true }
+      } catch (err) {
+        return { ok: false, error: String(err) }
+      }
+    },
+  )
+
+  ipcMain.handle('get-filter-block', (_event, blockIndex: number) => {
+    const path = getProfileBackedSetting(store, 'filterPath') as string | undefined
+    if (path) {
+      const current = getCurrentFilter()
+      if (!current || current.path !== path) {
+        try {
+          loadFilter(path)
+        } catch (err) {
+          return { ok: false as const, error: String(err) }
+        }
+      }
+    }
+    const currentFilter = getCurrentFilter()
+    if (!currentFilter) return { ok: false as const, error: 'No filter loaded' }
+    const block = currentFilter.blocks[blockIndex]
+    if (!block) return { ok: false as const, error: 'Block not found' }
+    return { ok: true as const, block, blockIndex }
+  })
+
+  ipcMain.handle('simulate-loot-drops', (_event, req: LootSimRequest) => {
+    const path = getProfileBackedSetting(store, 'filterPath') as string | undefined
+    if (path) {
+      const current = getCurrentFilter()
+      if (!current || current.path !== path) {
+        try {
+          loadFilter(path)
+        } catch (err) {
+          return { ok: false as const, error: String(err), drops: [], shown: 0, hidden: 0 }
+        }
+      }
+    }
+    const currentFilter = getCurrentFilter()
+    if (!currentFilter) return { ok: false as const, error: 'No filter loaded', drops: [], shown: 0, hidden: 0 }
+    try {
+      const result = simulateLootDrops(currentFilter, req, getPoeVersion() === 2 ? 2 : 1)
+      return { ok: true as const, ...result }
+    } catch (err) {
+      return { ok: false as const, error: String(err), drops: [], shown: 0, hidden: 0 }
+    }
+  })
+
+  ipcMain.handle('add-basetype-to-tier', (_event, blockIndex: number, baseType: string) => {
+    const currentFilter = getCurrentFilter()
+    if (!currentFilter) return { ok: false, error: 'No filter loaded' }
+    try {
+      const block = currentFilter.blocks[blockIndex]
+      captureSnapshot(currentFilter.path, 'block-edit', `Added "${baseType}" to tier`, baseType)
+      if (block?.tierTag) {
+        record({
+          type: 'move-basetype',
+          target: { typePath: block.tierTag.typePath, tier: block.tierTag.tier },
+          payload: { value: baseType, fromTier: '__new__' },
+          timestamp: Date.now(),
+        })
+      }
+      addBaseTypeToTier(currentFilter, blockIndex, baseType)
+      const path = getProfileBackedSetting(store, 'filterPath')
+      if (path) loadFilter(path)
+      if (store.get('reloadOnSave') !== false) reloadFilterInGame()
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, error: String(err) }
+    }
+  })
+
+  ipcMain.handle(
+    'insert-section-rule',
+    (
+      _event,
+      opts: {
+        typePath: string
+        tier: string
+        baseType: string
+        beforeBlockIndex: number
+        visibility?: FilterBlock['visibility']
+        copyStyleFromIndex?: number
+      },
+    ) => {
+      const currentFilter = getCurrentFilter()
+      if (!currentFilter) return { ok: false, error: 'No filter loaded' }
+      try {
+        captureSnapshot(
+          currentFilter.path,
+          'block-edit',
+          `Added rule "${opts.baseType}" (${opts.typePath}/${opts.tier})`,
+          opts.baseType,
+        )
+        insertSectionRule(currentFilter, opts)
+        const path = getProfileBackedSetting(store, 'filterPath')
+        if (path) loadFilter(path)
+        if (store.get('reloadOnSave') !== false) reloadFilterInGame()
+        return { ok: true }
+      } catch (err) {
+        return { ok: false, error: String(err) }
+      }
+    },
+  )
+
   ipcMain.handle('save-block-edit', (_event, blockIndex: number, updatedBlock: FilterBlock, itemJson?: string) => {
     const currentFilter = getCurrentFilter()
     if (!currentFilter) return { ok: false, error: 'No filter loaded' }

--- a/src/main/handlers/editing.ts
+++ b/src/main/handlers/editing.ts
@@ -101,41 +101,33 @@ export function register(store: Store<AppSettings>): void {
     return { ok: true as const, path: currentFilter.path, sections: buildFilterSections(currentFilter) }
   })
 
-  ipcMain.handle(
-    'set-section-tier-visibility',
-    (_event, blockIndex: number, visibility: FilterBlock['visibility']) => {
-      const currentFilter = getCurrentFilter()
-      if (!currentFilter) return { ok: false, error: 'No filter loaded' }
-      const oldBlock = currentFilter.blocks[blockIndex]
-      if (!oldBlock) return { ok: false, error: 'Block not found' }
-      if (oldBlock.visibility === visibility) return { ok: true }
-      try {
-        const updatedBlock: FilterBlock = { ...oldBlock, visibility }
-        const tier = oldBlock.tierTag?.tier ?? `block #${blockIndex + 1}`
-        captureSnapshot(
-          currentFilter.path,
-          'block-edit',
-          `${oldBlock.visibility} → ${visibility} (${tier})`,
-          undefined,
-        )
-        if (oldBlock.tierTag) {
-          record({
-            type: 'set-visibility',
-            target: { typePath: oldBlock.tierTag.typePath, tier: oldBlock.tierTag.tier },
-            payload: { visibility },
-            timestamp: Date.now(),
-          })
-        }
-        writeBlockEdit(currentFilter, blockIndex, updatedBlock)
-        const path = getProfileBackedSetting(store, 'filterPath')
-        if (path) loadFilter(path)
-        reloadFilterInGame()
-        return { ok: true }
-      } catch (err) {
-        return { ok: false, error: String(err) }
+  ipcMain.handle('set-section-tier-visibility', (_event, blockIndex: number, visibility: FilterBlock['visibility']) => {
+    const currentFilter = getCurrentFilter()
+    if (!currentFilter) return { ok: false, error: 'No filter loaded' }
+    const oldBlock = currentFilter.blocks[blockIndex]
+    if (!oldBlock) return { ok: false, error: 'Block not found' }
+    if (oldBlock.visibility === visibility) return { ok: true }
+    try {
+      const updatedBlock: FilterBlock = { ...oldBlock, visibility }
+      const tier = oldBlock.tierTag?.tier ?? `block #${blockIndex + 1}`
+      captureSnapshot(currentFilter.path, 'block-edit', `${oldBlock.visibility} → ${visibility} (${tier})`, undefined)
+      if (oldBlock.tierTag) {
+        record({
+          type: 'set-visibility',
+          target: { typePath: oldBlock.tierTag.typePath, tier: oldBlock.tierTag.tier },
+          payload: { visibility },
+          timestamp: Date.now(),
+        })
       }
-    },
-  )
+      writeBlockEdit(currentFilter, blockIndex, updatedBlock)
+      const path = getProfileBackedSetting(store, 'filterPath')
+      if (path) loadFilter(path)
+      reloadFilterInGame()
+      return { ok: true }
+    } catch (err) {
+      return { ok: false, error: String(err) }
+    }
+  })
 
   ipcMain.handle('get-filter-block', (_event, blockIndex: number) => {
     const path = getProfileBackedSetting(store, 'filterPath') as string | undefined

--- a/src/main/handlers/online-sync.ts
+++ b/src/main/handlers/online-sync.ts
@@ -1,18 +1,25 @@
 import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
 import { basename, join } from 'node:path'
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
 import type Store from 'electron-store'
 import type { AppSettings } from '@shared/types'
 import { getBaselineByLocalPath, saveBaseline } from '../baselines'
+import { filterBladeUrl, resolveFilterBladeLink } from '../filterblade-bridge'
 import { clearIntents, getIntents } from '../filter/intent-recorder'
 import { replayIntents } from '../filter/intent-replay'
 import { applyLocalNameHeader } from '../filter/local-name'
 import { writeFilterSelective } from '../filter/writer'
 import { loadFilter } from '../filter-state'
+import { getPoeVersion } from '../game-state'
 import { switchFilterInGame } from '../overlay'
 import { saveVersion } from '../update/versions'
 import { checkOnlineSyncNow } from '../online-sync'
 import { getProfileBackedSetting } from '../profiles/profile-settings'
+
+function defaultFilterDir(): string {
+  const game = getPoeVersion() === 2 ? 'Path of Exile 2' : 'Path of Exile'
+  return join(app.getPath('documents'), 'My Games', game)
+}
 
 /** Look up the online filter name and path for the currently active local filter */
 function findOnlineFilter(
@@ -271,6 +278,97 @@ export function register(store: Store<AppSettings>): void {
         if (currentPath === localPath) loadFilter(localPath, 'Online Filter Merged')
 
         return { ok: true, stats: { ...result.stats, skippedForValidity: fallbackBlocks.length } }
+      } catch (err) {
+        return { ok: false, error: String(err) }
+      }
+    },
+  )
+
+  ipcMain.handle('filterblade-url', (): string => filterBladeUrl(getPoeVersion() === 2 ? 2 : 1))
+
+  ipcMain.handle(
+    'filterblade-scan',
+    (
+      _event,
+      filterDir?: string,
+    ): {
+      filterDir: string
+      candidates: Array<{ name: string; path: string; score: number }>
+      needsSync: boolean
+    } => {
+      const dir =
+        (filterDir && filterDir.trim()) ||
+        (getProfileBackedSetting(store, 'filterDir') as string) ||
+        defaultFilterDir()
+      const resolved = resolveFilterBladeLink(dir)
+      return {
+        filterDir: dir,
+        candidates: resolved.candidates ?? [],
+        needsSync: Boolean(resolved.needsSync),
+      }
+    },
+  )
+
+  ipcMain.handle(
+    'filterblade-link',
+    (
+      _event,
+      opts?: { filterDir?: string; preferName?: string; force?: boolean },
+    ): {
+      ok: boolean
+      error?: string
+      needsSync?: boolean
+      conflict?: boolean
+      filterDir?: string
+      path?: string
+      onlineName?: string
+      localName?: string
+      alreadyLinked?: boolean
+      candidates?: Array<{ name: string; path: string; score: number }>
+    } => {
+      try {
+        const dir =
+          (opts?.filterDir && opts.filterDir.trim()) ||
+          (getProfileBackedSetting(store, 'filterDir') as string) ||
+          defaultFilterDir()
+        const resolved = resolveFilterBladeLink(dir, opts?.preferName)
+        if (!resolved.ok || !resolved.linked) {
+          return {
+            ok: false,
+            needsSync: resolved.needsSync,
+            error: resolved.error,
+            filterDir: dir,
+            candidates: resolved.candidates,
+          }
+        }
+
+        const { onlineName, onlinePath, localPath, localName, alreadyLinked } = resolved.linked
+        if (alreadyLinked && !opts?.force) {
+          return {
+            ok: true,
+            filterDir: dir,
+            path: localPath,
+            onlineName,
+            localName,
+            alreadyLinked: true,
+            candidates: resolved.candidates,
+          }
+        }
+
+        const originalContent = readFileSync(onlinePath, 'utf-8')
+        saveBaseline(onlineName, originalContent, onlinePath, localPath)
+        const content = applyLocalNameHeader(originalContent, localName)
+        writeFileSync(localPath, content, 'utf-8')
+        clearIntents()
+        return {
+          ok: true,
+          filterDir: dir,
+          path: localPath,
+          onlineName,
+          localName,
+          alreadyLinked: false,
+          candidates: resolved.candidates,
+        }
       } catch (err) {
         return { ok: false, error: String(err) }
       }

--- a/src/main/handlers/online-sync.ts
+++ b/src/main/handlers/online-sync.ts
@@ -297,9 +297,7 @@ export function register(store: Store<AppSettings>): void {
       needsSync: boolean
     } => {
       const dir =
-        (filterDir && filterDir.trim()) ||
-        (getProfileBackedSetting(store, 'filterDir') as string) ||
-        defaultFilterDir()
+        (filterDir && filterDir.trim()) || (getProfileBackedSetting(store, 'filterDir') as string) || defaultFilterDir()
       const resolved = resolveFilterBladeLink(dir)
       return {
         filterDir: dir,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -76,6 +76,30 @@ export const api = {
     force = false,
   ): Promise<{ ok: boolean; path?: string; error?: string; conflict?: boolean }> =>
     ipcRenderer.invoke('import-online-filter', sourcePath, filterName, targetDir, force),
+  filterBladeUrl: (): Promise<string> => ipcRenderer.invoke('filterblade-url'),
+  filterBladeScan: (
+    filterDir?: string,
+  ): Promise<{
+    filterDir: string
+    candidates: Array<{ name: string; path: string; score: number }>
+    needsSync: boolean
+  }> => ipcRenderer.invoke('filterblade-scan', filterDir),
+  filterBladeLink: (opts?: {
+    filterDir?: string
+    preferName?: string
+    force?: boolean
+  }): Promise<{
+    ok: boolean
+    error?: string
+    needsSync?: boolean
+    conflict?: boolean
+    filterDir?: string
+    path?: string
+    onlineName?: string
+    localName?: string
+    alreadyLinked?: boolean
+    candidates?: Array<{ name: string; path: string; score: number }>
+  }> => ipcRenderer.invoke('filterblade-link', opts),
   switchIngameFilter: (filterName: string, currentFilter?: string): Promise<{ ok: boolean; error?: string }> =>
     ipcRenderer.invoke('switch-ingame-filter', filterName, currentFilter),
 
@@ -90,6 +114,35 @@ export const api = {
     block: FilterBlock,
     itemJson?: string,
   ): Promise<{ ok: boolean; error?: string }> => ipcRenderer.invoke('save-block-edit', blockIndex, block, itemJson),
+  getFilterSections: (): Promise<{
+    ok: boolean
+    error?: string
+    path?: string
+    sections: import('@shared/types').FilterSection[]
+  }> => ipcRenderer.invoke('get-filter-sections'),
+  setSectionTierVisibility: (
+    blockIndex: number,
+    visibility: 'Show' | 'Hide' | 'Minimal',
+  ): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('set-section-tier-visibility', blockIndex, visibility),
+  getFilterBlock: (
+    blockIndex: number,
+  ): Promise<{ ok: boolean; error?: string; block?: import('@shared/types').FilterBlock; blockIndex?: number }> =>
+    ipcRenderer.invoke('get-filter-block', blockIndex),
+  addBaseTypeToTier: (blockIndex: number, baseType: string): Promise<{ ok: boolean; error?: string }> =>
+    ipcRenderer.invoke('add-basetype-to-tier', blockIndex, baseType),
+  insertSectionRule: (opts: {
+    typePath: string
+    tier: string
+    baseType: string
+    beforeBlockIndex: number
+    visibility?: 'Show' | 'Hide' | 'Minimal'
+    copyStyleFromIndex?: number
+  }): Promise<{ ok: boolean; error?: string }> => ipcRenderer.invoke('insert-section-rule', opts),
+  simulateLootDrops: (
+    req: import('@shared/types').LootSimRequest,
+  ): Promise<{ ok: boolean; error?: string } & import('@shared/types').LootSimResult> =>
+    ipcRenderer.invoke('simulate-loot-drops', req),
   reloadFilter: (): Promise<{ ok: boolean; error?: string }> => ipcRenderer.invoke('reload-filter'),
   getUniqueVisibility: (): Promise<Record<string, 'Show' | 'Hide'>> => ipcRenderer.invoke('get-unique-visibility'),
   lookupBaseType: (

--- a/src/renderer/src/components/FilterBladeBridge.tsx
+++ b/src/renderer/src/components/FilterBladeBridge.tsx
@@ -1,10 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import type { GameVariant, RuntimeSettings } from '@shared/types'
-import {
-  filterBladeUrl as filterBladeUrlFor,
-  poeItemFilterLadderUrl,
-  poeItemFilterUrl,
-} from '@shared/endpoints'
+import { filterBladeUrl as filterBladeUrlFor, poeItemFilterLadderUrl, poeItemFilterUrl } from '@shared/endpoints'
 
 interface Props {
   settings: RuntimeSettings
@@ -21,7 +17,10 @@ function onlineNameFromLocalPath(filterPath: string): string | null {
 }
 
 function poeFilterIdFromPath(onlinePath: string): string | null {
-  const id = onlinePath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '').trim()
+  const id = onlinePath
+    .replace(/^.*[\\/]/, '')
+    .replace(/\.filter$/i, '')
+    .trim()
   return id || null
 }
 
@@ -83,8 +82,7 @@ export function FilterBladeBridge({
   }
 
   const openFilterBlade = async (): Promise<void> => {
-    const url =
-      (window.api.filterBladeUrl && (await window.api.filterBladeUrl())) || filterBladeUrlFor(gameVariant)
+    const url = (window.api.filterBladeUrl && (await window.api.filterBladeUrl())) || filterBladeUrlFor(gameVariant)
     void window.api.openExternal(url)
   }
 
@@ -158,9 +156,7 @@ export function FilterBladeBridge({
 
       <div className="flex flex-wrap gap-2 mt-1">
         <button type="button" className="primary px-2.5 py-1 text-[11px]" onClick={openPoeFilterPage}>
-          {selectedFilterId
-            ? `Open “${selected?.name ?? 'filter'}” on PoE`
-            : 'Browse PoE filter ladder'}
+          {selectedFilterId ? `Open “${selected?.name ?? 'filter'}” on PoE` : 'Browse PoE filter ladder'}
         </button>
         <button type="button" className="px-2.5 py-1 text-[11px]" onClick={() => void openFilterBlade()}>
           Open FilterBlade
@@ -206,9 +202,7 @@ export function FilterBladeBridge({
         </label>
       )}
 
-      {candidates.length === 1 && (
-        <p className="text-[10px] text-text-dim m-0">Found online: {candidates[0].name}</p>
-      )}
+      {candidates.length === 1 && <p className="text-[10px] text-text-dim m-0">Found online: {candidates[0].name}</p>}
       {candidates.length === 0 && (
         <p className="text-[10px] text-text-dim m-0">
           No OnlineFilters yet — Follow a shared filter on pathofexile.com (or Sync from FilterBlade) and select it

--- a/src/renderer/src/components/FilterBladeBridge.tsx
+++ b/src/renderer/src/components/FilterBladeBridge.tsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { GameVariant, RuntimeSettings } from '@shared/types'
+import {
+  filterBladeUrl as filterBladeUrlFor,
+  poeItemFilterLadderUrl,
+  poeItemFilterUrl,
+} from '@shared/endpoints'
+
+interface Props {
+  settings: RuntimeSettings
+  onSettingsChange: (s: RuntimeSettings) => void
+  autoSwitchInGame?: boolean
+  onOnlineImport?: (filterName: string) => void
+  onLinked?: () => void
+}
+
+function onlineNameFromLocalPath(filterPath: string): string | null {
+  const base = filterPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '')
+  if (!base.endsWith('-local')) return null
+  return base.slice(0, -'-local'.length) || null
+}
+
+function poeFilterIdFromPath(onlinePath: string): string | null {
+  const id = onlinePath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '').trim()
+  return id || null
+}
+
+export function FilterBladeBridge({
+  settings,
+  onSettingsChange,
+  autoSwitchInGame,
+  onOnlineImport,
+  onLinked,
+}: Props): JSX.Element {
+  const gameVariant = (settings.poeVersion === 2 ? 2 : 1) as GameVariant
+  const fDir = settings.activeProfile?.filterDir ?? ''
+  const fPath = settings.activeProfile?.filterPath ?? ''
+  const linkedLocal = Boolean(fPath && /[/\\][^/\\]+-local\.filter$/i.test(fPath))
+  const linkedOnlineName = fPath ? onlineNameFromLocalPath(fPath) : null
+
+  const [busy, setBusy] = useState(false)
+  const [status, setStatus] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [candidates, setCandidates] = useState<Array<{ name: string; path: string; score: number }>>([])
+  const [preferName, setPreferName] = useState('')
+
+  const refreshCandidates = async (dir?: string): Promise<void> => {
+    if (!window.api.filterBladeScan) return
+    const scan = await window.api.filterBladeScan(dir ?? (fDir || undefined))
+    setCandidates(scan.candidates)
+    setPreferName((prev) => {
+      if (prev && scan.candidates.some((c) => c.name === prev)) return prev
+      if (linkedOnlineName && scan.candidates.some((c) => c.name === linkedOnlineName)) {
+        return linkedOnlineName
+      }
+      return scan.candidates[0]?.name ?? ''
+    })
+  }
+
+  useEffect(() => {
+    void refreshCandidates()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fDir, settings.poeVersion, linkedOnlineName])
+
+  const selected = useMemo(() => {
+    if (!candidates.length) return null
+    return (
+      candidates.find((c) => c.name === preferName) ||
+      (linkedOnlineName ? candidates.find((c) => c.name === linkedOnlineName) : null) ||
+      candidates[0]
+    )
+  }, [candidates, preferName, linkedOnlineName])
+
+  const selectedFilterId = selected ? poeFilterIdFromPath(selected.path) : null
+
+  const openPoeFilterPage = (): void => {
+    if (selectedFilterId) {
+      void window.api.openExternal(poeItemFilterUrl(selectedFilterId))
+      return
+    }
+    // No OnlineFilters yet — send them to the public ladder to Follow a shared filter.
+    void window.api.openExternal(poeItemFilterLadderUrl(gameVariant))
+  }
+
+  const openFilterBlade = async (): Promise<void> => {
+    const url =
+      (window.api.filterBladeUrl && (await window.api.filterBladeUrl())) || filterBladeUrlFor(gameVariant)
+    void window.api.openExternal(url)
+  }
+
+  const scanAndLink = async (force = false): Promise<void> => {
+    setBusy(true)
+    setError(null)
+    setStatus(null)
+    try {
+      const result = await window.api.filterBladeLink({
+        filterDir: fDir || undefined,
+        preferName: preferName || undefined,
+        force,
+      })
+      if (result.filterDir && result.filterDir !== fDir) {
+        const updated = await window.api.setProfileSettingForGame(gameVariant, 'filterDir', result.filterDir)
+        onSettingsChange(updated)
+      }
+      if (result.candidates) setCandidates(result.candidates)
+
+      if (!result.ok) {
+        setError(result.error ?? 'Could not link online filter')
+        return
+      }
+      if (!result.path || !result.localName) {
+        setError('Link succeeded but no local path was returned')
+        return
+      }
+
+      const updated = await window.api.setProfileSettingForGame(gameVariant, 'filterPath', result.path)
+      onSettingsChange(updated)
+
+      if (result.alreadyLinked) {
+        setStatus(`Already linked to “${result.onlineName}”. Checking for online updates…`)
+        window.api.checkForOnlineUpdate().catch(() => {})
+      } else {
+        setStatus(`Linked “${result.onlineName}” → ${result.localName}.filter`)
+        if (!autoSwitchInGame) onOnlineImport?.(result.localName)
+      }
+
+      if (autoSwitchInGame) {
+        const currentFilter = fPath ? fPath.replace(/^.*[\\/]/, '').replace(/\.filter$/i, '') : undefined
+        await window.api.switchIngameFilter(result.localName, currentFilter)
+      }
+
+      onLinked?.()
+      await refreshCandidates(result.filterDir)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-white/10 bg-white/[0.03] p-3 flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <div className="text-[12px] font-semibold text-text m-0">Online / shared filters</div>
+          <p className="text-[11px] text-text-dim m-0 mt-1 leading-relaxed">
+            Follow a shared filter on pathofexile.com (or Sync from FilterBlade), select it in-game once, then link
+            here. Scalpel edits a local copy and can pull updates later.
+          </p>
+        </div>
+      </div>
+
+      <ol className="m-0 pl-4 text-[11px] text-text-dim leading-relaxed space-y-0.5">
+        <li>Open the PoE filter page (or Follow from a player&apos;s shared filters)</li>
+        <li>Select that filter once in-game (downloads into OnlineFilters)</li>
+        <li>
+          Scan &amp; Link below — use the linked <span className="font-mono text-text">*-local</span> filter in PoE
+        </li>
+      </ol>
+
+      <div className="flex flex-wrap gap-2 mt-1">
+        <button type="button" className="primary px-2.5 py-1 text-[11px]" onClick={openPoeFilterPage}>
+          {selectedFilterId
+            ? `Open “${selected?.name ?? 'filter'}” on PoE`
+            : 'Browse PoE filter ladder'}
+        </button>
+        <button type="button" className="px-2.5 py-1 text-[11px]" onClick={() => void openFilterBlade()}>
+          Open FilterBlade
+        </button>
+        <button
+          type="button"
+          className="px-2.5 py-1 text-[11px]"
+          disabled={busy}
+          onClick={() => void scanAndLink(false)}
+        >
+          {busy ? 'Linking…' : linkedLocal ? 'Re-scan & Link' : 'Scan & Link'}
+        </button>
+        {linkedLocal && (
+          <button
+            type="button"
+            className="px-2.5 py-1 text-[11px]"
+            disabled={busy}
+            onClick={() => {
+              setStatus('Asking PoE to re-download the online filter…')
+              window.api.checkForOnlineUpdate().catch((e) => setError(String(e)))
+            }}
+          >
+            Check online updates
+          </button>
+        )}
+      </div>
+
+      {candidates.length > 1 && (
+        <label className="flex flex-col gap-1 text-[11px] text-text-dim">
+          Online filter to link
+          <select
+            className="bg-[#12131a] text-text border border-white/12 rounded px-2 py-1 text-[11px]"
+            value={preferName}
+            onChange={(e) => setPreferName(e.target.value)}
+          >
+            {candidates.map((c) => (
+              <option key={c.path} value={c.name}>
+                {c.name}
+                {c.score >= 5 ? ' · NeverSink?' : ''}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {candidates.length === 1 && (
+        <p className="text-[10px] text-text-dim m-0">Found online: {candidates[0].name}</p>
+      )}
+      {candidates.length === 0 && (
+        <p className="text-[10px] text-text-dim m-0">
+          No OnlineFilters yet — Follow a shared filter on pathofexile.com (or Sync from FilterBlade) and select it
+          in-game first.
+        </p>
+      )}
+
+      {status && <p className="text-[11px] text-accent m-0">{status}</p>}
+      {error && <p className="text-[11px] text-red-400 m-0">{error}</p>}
+    </div>
+  )
+}

--- a/src/renderer/src/components/FilterPicker.tsx
+++ b/src/renderer/src/components/FilterPicker.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { CloseSmall, Info } from '@icon-park/react'
 import type { FilterListEntry, GameVariant, RuntimeSettings } from '@shared/types'
+import { FilterBladeBridge } from './FilterBladeBridge'
 
 interface Props {
   settings: RuntimeSettings
@@ -240,6 +241,19 @@ export function FilterPicker({
             {dirName ? 'Change' : 'Browse...'}
           </button>
         </div>
+      )}
+
+      {(showFolder || showList) && (
+        <FilterBladeBridge
+          settings={settings}
+          onSettingsChange={onSettingsChange}
+          autoSwitchInGame={autoSwitchInGame}
+          onOnlineImport={onOnlineImport}
+          onLinked={() => {
+            const dir = settingsRef.current.activeProfile?.filterDir
+            if (dir) void scanDir(dir)
+          }}
+        />
       )}
 
       {/* Filter list */}

--- a/src/renderer/src/components/FilterSectionEditor.tsx
+++ b/src/renderer/src/components/FilterSectionEditor.tsx
@@ -1,0 +1,507 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { FilterSection, FilterSectionTier } from '@shared/types'
+import { HiddenLootLabel, LootLabel } from '@renderer/shared/LootLabel'
+import { TierStyleEditor } from './TierStyleEditor'
+
+interface Props {
+  filterPath?: string | null
+}
+
+interface DragPayload {
+  baseType: string
+  fromBlockIndex: number
+}
+
+/** FilterBlade-style section browser with style edit, DnD, and Add rule. */
+export function FilterSectionEditor({ filterPath }: Props): JSX.Element {
+  const [sections, setSections] = useState<FilterSection[]>([])
+  const [loadedPath, setLoadedPath] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [query, setQuery] = useState('')
+  const [activeType, setActiveType] = useState('')
+  const [expandedTier, setExpandedTier] = useState<number | null>(null)
+  const [styleBlock, setStyleBlock] = useState<{ index: number; label: string } | null>(null)
+  const [dropTarget, setDropTarget] = useState<number | null>(null)
+  const [addOpen, setAddOpen] = useState(false)
+  const [addName, setAddName] = useState('')
+  const [addTier, setAddTier] = useState('')
+  const [addMode, setAddMode] = useState<'existing' | 'new'>('existing')
+  const [addNewTierId, setAddNewTierId] = useState('custom')
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!window.api.getFilterSections) return
+    const result = await window.api.getFilterSections()
+    if (!result.ok) {
+      setError(result.error ?? 'No filter loaded')
+      setSections([])
+      setLoadedPath(null)
+      return
+    }
+    setError(null)
+    setSections(result.sections)
+    setLoadedPath(result.path ?? null)
+    setActiveType((prev) => {
+      if (prev && result.sections.some((s) => s.typePath === prev)) return prev
+      return result.sections[0]?.typePath ?? ''
+    })
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [filterPath, refresh])
+
+  const active = useMemo(
+    () => sections.find((s) => s.typePath === activeType) ?? sections[0] ?? null,
+    [sections, activeType],
+  )
+
+  const tiers = useMemo(() => {
+    if (!active) return []
+    const q = query.trim().toLowerCase()
+    if (!q) return active.tiers
+    return active.tiers.filter(
+      (t) =>
+        t.label.toLowerCase().includes(q) ||
+        t.tier.toLowerCase().includes(q) ||
+        t.baseTypes.some((b) => b.toLowerCase().includes(q)),
+    )
+  }, [active, query])
+
+  useEffect(() => {
+    if (!addTier && tiers[0]) setAddTier(String(tiers[0].blockIndex))
+  }, [tiers, addTier])
+
+  const toggleVisibility = async (tier: FilterSectionTier): Promise<void> => {
+    const next = tier.visibility === 'Show' ? 'Hide' : 'Show'
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await window.api.setSectionTierVisibility(tier.blockIndex, next)
+      if (!result.ok) {
+        setError(result.error ?? 'Failed to update visibility')
+        return
+      }
+      await refresh()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const moveBase = async (baseType: string, fromBlockIndex: number, toBlockIndex: number): Promise<void> => {
+    if (fromBlockIndex === toBlockIndex) return
+    setBusy(true)
+    setError(null)
+    try {
+      const result = await window.api.moveItemTier(baseType, fromBlockIndex, toBlockIndex, '')
+      if (!result.ok) {
+        setError(result.error ?? 'Failed to move item')
+        return
+      }
+      await refresh()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const onDragStart = (e: React.DragEvent, payload: DragPayload): void => {
+    e.dataTransfer.setData('application/x-scalpel-basetype', JSON.stringify(payload))
+    e.dataTransfer.effectAllowed = 'move'
+  }
+
+  const onDragOverTier = (e: React.DragEvent, blockIndex: number): void => {
+    if (!e.dataTransfer.types.includes('application/x-scalpel-basetype')) return
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    setDropTarget(blockIndex)
+  }
+
+  const onDropTier = async (e: React.DragEvent, toBlockIndex: number): Promise<void> => {
+    e.preventDefault()
+    setDropTarget(null)
+    const raw = e.dataTransfer.getData('application/x-scalpel-basetype')
+    if (!raw) return
+    try {
+      const payload = JSON.parse(raw) as DragPayload
+      await moveBase(payload.baseType, payload.fromBlockIndex, toBlockIndex)
+      setExpandedTier(toBlockIndex)
+    } catch {
+      setError('Invalid drag payload')
+    }
+  }
+
+  const submitAddRule = async (): Promise<void> => {
+    if (!active) return
+    const name = addName.trim()
+    if (!name) {
+      setError('Enter a BaseType name')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      if (addMode === 'existing') {
+        const blockIndex = Number(addTier)
+        const result = await window.api.addBaseTypeToTier(blockIndex, name)
+        if (!result.ok) {
+          setError(result.error ?? 'Failed to add item')
+          return
+        }
+        setExpandedTier(blockIndex)
+      } else {
+        const before = active.tiers[0]?.blockIndex
+        if (before == null) {
+          setError('Section has no tiers to insert before')
+          return
+        }
+        const result = await window.api.insertSectionRule({
+          typePath: active.typePath,
+          tier: addNewTierId.trim() || 'custom',
+          baseType: name,
+          beforeBlockIndex: before,
+          visibility: 'Show',
+          copyStyleFromIndex: before,
+        })
+        if (!result.ok) {
+          setError(result.error ?? 'Failed to add rule')
+          return
+        }
+      }
+      setAddName('')
+      setAddOpen(false)
+      await refresh()
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!filterPath) {
+    return (
+      <p style={{ margin: 0, fontSize: 12, color: '#9a9aab' }}>
+        Select a local filter (e.g. 9lives-local) to edit sections.
+      </p>
+    )
+  }
+
+  return (
+    <div
+      style={{
+        border: '1px solid rgba(255,255,255,0.12)',
+        borderRadius: 8,
+        background: '#12131a',
+        padding: 12,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8, alignItems: 'center' }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: '#f0e6d2' }}>Section editor</div>
+        <button type="button" disabled={busy} onClick={() => void refresh()} style={{ fontSize: 11 }}>
+          Refresh
+        </button>
+      </div>
+
+      {loadedPath && (
+        <div style={{ fontSize: 11, color: '#9a9aab' }}>Editing: {loadedPath.replace(/^.*[\\/]/, '')}</div>
+      )}
+
+      {error && <div style={{ fontSize: 12, color: '#f87171' }}>{error}</div>}
+
+      {styleBlock && (
+        <TierStyleEditor
+          blockIndex={styleBlock.index}
+          tierLabel={styleBlock.label}
+          onClose={() => setStyleBlock(null)}
+          onSaved={() => void refresh()}
+        />
+      )}
+
+      {sections.length === 0 && !error ? (
+        <div style={{ fontSize: 12, color: '#9a9aab' }}>No NeverSink-tagged sections in this filter.</div>
+      ) : (
+        <>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: '#9a9aab' }}>
+            Section
+            <select
+              value={active?.typePath ?? ''}
+              onChange={(e) => {
+                setActiveType(e.target.value)
+                setExpandedTier(null)
+                setStyleBlock(null)
+                setAddOpen(false)
+              }}
+              style={{
+                background: '#0a0b10',
+                color: '#f0e6d2',
+                border: '1px solid rgba(255,255,255,0.14)',
+                borderRadius: 6,
+                padding: '8px 10px',
+                fontSize: 13,
+              }}
+            >
+              {sections.map((s) => (
+                <option key={s.typePath} value={s.typePath}>
+                  {s.title} ({s.shownCount}/{s.totalCount} shown)
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Filter tiers / items…"
+            style={{
+              background: '#0a0b10',
+              color: '#f0e6d2',
+              border: '1px solid rgba(255,255,255,0.14)',
+              borderRadius: 6,
+              padding: '8px 10px',
+              fontSize: 12,
+            }}
+          />
+
+          <div style={{ fontSize: 11, color: '#9a9aab' }}>
+            Drag items onto another tier · brush edits style · Add rule appends a BaseType
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, maxHeight: 360, overflowY: 'auto' }}>
+            {tiers.map((tier, idx) => {
+              const shown = tier.visibility === 'Show'
+              const open = expandedTier === tier.blockIndex
+              const isDrop = dropTarget === tier.blockIndex
+              return (
+                <div
+                  key={tier.blockIndex}
+                  onDragOver={(e) => onDragOverTier(e, tier.blockIndex)}
+                  onDragLeave={() => setDropTarget((t) => (t === tier.blockIndex ? null : t))}
+                  onDrop={(e) => void onDropTier(e, tier.blockIndex)}
+                  style={{
+                    border: isDrop ? '1px solid #c9a227' : '1px solid rgba(255,255,255,0.12)',
+                    borderRadius: 6,
+                    background: isDrop
+                      ? 'rgba(201,162,39,0.12)'
+                      : shown
+                        ? 'rgba(255,255,255,0.05)'
+                        : 'rgba(0,0,0,0.35)',
+                    padding: '8px 10px',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void toggleVisibility(tier)}
+                      title={shown ? 'Hide tier' : 'Show tier'}
+                      style={{
+                        width: 32,
+                        height: 28,
+                        fontSize: 16,
+                        lineHeight: 1,
+                        padding: 0,
+                        background: shown ? 'rgba(76,175,80,0.25)' : 'rgba(255,255,255,0.06)',
+                        color: '#f0e6d2',
+                      }}
+                    >
+                      {shown ? '☑' : '☐'}
+                    </button>
+
+                    <button
+                      type="button"
+                      onClick={() => setExpandedTier(open ? null : tier.blockIndex)}
+                      style={{
+                        flex: 1,
+                        textAlign: 'left',
+                        background: 'transparent',
+                        padding: '4px 0',
+                        display: 'flex',
+                        gap: 8,
+                        alignItems: 'center',
+                        color: '#f0e6d2',
+                      }}
+                    >
+                      <span style={{ color: '#c9a227', width: 12 }}>{open ? '▾' : '▸'}</span>
+                      <span style={{ fontSize: 13, fontWeight: 700 }}>{tier.label}</span>
+                      <span style={{ fontSize: 11, color: '#9a9aab' }}>{tier.itemCount} items</span>
+                    </button>
+
+                    <button
+                      type="button"
+                      title="Edit style"
+                      disabled={busy}
+                      onClick={() => setStyleBlock({ index: tier.blockIndex, label: tier.label })}
+                      style={{ width: 30, height: 28, padding: 0, fontSize: 14 }}
+                    >
+                      🖌
+                    </button>
+
+                    <div
+                      className="shrink-0 max-w-[180px] overflow-hidden"
+                      title={tier.previewLabel}
+                      style={{ opacity: shown ? 1 : 0.85 }}
+                    >
+                      {shown ? (
+                        <LootLabel block={{ actions: tier.previewActions }} label={tier.previewLabel} />
+                      ) : (
+                        <HiddenLootLabel label={tier.previewLabel} />
+                      )}
+                    </div>
+                  </div>
+
+                  {open && (
+                    <div style={{ marginTop: 8, paddingTop: 8, borderTop: '1px solid rgba(255,255,255,0.08)' }}>
+                      {tier.baseTypes.length === 0 ? (
+                        <div style={{ fontSize: 11, color: '#9a9aab' }}>No BaseType list — drop items here or Add rule.</div>
+                      ) : (
+                        tier.baseTypes.map((base) => (
+                          <div
+                            key={base}
+                            draggable={!busy}
+                            onDragStart={(e) => onDragStart(e, { baseType: base, fromBlockIndex: tier.blockIndex })}
+                            style={{
+                              display: 'flex',
+                              alignItems: 'center',
+                              gap: 6,
+                              padding: '5px 6px',
+                              marginBottom: 4,
+                              background: 'rgba(0,0,0,0.35)',
+                              borderRadius: 4,
+                              fontSize: 12,
+                              color: '#f0e6d2',
+                              cursor: 'grab',
+                            }}
+                          >
+                            <span style={{ color: '#9a9aab', fontSize: 11 }}>⋮⋮</span>
+                            <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis' }}>{base}</span>
+                            <button
+                              type="button"
+                              disabled={busy || idx === 0}
+                              onClick={() => void moveBase(base, tier.blockIndex, tiers[idx - 1]?.blockIndex ?? tier.blockIndex)}
+                              style={{ padding: '2px 8px', fontSize: 11 }}
+                            >
+                              ↑
+                            </button>
+                            <button
+                              type="button"
+                              disabled={busy || idx >= tiers.length - 1}
+                              onClick={() => void moveBase(base, tier.blockIndex, tiers[idx + 1]?.blockIndex ?? tier.blockIndex)}
+                              style={{ padding: '2px 8px', fontSize: 11 }}
+                            >
+                              ↓
+                            </button>
+                          </div>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <button type="button" disabled={busy || !active} onClick={() => setAddOpen((v) => !v)} style={{ fontSize: 12 }}>
+              {addOpen ? 'Cancel' : 'Add rule'}
+            </button>
+          </div>
+
+          {addOpen && active && (
+            <div
+              style={{
+                border: '1px solid rgba(255,255,255,0.12)',
+                borderRadius: 6,
+                padding: 10,
+                background: '#0a0b10',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 8,
+              }}
+            >
+              <div style={{ fontSize: 12, fontWeight: 700, color: '#f0e6d2' }}>Add rule — {active.title}</div>
+              <input
+                type="text"
+                value={addName}
+                onChange={(e) => setAddName(e.target.value)}
+                placeholder="BaseType name (e.g. Divine Orb)"
+                style={{
+                  background: '#12131a',
+                  color: '#f0e6d2',
+                  border: '1px solid rgba(255,255,255,0.14)',
+                  borderRadius: 6,
+                  padding: '8px 10px',
+                  fontSize: 12,
+                }}
+              />
+              <div style={{ display: 'flex', gap: 8 }}>
+                <button
+                  type="button"
+                  onClick={() => setAddMode('existing')}
+                  style={{
+                    fontSize: 11,
+                    background: addMode === 'existing' ? 'var(--accent)' : 'rgba(255,255,255,0.08)',
+                    color: addMode === 'existing' ? '#171821' : '#f0e6d2',
+                  }}
+                >
+                  Add to tier
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setAddMode('new')}
+                  style={{
+                    fontSize: 11,
+                    background: addMode === 'new' ? 'var(--accent)' : 'rgba(255,255,255,0.08)',
+                    color: addMode === 'new' ? '#171821' : '#f0e6d2',
+                  }}
+                >
+                  New tier rule
+                </button>
+              </div>
+              {addMode === 'existing' ? (
+                <select
+                  value={addTier}
+                  onChange={(e) => setAddTier(e.target.value)}
+                  style={{
+                    background: '#12131a',
+                    color: '#f0e6d2',
+                    border: '1px solid rgba(255,255,255,0.14)',
+                    borderRadius: 6,
+                    padding: '8px 10px',
+                    fontSize: 12,
+                  }}
+                >
+                  {tiers.map((t) => (
+                    <option key={t.blockIndex} value={t.blockIndex}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+              ) : (
+                <input
+                  type="text"
+                  value={addNewTierId}
+                  onChange={(e) => setAddNewTierId(e.target.value)}
+                  placeholder="New tier id (e.g. custom)"
+                  style={{
+                    background: '#12131a',
+                    color: '#f0e6d2',
+                    border: '1px solid rgba(255,255,255,0.14)',
+                    borderRadius: 6,
+                    padding: '8px 10px',
+                    fontSize: 12,
+                  }}
+                />
+              )}
+              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                <button type="button" className="primary" disabled={busy} onClick={() => void submitAddRule()} style={{ fontSize: 12 }}>
+                  {busy ? 'Adding…' : 'Add'}
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/FilterSectionEditor.tsx
+++ b/src/renderer/src/components/FilterSectionEditor.tsx
@@ -353,7 +353,9 @@ export function FilterSectionEditor({ filterPath }: Props): JSX.Element {
                   {open && (
                     <div style={{ marginTop: 8, paddingTop: 8, borderTop: '1px solid rgba(255,255,255,0.08)' }}>
                       {tier.baseTypes.length === 0 ? (
-                        <div style={{ fontSize: 11, color: '#9a9aab' }}>No BaseType list — drop items here or Add rule.</div>
+                        <div style={{ fontSize: 11, color: '#9a9aab' }}>
+                          No BaseType list — drop items here or Add rule.
+                        </div>
                       ) : (
                         tier.baseTypes.map((base) => (
                           <div
@@ -378,7 +380,9 @@ export function FilterSectionEditor({ filterPath }: Props): JSX.Element {
                             <button
                               type="button"
                               disabled={busy || idx === 0}
-                              onClick={() => void moveBase(base, tier.blockIndex, tiers[idx - 1]?.blockIndex ?? tier.blockIndex)}
+                              onClick={() =>
+                                void moveBase(base, tier.blockIndex, tiers[idx - 1]?.blockIndex ?? tier.blockIndex)
+                              }
                               style={{ padding: '2px 8px', fontSize: 11 }}
                             >
                               ↑
@@ -386,7 +390,9 @@ export function FilterSectionEditor({ filterPath }: Props): JSX.Element {
                             <button
                               type="button"
                               disabled={busy || idx >= tiers.length - 1}
-                              onClick={() => void moveBase(base, tier.blockIndex, tiers[idx + 1]?.blockIndex ?? tier.blockIndex)}
+                              onClick={() =>
+                                void moveBase(base, tier.blockIndex, tiers[idx + 1]?.blockIndex ?? tier.blockIndex)
+                              }
                               style={{ padding: '2px 8px', fontSize: 11 }}
                             >
                               ↓
@@ -402,7 +408,12 @@ export function FilterSectionEditor({ filterPath }: Props): JSX.Element {
           </div>
 
           <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <button type="button" disabled={busy || !active} onClick={() => setAddOpen((v) => !v)} style={{ fontSize: 12 }}>
+            <button
+              type="button"
+              disabled={busy || !active}
+              onClick={() => setAddOpen((v) => !v)}
+              style={{ fontSize: 12 }}
+            >
               {addOpen ? 'Cancel' : 'Add rule'}
             </button>
           </div>
@@ -494,7 +505,13 @@ export function FilterSectionEditor({ filterPath }: Props): JSX.Element {
                 />
               )}
               <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-                <button type="button" className="primary" disabled={busy} onClick={() => void submitAddRule()} style={{ fontSize: 12 }}>
+                <button
+                  type="button"
+                  className="primary"
+                  disabled={busy}
+                  onClick={() => void submitAddRule()}
+                  style={{ fontSize: 12 }}
+                >
                   {busy ? 'Adding…' : 'Add'}
                 </button>
               </div>

--- a/src/renderer/src/components/LootSimulator.tsx
+++ b/src/renderer/src/components/LootSimulator.tsx
@@ -6,11 +6,7 @@ interface Props {
   filterPath?: string | null
 }
 
-async function playDropAlert(
-  drop: LootSimDrop,
-  volume: number,
-  filterDir: string | null,
-): Promise<void> {
+async function playDropAlert(drop: LootSimDrop, volume: number, filterDir: string | null): Promise<void> {
   if (drop.alert.kind === 'none' || !drop.alert.value) return
   try {
     if (drop.alert.kind === 'builtin') {
@@ -138,11 +134,7 @@ export function LootSimulator({ filterPath }: Props): JSX.Element {
   }
 
   if (!filterPath) {
-    return (
-      <p style={{ margin: 0, fontSize: 12, color: '#9a9aab' }}>
-        Select a local filter to run the loot simulator.
-      </p>
-    )
+    return <p style={{ margin: 0, fontSize: 12, color: '#9a9aab' }}>Select a local filter to run the loot simulator.</p>
   }
 
   const rendered = drops.filter((d) => showHidden || !d.hidden)
@@ -161,18 +153,26 @@ export function LootSimulator({ filterPath }: Props): JSX.Element {
     >
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
         <div style={{ fontSize: 13, fontWeight: 700, color: '#f0e6d2' }}>Loot simulator</div>
-        <button type="button" className="primary" disabled={busy || pool.length === 0} onClick={() => void runSim()} style={{ fontSize: 12 }}>
+        <button
+          type="button"
+          className="primary"
+          disabled={busy || pool.length === 0}
+          onClick={() => void runSim()}
+          style={{ fontSize: 12 }}
+        >
           {busy ? 'Dropping…' : 'Simulate drops'}
         </button>
       </div>
 
       <p style={{ margin: 0, fontSize: 11, color: '#9a9aab', lineHeight: 1.4 }}>
-        Rolls items from a filter section against your active local filter — shows Fontin labels and plays alert
-        sounds like a pack drop.
+        Rolls items from a filter section against your active local filter — shows Fontin labels and plays alert sounds
+        like a pack drop.
       </p>
 
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, alignItems: 'end' }}>
-        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: '#9a9aab', minWidth: 160 }}>
+        <label
+          style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: '#9a9aab', minWidth: 160 }}
+        >
           Section pool
           <select
             value={active?.typePath ?? ''}
@@ -216,12 +216,16 @@ export function LootSimulator({ filterPath }: Props): JSX.Element {
           </select>
         </label>
 
-        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#f0e6d2', paddingBottom: 6 }}>
+        <label
+          style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#f0e6d2', paddingBottom: 6 }}
+        >
           <input type="checkbox" checked={playSounds} onChange={(e) => setPlaySounds(e.target.checked)} />
           Play sounds
         </label>
 
-        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#f0e6d2', paddingBottom: 6 }}>
+        <label
+          style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#f0e6d2', paddingBottom: 6 }}
+        >
           <input type="checkbox" checked={showHidden} onChange={(e) => setShowHidden(e.target.checked)} />
           Show hidden
         </label>

--- a/src/renderer/src/components/LootSimulator.tsx
+++ b/src/renderer/src/components/LootSimulator.tsx
@@ -1,0 +1,300 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { FilterSection, LootSimDrop, LootSimPoolItem } from '@shared/types'
+import { HiddenLootLabel, LootLabel } from '@renderer/shared/LootLabel'
+
+interface Props {
+  filterPath?: string | null
+}
+
+async function playDropAlert(
+  drop: LootSimDrop,
+  volume: number,
+  filterDir: string | null,
+): Promise<void> {
+  if (drop.alert.kind === 'none' || !drop.alert.value) return
+  try {
+    if (drop.alert.kind === 'builtin') {
+      const id = drop.alert.value.padStart(2, '0')
+      const soundUrl = new URL(`../assets/sounds/AlertSound_${id}.ogg`, import.meta.url).href
+      const audio = new Audio(soundUrl)
+      audio.volume = volume
+      await audio.play().catch(() => {})
+      return
+    }
+    if (drop.alert.kind === 'custom' && filterDir) {
+      const url = await window.api.getSoundDataUrl(filterDir, drop.alert.value)
+      if (!url) return
+      const audio = new Audio(url)
+      audio.volume = volume
+      await audio.play().catch(() => {})
+    }
+  } catch {
+    // ignore preview failures
+  }
+}
+
+export function LootSimulator({ filterPath }: Props): JSX.Element {
+  const [sections, setSections] = useState<FilterSection[]>([])
+  const [sectionType, setSectionType] = useState('')
+  const [count, setCount] = useState(24)
+  const [playSounds, setPlaySounds] = useState(true)
+  const [showHidden, setShowHidden] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [drops, setDrops] = useState<LootSimDrop[]>([])
+  const [visibleIds, setVisibleIds] = useState<Set<string>>(new Set())
+  const [stats, setStats] = useState<{ shown: number; hidden: number } | null>(null)
+  const [previewVolume, setPreviewVolume] = useState(0.25)
+  const [filterDir, setFilterDir] = useState<string | null>(null)
+  const cancelRef = useRef(0)
+
+  useEffect(() => {
+    void window.api.getSettings().then((s) => {
+      if (typeof s.previewVolume === 'number') setPreviewVolume(s.previewVolume)
+      setFilterDir(s.activeProfile?.filterDir ?? null)
+    })
+  }, [])
+
+  const refreshSections = useCallback(async (): Promise<void> => {
+    if (!window.api.getFilterSections) return
+    const result = await window.api.getFilterSections()
+    if (!result.ok) {
+      setSections([])
+      return
+    }
+    setSections(result.sections)
+    setSectionType((prev) => {
+      if (prev && result.sections.some((s) => s.typePath === prev)) return prev
+      const currency = result.sections.find((s) => s.typePath === 'currency')
+      return currency?.typePath ?? result.sections[0]?.typePath ?? ''
+    })
+  }, [])
+
+  useEffect(() => {
+    void refreshSections()
+  }, [filterPath, refreshSections])
+
+  const active = useMemo(
+    () => sections.find((s) => s.typePath === sectionType) ?? sections[0] ?? null,
+    [sections, sectionType],
+  )
+
+  const pool: LootSimPoolItem[] = useMemo(() => {
+    if (!active) return []
+    const seen = new Set<string>()
+    const out: LootSimPoolItem[] = []
+    for (const tier of active.tiers) {
+      for (const base of tier.baseTypes) {
+        if (seen.has(base)) continue
+        seen.add(base)
+        out.push({
+          name: base,
+          baseType: base,
+          itemClass: 'Stackable Currency',
+          rarity: 'Normal',
+        })
+      }
+    }
+    return out
+  }, [active])
+
+  const runSim = async (): Promise<void> => {
+    if (!pool.length) {
+      setError('No BaseTypes in this section to simulate')
+      return
+    }
+    const runId = ++cancelRef.current
+    setBusy(true)
+    setError(null)
+    setVisibleIds(new Set())
+    try {
+      const result = await window.api.simulateLootDrops({
+        pool,
+        count,
+        seed: Date.now(),
+      })
+      if (!result.ok) {
+        setError(result.error ?? 'Simulation failed')
+        setDrops([])
+        setStats(null)
+        return
+      }
+      setDrops(result.drops)
+      setStats({ shown: result.shown, hidden: result.hidden })
+
+      // Stagger reveal + sounds so it feels like a pack drop
+      for (let i = 0; i < result.drops.length; i++) {
+        if (cancelRef.current !== runId) return
+        const drop = result.drops[i]
+        setVisibleIds((prev) => new Set(prev).add(drop.id))
+        if (playSounds && !drop.hidden) {
+          void playDropAlert(drop, previewVolume, filterDir)
+        }
+        await new Promise((r) => setTimeout(r, 70))
+      }
+    } finally {
+      if (cancelRef.current === runId) setBusy(false)
+    }
+  }
+
+  if (!filterPath) {
+    return (
+      <p style={{ margin: 0, fontSize: 12, color: '#9a9aab' }}>
+        Select a local filter to run the loot simulator.
+      </p>
+    )
+  }
+
+  const rendered = drops.filter((d) => showHidden || !d.hidden)
+
+  return (
+    <div
+      style={{
+        border: '1px solid rgba(255,255,255,0.12)',
+        borderRadius: 8,
+        background: '#12131a',
+        padding: 12,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: '#f0e6d2' }}>Loot simulator</div>
+        <button type="button" className="primary" disabled={busy || pool.length === 0} onClick={() => void runSim()} style={{ fontSize: 12 }}>
+          {busy ? 'Dropping…' : 'Simulate drops'}
+        </button>
+      </div>
+
+      <p style={{ margin: 0, fontSize: 11, color: '#9a9aab', lineHeight: 1.4 }}>
+        Rolls items from a filter section against your active local filter — shows Fontin labels and plays alert
+        sounds like a pack drop.
+      </p>
+
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 10, alignItems: 'end' }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: '#9a9aab', minWidth: 160 }}>
+          Section pool
+          <select
+            value={active?.typePath ?? ''}
+            onChange={(e) => setSectionType(e.target.value)}
+            style={{
+              background: '#0a0b10',
+              color: '#f0e6d2',
+              border: '1px solid rgba(255,255,255,0.14)',
+              borderRadius: 6,
+              padding: '7px 8px',
+              fontSize: 12,
+            }}
+          >
+            {sections.map((s) => (
+              <option key={s.typePath} value={s.typePath}>
+                {s.title} ({s.tiers.reduce((n, t) => n + t.itemCount, 0)} items)
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: '#9a9aab' }}>
+          Drop count
+          <select
+            value={count}
+            onChange={(e) => setCount(Number(e.target.value))}
+            style={{
+              background: '#0a0b10',
+              color: '#f0e6d2',
+              border: '1px solid rgba(255,255,255,0.14)',
+              borderRadius: 6,
+              padding: '7px 8px',
+              fontSize: 12,
+            }}
+          >
+            {[12, 24, 40, 60].map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#f0e6d2', paddingBottom: 6 }}>
+          <input type="checkbox" checked={playSounds} onChange={(e) => setPlaySounds(e.target.checked)} />
+          Play sounds
+        </label>
+
+        <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#f0e6d2', paddingBottom: 6 }}>
+          <input type="checkbox" checked={showHidden} onChange={(e) => setShowHidden(e.target.checked)} />
+          Show hidden
+        </label>
+      </div>
+
+      {error && <div style={{ color: '#f87171', fontSize: 12 }}>{error}</div>}
+
+      {stats && (
+        <div style={{ fontSize: 11, color: '#9a9aab' }}>
+          Result: {stats.shown} shown · {stats.hidden} hidden · pool {pool.length} BaseTypes
+        </div>
+      )}
+
+      <div
+        style={{
+          position: 'relative',
+          height: 280,
+          borderRadius: 8,
+          border: '1px solid rgba(255,255,255,0.1)',
+          background:
+            'radial-gradient(ellipse at center, rgba(40,36,28,0.9) 0%, rgba(12,12,16,1) 70%), repeating-linear-gradient(0deg, transparent, transparent 11px, rgba(255,255,255,0.02) 12px)',
+          overflow: 'hidden',
+        }}
+      >
+        {rendered.length === 0 && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#6a6a78',
+              fontSize: 12,
+            }}
+          >
+            Click Simulate drops to scatter loot
+          </div>
+        )}
+        {rendered.map((drop) => {
+          const shown = visibleIds.has(drop.id)
+          return (
+            <button
+              key={drop.id}
+              type="button"
+              title={`${drop.name}${drop.hidden ? ' (hidden)' : ''} — click to replay sound`}
+              onClick={() => void playDropAlert(drop, previewVolume, filterDir)}
+              style={{
+                position: 'absolute',
+                left: `${drop.x}%`,
+                top: `${drop.y}%`,
+                transform: 'translate(-50%, -50%)',
+                opacity: shown ? 1 : 0,
+                transition: 'opacity 120ms ease-out',
+                background: 'transparent',
+                border: 'none',
+                padding: 0,
+                cursor: 'pointer',
+                maxWidth: '42%',
+                zIndex: drop.hidden ? 1 : 2,
+              }}
+            >
+              {drop.hidden ? (
+                <HiddenLootLabel label={drop.name} />
+              ) : drop.blocks ? (
+                <LootLabel blocks={drop.blocks} label={drop.name} />
+              ) : (
+                <HiddenLootLabel label={drop.name} />
+              )}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/TierStyleEditor.tsx
+++ b/src/renderer/src/components/TierStyleEditor.tsx
@@ -55,18 +55,12 @@ export function TierStyleEditor({ blockIndex, tierLabel, onClose, onSaved }: Pro
     })
   }, [blockIndex])
 
-  const text = useMemo(
-    () => (block ? actionOf(block, 'SetTextColor', ['200', '200', '200', '255']) : null),
-    [block],
-  )
+  const text = useMemo(() => (block ? actionOf(block, 'SetTextColor', ['200', '200', '200', '255']) : null), [block])
   const border = useMemo(
     () => (block ? actionOf(block, 'SetBorderColor', ['100', '100', '100', '255']) : null),
     [block],
   )
-  const bg = useMemo(
-    () => (block ? actionOf(block, 'SetBackgroundColor', ['0', '0', '0', '180']) : null),
-    [block],
-  )
+  const bg = useMemo(() => (block ? actionOf(block, 'SetBackgroundColor', ['0', '0', '0', '180']) : null), [block])
   const font = useMemo(() => (block ? actionOf(block, 'SetFontSize', ['32']) : null), [block])
   const alert = useMemo(() => {
     if (!block) return null
@@ -99,9 +93,7 @@ export function TierStyleEditor({ blockIndex, tierLabel, onClose, onSaved }: Pro
   }
 
   if (!block) {
-    return (
-      <div style={{ padding: 12, color: '#9a9aab', fontSize: 12 }}>{error ?? 'Loading style…'}</div>
-    )
+    return <div style={{ padding: 12, color: '#9a9aab', fontSize: 12 }}>{error ?? 'Loading style…'}</div>
   }
 
   return (
@@ -133,11 +125,7 @@ export function TierStyleEditor({ blockIndex, tierLabel, onClose, onSaved }: Pro
         {border && (
           <div>
             <div style={{ fontSize: 10, color: '#9a9aab', marginBottom: 4 }}>Border</div>
-            <ColorActionEditor
-              action={border}
-              onChange={(a) => setBlock(upsertAction(block, a))}
-              unset={borderUnset}
-            />
+            <ColorActionEditor action={border} onChange={(a) => setBlock(upsertAction(block, a))} unset={borderUnset} />
           </div>
         )}
         {bg && (
@@ -156,7 +144,12 @@ export function TierStyleEditor({ blockIndex, tierLabel, onClose, onSaved }: Pro
           max={45}
           value={Number(font?.values[0] ?? 32)}
           onChange={(e) =>
-            setBlock(upsertAction(block, { type: 'SetFontSize', values: [String(Math.max(18, Math.min(45, Number(e.target.value) || 32)))] }))
+            setBlock(
+              upsertAction(block, {
+                type: 'SetFontSize',
+                values: [String(Math.max(18, Math.min(45, Number(e.target.value) || 32)))],
+              }),
+            )
           }
           style={{
             background: '#12131a',
@@ -256,7 +249,12 @@ export function TierStyleEditor({ blockIndex, tierLabel, onClose, onSaved }: Pro
                 }),
               )
             }
-            style={{ background: '#12131a', color: '#f0e6d2', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 4 }}
+            style={{
+              background: '#12131a',
+              color: '#f0e6d2',
+              border: '1px solid rgba(255,255,255,0.14)',
+              borderRadius: 4,
+            }}
           >
             {MINIMAP_SIZES.map((s) => (
               <option key={s.id} value={s.id}>
@@ -275,7 +273,12 @@ export function TierStyleEditor({ blockIndex, tierLabel, onClose, onSaved }: Pro
                 }),
               )
             }
-            style={{ background: '#12131a', color: '#f0e6d2', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 4 }}
+            style={{
+              background: '#12131a',
+              color: '#f0e6d2',
+              border: '1px solid rgba(255,255,255,0.14)',
+              borderRadius: 4,
+            }}
           >
             {MINIMAP_COLORS.map((c) => (
               <option key={c} value={c}>
@@ -294,7 +297,12 @@ export function TierStyleEditor({ blockIndex, tierLabel, onClose, onSaved }: Pro
                 }),
               )
             }
-            style={{ background: '#12131a', color: '#f0e6d2', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 4 }}
+            style={{
+              background: '#12131a',
+              color: '#f0e6d2',
+              border: '1px solid rgba(255,255,255,0.14)',
+              borderRadius: 4,
+            }}
           >
             {MINIMAP_SHAPES.map((s) => (
               <option key={s.id} value={s.id}>
@@ -325,7 +333,13 @@ export function TierStyleEditor({ blockIndex, tierLabel, onClose, onSaved }: Pro
         <button type="button" onClick={onClose} style={{ fontSize: 12 }}>
           Cancel
         </button>
-        <button type="button" className="primary" disabled={saving} onClick={() => void save()} style={{ fontSize: 12 }}>
+        <button
+          type="button"
+          className="primary"
+          disabled={saving}
+          onClick={() => void save()}
+          style={{ fontSize: 12 }}
+        >
           {saving ? 'Saving…' : 'Save style'}
         </button>
       </div>

--- a/src/renderer/src/components/TierStyleEditor.tsx
+++ b/src/renderer/src/components/TierStyleEditor.tsx
@@ -1,0 +1,334 @@
+import { useEffect, useMemo, useState } from 'react'
+import type { FilterAction, FilterBlock } from '@shared/types'
+import {
+  ALERT_SOUNDS,
+  BEAM_COLORS,
+  MINIMAP_COLORS,
+  MINIMAP_SHAPES,
+  MINIMAP_SIZES,
+  POE_COLOR_HEX,
+} from '@shared/data/filter/filter-actions'
+import { ColorActionEditor } from '@renderer/features/filter/filter-block-editor/ColorActionEditor'
+
+function actionOf(block: FilterBlock, type: FilterAction['type'], fallback: string[] = []): FilterAction {
+  return block.actions.find((a) => a.type === type) ?? { type, values: fallback }
+}
+
+function upsertAction(block: FilterBlock, action: FilterAction): FilterBlock {
+  const actions = [...block.actions]
+  const idx = actions.findIndex((a) => a.type === action.type)
+  if (action.values.length === 0) {
+    if (idx >= 0) actions.splice(idx, 1)
+  } else if (idx >= 0) {
+    actions[idx] = action
+  } else {
+    actions.push(action)
+  }
+  // Alert sound types are mutually exclusive
+  if (action.type === 'PlayAlertSound' || action.type === 'CustomAlertSound') {
+    const drop = action.type === 'PlayAlertSound' ? 'CustomAlertSound' : 'PlayAlertSound'
+    const dropIdx = actions.findIndex((a) => a.type === drop)
+    if (dropIdx >= 0) actions.splice(dropIdx, 1)
+  }
+  return { ...block, actions }
+}
+
+interface Props {
+  blockIndex: number
+  tierLabel: string
+  onClose: () => void
+  onSaved: () => void
+}
+
+export function TierStyleEditor({ blockIndex, tierLabel, onClose, onSaved }: Props): JSX.Element {
+  const [block, setBlock] = useState<FilterBlock | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    void window.api.getFilterBlock(blockIndex).then((r) => {
+      if (!r.ok || !r.block) {
+        setError(r.error ?? 'Could not load tier')
+        return
+      }
+      setBlock(structuredClone(r.block))
+    })
+  }, [blockIndex])
+
+  const text = useMemo(
+    () => (block ? actionOf(block, 'SetTextColor', ['200', '200', '200', '255']) : null),
+    [block],
+  )
+  const border = useMemo(
+    () => (block ? actionOf(block, 'SetBorderColor', ['100', '100', '100', '255']) : null),
+    [block],
+  )
+  const bg = useMemo(
+    () => (block ? actionOf(block, 'SetBackgroundColor', ['0', '0', '0', '180']) : null),
+    [block],
+  )
+  const font = useMemo(() => (block ? actionOf(block, 'SetFontSize', ['32']) : null), [block])
+  const alert = useMemo(() => {
+    if (!block) return null
+    const custom = block.actions.find((a) => a.type === 'CustomAlertSound')
+    if (custom) return custom
+    return actionOf(block, 'PlayAlertSound')
+  }, [block])
+  const beam = useMemo(() => (block ? actionOf(block, 'PlayEffect') : null), [block])
+  const minimap = useMemo(() => (block ? actionOf(block, 'MinimapIcon') : null), [block])
+
+  const textUnset = Boolean(block && !block.actions.some((a) => a.type === 'SetTextColor'))
+  const borderUnset = Boolean(block && !block.actions.some((a) => a.type === 'SetBorderColor'))
+  const bgUnset = Boolean(block && !block.actions.some((a) => a.type === 'SetBackgroundColor'))
+
+  const save = async (): Promise<void> => {
+    if (!block) return
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await window.api.saveBlockEdit(blockIndex, block)
+      if (!result.ok) {
+        setError(result.error ?? 'Save failed')
+        return
+      }
+      onSaved()
+      onClose()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!block) {
+    return (
+      <div style={{ padding: 12, color: '#9a9aab', fontSize: 12 }}>{error ?? 'Loading style…'}</div>
+    )
+  }
+
+  return (
+    <div
+      style={{
+        border: '1px solid rgba(255,255,255,0.14)',
+        borderRadius: 8,
+        background: '#0a0b10',
+        padding: 12,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8 }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: '#f0e6d2' }}>Style — {tierLabel}</div>
+        <button type="button" onClick={onClose} style={{ fontSize: 11 }}>
+          Close
+        </button>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8 }}>
+        {text && (
+          <div>
+            <div style={{ fontSize: 10, color: '#9a9aab', marginBottom: 4 }}>Text</div>
+            <ColorActionEditor action={text} onChange={(a) => setBlock(upsertAction(block, a))} unset={textUnset} />
+          </div>
+        )}
+        {border && (
+          <div>
+            <div style={{ fontSize: 10, color: '#9a9aab', marginBottom: 4 }}>Border</div>
+            <ColorActionEditor
+              action={border}
+              onChange={(a) => setBlock(upsertAction(block, a))}
+              unset={borderUnset}
+            />
+          </div>
+        )}
+        {bg && (
+          <div>
+            <div style={{ fontSize: 10, color: '#9a9aab', marginBottom: 4 }}>Background</div>
+            <ColorActionEditor action={bg} onChange={(a) => setBlock(upsertAction(block, a))} unset={bgUnset} />
+          </div>
+        )}
+      </div>
+
+      <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: '#9a9aab' }}>
+        Font size
+        <input
+          type="number"
+          min={18}
+          max={45}
+          value={Number(font?.values[0] ?? 32)}
+          onChange={(e) =>
+            setBlock(upsertAction(block, { type: 'SetFontSize', values: [String(Math.max(18, Math.min(45, Number(e.target.value) || 32)))] }))
+          }
+          style={{
+            background: '#12131a',
+            color: '#f0e6d2',
+            border: '1px solid rgba(255,255,255,0.14)',
+            borderRadius: 6,
+            padding: '6px 8px',
+            width: 80,
+          }}
+        />
+      </label>
+
+      <label style={{ display: 'flex', flexDirection: 'column', gap: 4, fontSize: 11, color: '#9a9aab' }}>
+        Alert sound
+        <select
+          value={
+            alert?.type === 'CustomAlertSound'
+              ? `custom:${alert.values[0] ?? ''}`
+              : alert && alert.values.length > 0
+                ? alert.values[0]
+                : '__none__'
+          }
+          onChange={(e) => {
+            const val = e.target.value
+            if (val === '__none__') setBlock(upsertAction(block, { type: 'PlayAlertSound', values: [] }))
+            else if (val.startsWith('custom:'))
+              setBlock(upsertAction(block, { type: 'CustomAlertSound', values: [val.slice(7), '300'] }))
+            else setBlock(upsertAction(block, { type: 'PlayAlertSound', values: [val, '300'] }))
+          }}
+          style={{
+            background: '#12131a',
+            color: '#f0e6d2',
+            border: '1px solid rgba(255,255,255,0.14)',
+            borderRadius: 6,
+            padding: '6px 8px',
+          }}
+        >
+          <option value="__none__">None</option>
+          {ALERT_SOUNDS.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <div>
+        <div style={{ fontSize: 10, color: '#9a9aab', marginBottom: 4 }}>Beam</div>
+        <div style={{ display: 'flex', gap: 4 }}>
+          <button
+            type="button"
+            onClick={() => setBlock(upsertAction(block, { type: 'PlayEffect', values: [] }))}
+            style={{
+              fontSize: 10,
+              background: !beam || beam.values.length === 0 ? 'var(--accent)' : 'rgba(255,255,255,0.08)',
+              color: !beam || beam.values.length === 0 ? '#171821' : '#f0e6d2',
+            }}
+          >
+            None
+          </button>
+          {BEAM_COLORS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              title={c}
+              onClick={() => setBlock(upsertAction(block, { type: 'PlayEffect', values: [c] }))}
+              style={{
+                width: 22,
+                height: 22,
+                padding: 0,
+                background: POE_COLOR_HEX[c],
+                border: beam?.values[0] === c ? '2px solid #fff' : '2px solid transparent',
+              }}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <div style={{ fontSize: 10, color: '#9a9aab', marginBottom: 4 }}>Minimap</div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+          <button
+            type="button"
+            onClick={() => setBlock(upsertAction(block, { type: 'MinimapIcon', values: [] }))}
+            style={{ fontSize: 10 }}
+          >
+            None
+          </button>
+          <select
+            value={minimap?.values[0] ?? '0'}
+            disabled={!minimap || minimap.values.length === 0}
+            onChange={(e) =>
+              setBlock(
+                upsertAction(block, {
+                  type: 'MinimapIcon',
+                  values: [e.target.value, minimap?.values[1] ?? 'White', minimap?.values[2] ?? 'Circle'],
+                }),
+              )
+            }
+            style={{ background: '#12131a', color: '#f0e6d2', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 4 }}
+          >
+            {MINIMAP_SIZES.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <select
+            value={minimap?.values[1] ?? 'White'}
+            disabled={!minimap || minimap.values.length === 0}
+            onChange={(e) =>
+              setBlock(
+                upsertAction(block, {
+                  type: 'MinimapIcon',
+                  values: [minimap?.values[0] ?? '0', e.target.value, minimap?.values[2] ?? 'Circle'],
+                }),
+              )
+            }
+            style={{ background: '#12131a', color: '#f0e6d2', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 4 }}
+          >
+            {MINIMAP_COLORS.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+          <select
+            value={minimap?.values[2] ?? 'Circle'}
+            disabled={!minimap || minimap.values.length === 0}
+            onChange={(e) =>
+              setBlock(
+                upsertAction(block, {
+                  type: 'MinimapIcon',
+                  values: [minimap?.values[0] ?? '0', minimap?.values[1] ?? 'White', e.target.value],
+                }),
+              )
+            }
+            style={{ background: '#12131a', color: '#f0e6d2', border: '1px solid rgba(255,255,255,0.14)', borderRadius: 4 }}
+          >
+            {MINIMAP_SHAPES.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() =>
+              setBlock(
+                upsertAction(block, {
+                  type: 'MinimapIcon',
+                  values: [minimap?.values[0] ?? '0', minimap?.values[1] ?? 'White', minimap?.values[2] ?? 'Circle'],
+                }),
+              )
+            }
+            style={{ fontSize: 10 }}
+          >
+            Enable
+          </button>
+        </div>
+      </div>
+
+      {error && <div style={{ color: '#f87171', fontSize: 12 }}>{error}</div>}
+
+      <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+        <button type="button" onClick={onClose} style={{ fontSize: 12 }}>
+          Cancel
+        </button>
+        <button type="button" className="primary" disabled={saving} onClick={() => void save()} style={{ fontSize: 12 }}>
+          {saving ? 'Saving…' : 'Save style'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/features/settings/tabs/FilterTab.tsx
+++ b/src/renderer/src/features/settings/tabs/FilterTab.tsx
@@ -1,7 +1,9 @@
 import type { AppSettings, ProfileSettingValue, PoeItem, RuntimeSettings } from '@shared/types'
 import { getGameFeatures } from '@shared/game-features'
 import { FilterPicker } from '@renderer/components/FilterPicker'
+import { FilterSectionEditor } from '@renderer/components/FilterSectionEditor'
 import { HistoryPanel } from '@renderer/components/HistoryPanel'
+import { LootSimulator } from '@renderer/components/LootSimulator'
 import { HotkeyField } from '@renderer/components/primitives/HotkeyField'
 import { SettingToggleBox } from '@renderer/components/primitives/SettingToggleBox'
 import { m } from '@shared/paraglide/messages.js'
@@ -63,6 +65,20 @@ export function FilterTab({
     <>
       <div className="settings-section-title mt-3">{m.settings_filter_heading()}</div>
 
+      <section>
+        <label>Edit filter sections</label>
+        <div className="mt-[6px]">
+          <FilterSectionEditor filterPath={filterPath} />
+        </div>
+      </section>
+
+      <section>
+        <label>Loot simulator</label>
+        <div className="mt-[6px]">
+          <LootSimulator filterPath={filterPath} />
+        </div>
+      </section>
+
       {/* Filter folder & picker */}
       <section>
         <label>{m.settings_filter_folder()}</label>
@@ -73,6 +89,7 @@ export function FilterTab({
             autoSwitchInGame={isOverlay || undefined}
             onOnlineFilterUpdated={onOnlineFilterUpdated}
             onOnlineImport={onOnlineImport}
+            maxListHeight={140}
           />
         </div>
         {isOverlay && !filterPath && (

--- a/src/shared/contracts/filter-sections.ts
+++ b/src/shared/contracts/filter-sections.ts
@@ -1,0 +1,25 @@
+import type { Visibility } from './core'
+import type { FilterAction } from './items'
+
+/** One NeverSink-tagged tier row inside a section (e.g. currency / s). */
+export interface FilterSectionTier {
+  tier: string
+  label: string
+  blockIndex: number
+  visibility: Visibility
+  previewLabel: string
+  /** Actions used by LootLabel (colors / font size). */
+  previewActions: FilterAction[]
+  style: { text: string; bg: string; border: string }
+  baseTypes: string[]
+  itemCount: number
+}
+
+/** A FilterBlade-style section grouped by `$type->…` path. */
+export interface FilterSection {
+  typePath: string
+  title: string
+  tiers: FilterSectionTier[]
+  shownCount: number
+  totalCount: number
+}

--- a/src/shared/contracts/ipc.ts
+++ b/src/shared/contracts/ipc.ts
@@ -35,6 +35,12 @@ export const IPC_CHANNELS = {
     SWITCH_INGAME: 'switch-ingame-filter',
     GET_COLOR_FREQUENCIES: 'get-color-frequencies',
     SAVE_BLOCK_EDIT: 'save-block-edit',
+    GET_FILTER_SECTIONS: 'get-filter-sections',
+    SET_SECTION_TIER_VISIBILITY: 'set-section-tier-visibility',
+    GET_FILTER_BLOCK: 'get-filter-block',
+    ADD_BASETYPE_TO_TIER: 'add-basetype-to-tier',
+    INSERT_SECTION_RULE: 'insert-section-rule',
+    SIMULATE_LOOT_DROPS: 'simulate-loot-drops',
     RELOAD: 'reload-filter',
     GET_UNIQUE_VISIBILITY: 'get-unique-visibility',
     MOVE_ITEM_TIER: 'move-item-tier',
@@ -60,6 +66,9 @@ export const IPC_CHANNELS = {
     QUICK_UPDATE: 'quick-update-filter',
     MERGE: 'merge-online-filter',
     ONLINE_FILTER_CHANGED_EVENT: 'online-filter-changed',
+    FILTERBLADE_URL: 'filterblade-url',
+    FILTERBLADE_SCAN: 'filterblade-scan',
+    FILTERBLADE_LINK: 'filterblade-link',
   },
 
   PRICES: {

--- a/src/shared/contracts/loot-sim.ts
+++ b/src/shared/contracts/loot-sim.ts
@@ -1,0 +1,46 @@
+import type { Visibility } from './core'
+import type { FilterAction } from './items'
+
+export interface LootSimDropStyle {
+  visibility: Visibility
+  actions: FilterAction[]
+  continue: boolean
+}
+
+export interface LootSimAlert {
+  kind: 'builtin' | 'custom' | 'none'
+  value?: string
+  volume?: string
+}
+
+export interface LootSimDrop {
+  id: string
+  name: string
+  baseType: string
+  itemClass: string
+  hidden: boolean
+  blocks: LootSimDropStyle[] | null
+  alert: LootSimAlert
+  x: number
+  y: number
+}
+
+export interface LootSimPoolItem {
+  name: string
+  baseType: string
+  itemClass: string
+  rarity?: 'Normal' | 'Magic' | 'Rare' | 'Unique' | 'Gem' | 'Currency'
+}
+
+export interface LootSimRequest {
+  pool: LootSimPoolItem[]
+  count: number
+  seed?: number
+  areaLevel?: number
+}
+
+export interface LootSimResult {
+  drops: LootSimDrop[]
+  shown: number
+  hidden: number
+}

--- a/src/shared/endpoints.ts
+++ b/src/shared/endpoints.ts
@@ -117,6 +117,25 @@ export const PREMIUM_MODS_URL =
 export const ENDGAME_FILTER_SUPPORT_URL =
   'https://raw.githubusercontent.com/scalpelpoe/scalpel/main/src/shared/data/trade/endgame-filter-support.json'
 
+/** URL of FilterBlade for PoE1 / PoE2 NeverSink customization. Sync exports
+ *  land in PoE's OnlineFilters folder — Scalpel links those as `-local` copies. */
+export function filterBladeUrl(poeVersion: 1 | 2): string {
+  return poeVersion === 2 ? 'https://www.filterblade.xyz/?game=Poe2' : 'https://www.filterblade.xyz/?game=Poe'
+}
+
+/** PoE website page for a specific account / shared item filter.
+ *  OnlineFilters entries are named by this id (e.g. `rkY4jLfX`). */
+export function poeItemFilterUrl(filterId: string): string {
+  const id = filterId.trim().replace(/\.filter$/i, '')
+  return `${POE_WEBSITE}/item-filter/${encodeURIComponent(id)}`
+}
+
+/** PoE2 (or PoE1) public filter ladder — Follow shared filters from other players. */
+export function poeItemFilterLadderUrl(poeVersion: 1 | 2): string {
+  const type = poeVersion === 2 ? 'PoE2' : 'PoE1'
+  return `${POE_WEBSITE}/item-filter/ladder/follower/type/${type}`
+}
+
 /** "Powered by..." attribution links shown under the regex output bar. The
  *  underlying mod / regex data ships from these projects; we point users at the
  *  source so they can compare against the upstream tools and contribute upstream. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -52,5 +52,16 @@ export type { InstallManifest, Manifest, AuthResult } from './contracts/updates'
 
 export type { HistoryEntry, FilterChange, FilterVersion } from './contracts/history'
 
+export type { FilterSection, FilterSectionTier } from './contracts/filter-sections'
+
+export type {
+  LootSimAlert,
+  LootSimDrop,
+  LootSimDropStyle,
+  LootSimPoolItem,
+  LootSimRequest,
+  LootSimResult,
+} from './contracts/loot-sim'
+
 export type { MacroScope }
 export type { ThemePalette }


### PR DESCRIPTION
## Summary
- Adds a NeverSink `$type`/`$tier` section browser in Settings → Filter: Show/Hide tiers, reorder BaseTypes (including drag-and-drop), edit tier style, and add rules to existing or new tiers.
- Adds a loot simulator that picks BaseTypes from filter sections and previews labels + alert sounds against the active filter.
- Adds a FilterBlade / PoE OnlineFilters bridge (open PoE filter page or FilterBlade, scan OnlineFilters, link as `*-local.filter`) so testers can try the editor without manual import steps.

## Test plan
- [ ] Build/run from this branch (`pnpm install` / `npm install`, then start the app)
- [ ] Settings → Filter: select a NeverSink-style filter (or link one via Scan & Link)
- [ ] Section editor lists sections/tiers; toggle Show/Hide and confirm filter + in-game reload (if enabled)
- [ ] Drag a BaseType between tiers; use ↑↓; use style brush; Add rule to existing tier and as a new tier
- [ ] Loot simulator: pick a section pool, run drops, confirm Fontin-style labels and alert sounds
- [ ] FilterBlade bridge: Open PoE/FilterBlade links; Scan & Link creates/selects a `*-local` filter
- [ ] Confirm unrelated filters/settings (price check, regex, etc.) still work