### PR TITLE
fix(trade): PoE1 staff-block jewels vs (Staves) mapping

### DIFF
--- a/src/main/trade/stat-exceptions.ts
+++ b/src/main/trade/stat-exceptions.ts
@@ -9,7 +9,23 @@ export const STAT_ID_REMAPS: Record<string, string> = {
   // "Socketed Gems are Supported by Level # Chance To Bleed" (capital T) is the wrong variant.
   // The correct one is "supported" (lowercase s) -> stat_2178803872
   'explicit.stat_4197676934': 'explicit.stat_2178803872',
-  // "+#% Chance to Block Attack Damage while wielding a Staff" has two identical-text stat IDs.
-  // stat_1778298516 doesn't work for uniques, stat_1001829678 does.
-  'explicit.stat_1778298516': 'explicit.stat_1001829678',
+}
+
+/** PoE1 "+#% Chance to Block Attack Damage while wielding a Staff":
+ *  jewels → untagged explicit.stat_1778298516
+ *  staves → explicit.stat_1001829678 "(Staves)"
+ *  A blanket remap from jewels→staves broke Cobalt/Abyss jewel searches. Prefer the
+ *  trade-stat `(Staves)` qualifier via QUALIFIER_BY_ITEM_CLASS, and pin here when the
+ *  matcher still lands on the wrong twin (API order / missing qualifier). */
+export const STAFF_BLOCK_ATTACK_STAT = {
+  jewels: 'explicit.stat_1778298516',
+  staves: 'explicit.stat_1001829678',
+} as const
+
+const STAFF_BLOCK_ATTACK_IDS = new Set<string>([STAFF_BLOCK_ATTACK_STAT.jewels, STAFF_BLOCK_ATTACK_STAT.staves])
+
+export function resolveStaffBlockAttackStatId(statId: string, itemClass: string | undefined): string {
+  if (!STAFF_BLOCK_ATTACK_IDS.has(statId)) return statId
+  const isJewel = itemClass === 'Jewels' || itemClass === 'Abyss Jewels'
+  return isJewel ? STAFF_BLOCK_ATTACK_STAT.jewels : STAFF_BLOCK_ATTACK_STAT.staves
 }

--- a/src/main/trade/stat-matcher.test.ts
+++ b/src/main/trade/stat-matcher.test.ts
@@ -3156,6 +3156,64 @@ describe('matchItemMods', () => {
     })
   })
 
+  describe('PoE1 staff-block attack (jewels vs Staves)', () => {
+    // Live trade API: jewels use untagged stat_1778298516; staves use
+    // stat_1001829678 tagged "(Staves)". A former STAT_ID_REMAPS blanket always
+    // forced jewels→staves and empty-resulted Cobalt Jewel searches.
+    const STAFF_BLOCK_STATS = [
+      {
+        id: 'explicit.stat_1778298516',
+        text: '+#% Chance to Block Attack Damage while wielding a Staff',
+        type: 'explicit',
+      },
+      {
+        id: 'explicit.stat_1001829678',
+        text: '+#% Chance to Block Attack Damage while wielding a Staff (Staves)',
+        type: 'explicit',
+      },
+    ]
+
+    it('Cobalt Jewel keeps the untagged jewels trade id', () => {
+      _setStatEntriesForTests(STAFF_BLOCK_STATS)
+      const filters = matchItemMods(
+        ['+3% Chance to Block Attack Damage while wielding a Staff'],
+        [],
+        undefined,
+        makeItemInfo({ rarity: 'Magic', itemClass: 'Jewels', baseType: 'Cobalt Jewel' }),
+      )
+      const block = filters.find((f) => f.id === 'explicit.stat_1778298516')
+      expect(block).toBeDefined()
+      expect(block?.value).toBe(3)
+      expect(filters.find((f) => f.id === 'explicit.stat_1001829678')).toBeUndefined()
+    })
+
+    it('staff weapon prefers the (Staves) trade id', () => {
+      _setStatEntriesForTests(STAFF_BLOCK_STATS)
+      const filters = matchItemMods(
+        ['+18% Chance to Block Attack Damage while wielding a Staff'],
+        [],
+        undefined,
+        makeItemInfo({ rarity: 'Unique', itemClass: 'Staves', baseType: 'Judgement Staff' }),
+      )
+      const block = filters.find((f) => f.id === 'explicit.stat_1001829678')
+      expect(block).toBeDefined()
+      expect(block?.value).toBe(18)
+      expect(filters.find((f) => f.id === 'explicit.stat_1778298516')).toBeUndefined()
+    })
+
+    it('still picks jewels id when the staves entry is listed first', () => {
+      _setStatEntriesForTests([...STAFF_BLOCK_STATS].reverse())
+      const filters = matchItemMods(
+        ['+3% Chance to Block Attack Damage while wielding a Staff'],
+        [],
+        undefined,
+        makeItemInfo({ rarity: 'Magic', itemClass: 'Jewels', baseType: 'Cobalt Jewel' }),
+      )
+      expect(filters.find((f) => f.id === 'explicit.stat_1778298516')).toBeDefined()
+      expect(filters.find((f) => f.id === 'explicit.stat_1001829678')).toBeUndefined()
+    })
+  })
+
   // The PoE2 trade API disambiguates "#% increased Duration" with a trailing
   // category qualifier: "(Charm)", "(Flask)". The clipboard text on the item is
   // the bare "X% increased Duration", so the matcher has to strip the qualifier

--- a/src/main/trade/stat-matcher/item-classes.ts
+++ b/src/main/trade/stat-matcher/item-classes.ts
@@ -75,6 +75,11 @@ export const QUALIFIER_BY_ITEM_CLASS: Record<string, string> = {
   'Life Flasks': 'Flask',
   'Mana Flasks': 'Flask',
   Jewels: 'Jewel',
+  'Abyss Jewels': 'Jewel',
+  // PoE1 staff-block twin is tagged "(Staves)" on the trade API; prefer it for
+  // staves so unique staff searches don't land on the untagged jewel id.
+  Staves: 'Staves',
+  Warstaves: 'Staves',
   // A corrupted shield's "+#% Chance to Block" implicit is published only as
   // "+#% Chance to Block (Shields)" -- unlike the staff block implicit there is
   // no unqualified twin for the explicit-stat fallback to land on, so without

--- a/src/main/trade/stat-matcher/mod-matcher.ts
+++ b/src/main/trade/stat-matcher/mod-matcher.ts
@@ -169,7 +169,13 @@ function _matchModToStat(
           // Only the requested category's qualified entry is a candidate; entries
           // for other categories (e.g. "(Flask)" when matching a charm) are ignored
           // so they can't pollute the plain bucket once their qualifier is stripped.
-          if (qualifier === preferQualifier && (!qualifiedMatch || entry.text.length > qualifiedMatch._textLen))
+          // Compare case-insensitively so PoE1 "(Staves)" matches prefer "Staves"
+          // and PoE2 "(Jewel)" still matches prefer "Jewel".
+          if (
+            preferQualifier &&
+            qualifier.toLowerCase() === preferQualifier.toLowerCase() &&
+            (!qualifiedMatch || entry.text.length > qualifiedMatch._textLen)
+          )
             qualifiedMatch = result
         } else {
           if (!nonLocalMatch || entry.text.length > nonLocalMatch._textLen) nonLocalMatch = result

--- a/src/main/trade/stat-matcher/producers/explicits.ts
+++ b/src/main/trade/stat-matcher/producers/explicits.ts
@@ -5,6 +5,7 @@ import { BENEFICIAL_NEGATIVE_KEYWORDS } from '@shared/data/trade/beneficial-nega
 import { isClusterJewel } from '@shared/poe-item'
 import type { ModTier } from '@shared/data/tiers/types'
 import type { StatFilter } from '../../trade'
+import { resolveStaffBlockAttackStatId } from '../../stat-exceptions'
 import { findAdvMod } from '../adv-mods'
 import { computeValueBounds } from '../bounds'
 import { isDefenseMod, isLocalMod, isLowPriority } from '../classification'
@@ -254,6 +255,11 @@ export function processExplicits(ctx: MatchContext): StatFilter[] {
       if (matched.statId === 'explicit.stat_2582079000' && itemInfo?.itemClass !== 'Belts') {
         matched.statId = 'explicit.stat_554899692'
       }
+
+      // PoE1 staff-block: jewels use untagged stat_1778298516; staves use
+      // stat_1001829678 "(Staves)". Pin by item class so jewel searches aren't
+      // forced onto the staves id (and unique staves still get the Staves twin).
+      matched.statId = resolveStaffBlockAttackStatId(matched.statId, itemInfo?.itemClass)
 
       // Determine if this value is fixed or rolled, and capture tier/range for display
       // Fixed values (min === max in tier range, or no range) use exact match


### PR DESCRIPTION
## Summary
- PoE1 `+#% Chance to Block Attack Damage while wielding a Staff` has two trade IDs: untagged `stat_1778298516` (jewels) and `stat_1001829678` tagged `(Staves)`.
- Removes the blanket jewels→staves remap that made jewel price-checks return no listings.
- Prefers the `(Staves)` qualifier for Staves/Warstaves and pins by item class so jewels and staves each keep the correct ID.

## Test plan
- [ ] PoE1 Cobalt/Crimson/Abyss jewel with Block while Staff → search uses jewels id and finds listings
- [ ] Unique staff with the same mod text → search uses `(Staves)` id
- [ ] `npm test -- src/main/trade/stat-matcher.test.ts -t staff-block`
