### PR TITLE
fix(trade): pin Elder hybrid socketed-support levels

### DIFF
--- a/src/main/trade/clipboard.ts
+++ b/src/main/trade/clipboard.ts
@@ -1012,11 +1012,11 @@ function parseAdvancedMods(text: string): AdvancedMod[] {
       currentMod.lines.push(line)
 
       // Forbidden Shako-style rolling supports: when a "Socketed Gems are Supported by"
-      // line carries the "Unscalable Value" suffix, the trade API stores it under the
-      // explicit.indexable_support_* family rather than the regular explicit.stat_*
-      // family. Both share identical display text in the stat dictionary, so without
-      // this signal the matcher coin-flips between them.
-      if (/^Socketed Gems are Supported by Level/i.test(line) && /\bUnscalable Value\b/i.test(line)) {
+      // line carries a rolled Level N(min-max) bracket AND "Unscalable Value", the trade
+      // API stores it under explicit.indexable_support_* rather than explicit.stat_*.
+      // Elder hybrids also say "Unscalable Value" but have a fixed Level N with no
+      // bracket — those must stay on the craftable stat_* ids.
+      if (/^Socketed Gems are Supported by Level \d+\(/i.test(line) && /\bUnscalable Value\b/i.test(line)) {
         currentMod.randomSupport = true
       }
 

--- a/src/main/trade/stat-matcher.test.ts
+++ b/src/main/trade/stat-matcher.test.ts
@@ -4527,9 +4527,8 @@ describe('tier-aware default enablement (e2e via matchItemMods)', () => {
 
 describe('parseAdvancedMods (Forbidden Shako randomSupport detection)', () => {
   // Sanity: the clipboard parser must set randomSupport=true on advanced mod blocks
-  // whose lines start with "Socketed Gems are Supported by" AND carry the
-  // "Unscalable Value" suffix. This is the upstream fingerprint that drives the
-  // indexable_support routing in matchModToStat.
+  // whose support lines carry a rolled Level N(min-max) bracket AND "Unscalable Value".
+  // Fixed Elder hybrid supports (Level N — Unscalable Value, no bracket) must NOT be flagged.
 
   it('flags Forbidden Shako support mods with randomSupport=true', async () => {
     const { parseItemText } = await import('./clipboard')
@@ -4558,6 +4557,118 @@ Socketed Gems are Supported by Level 35(25-35) Bloodthirst(Greater Multiple Proj
     const attrMod = item?.advancedMods?.find((am) => am.lines.some((l) => /to all Attributes/.test(l)))
     expect(attrMod).toBeDefined()
     expect(attrMod?.randomSupport).toBeUndefined()
+  })
+
+  it('does not flag Elder hybrid fixed support levels as randomSupport', async () => {
+    const { parseItemText } = await import('./clipboard')
+    const text = `Item Class: Helmets
+Rarity: Rare
+Skull Crown
+Conqueror's Helmet
+--------
+Item Level: 85
+--------
+{ Prefix Modifier "The Elder's" (Tier: 1) }
+Socketed Gems are Supported by Level 20 Burning Damage — Unscalable Value
+35(31-35)% increased Burning Damage
+{ Suffix Modifier "of the Elder" (Tier: 4) }
+Socketed Gems are Supported by Level 16 Concentrated Effect — Unscalable Value
+15(12-14)% increased Area Damage
+`
+    const item = parseItemText(text)
+    expect(item).not.toBeNull()
+    const supportMods =
+      item?.advancedMods?.filter((am) => am.lines.some((l) => /Socketed Gems are Supported by/i.test(l))) ?? []
+    expect(supportMods.length).toBe(2)
+    expect(supportMods.every((m) => !m.randomSupport)).toBe(true)
+  })
+})
+
+describe('Elder hybrid socketed-support search values', () => {
+  // Companion "% increased" brackets must not rewrite the support Level N search min.
+  it('pins Burning / Concentrated support chips to Level N, not companion T# ranges', () => {
+    const BURN_SUPPORT = {
+      id: 'explicit.stat_elder_burn_support',
+      text: 'Socketed Gems are Supported by Level # Burning Damage',
+      type: 'explicit',
+    }
+    const BURN_INC = {
+      id: 'explicit.stat_elder_burn_inc',
+      text: '#% increased Burning Damage',
+      type: 'explicit',
+    }
+    const CONC_SUPPORT = {
+      id: 'explicit.stat_elder_conc_support',
+      text: 'Socketed Gems are Supported by Level # Concentrated Effect',
+      type: 'explicit',
+    }
+    const AREA_INC = {
+      id: 'explicit.stat_elder_area_inc',
+      text: '#% increased Area Damage',
+      type: 'explicit',
+    }
+    _setStatEntriesForTests([BURN_SUPPORT, BURN_INC, CONC_SUPPORT, AREA_INC])
+
+    const adv: AdvancedMod[] = [
+      {
+        type: 'prefix',
+        name: "The Elder's",
+        tier: 1,
+        tags: [],
+        lines: [
+          'Socketed Gems are Supported by Level 20 Burning Damage — Unscalable Value',
+          '35(31-35)% increased Burning Damage',
+        ],
+        ranges: [{ value: 35, min: 31, max: 35 }],
+      },
+      {
+        type: 'suffix',
+        name: 'of the Elder',
+        tier: 4,
+        tags: [],
+        lines: [
+          'Socketed Gems are Supported by Level 16 Concentrated Effect — Unscalable Value',
+          '15(12-14)% increased Area Damage',
+        ],
+        ranges: [{ value: 15, min: 12, max: 14 }],
+      },
+    ]
+
+    const filters = matchItemMods(
+      [
+        'Socketed Gems are Supported by Level 20 Burning Damage',
+        '35% increased Burning Damage',
+        'Socketed Gems are Supported by Level 16 Concentrated Effect',
+        '15% increased Area Damage',
+      ],
+      [],
+      undefined,
+      makeItemInfo({
+        rarity: 'Rare',
+        itemClass: 'Helmets',
+        baseType: "Conqueror's Helmet",
+        itemLevel: 85,
+      }),
+      adv,
+    )
+
+    const burn = filters.find((f) => f.id === BURN_SUPPORT.id)
+    expect(burn).toBeDefined()
+    expect(burn?.value).toBe(20)
+    expect(burn?.min).toBe(20)
+    expect(burn?.max).toBe(20)
+    expect(burn?.tierLadder).toBeUndefined()
+
+    const conc = filters.find((f) => f.id === CONC_SUPPORT.id)
+    expect(conc).toBeDefined()
+    expect(conc?.value).toBe(16)
+    expect(conc?.min).toBe(16)
+    expect(conc?.max).toBe(16)
+    expect(conc?.tierLadder).toBeUndefined()
+
+    // Companion % lines stay present but off by default (hybrid companion rule).
+    expect(filters.find((f) => f.id === BURN_INC.id)?.enabled).toBe(false)
+    expect(filters.find((f) => f.id === AREA_INC.id)?.enabled).toBe(false)
   })
 })
 

--- a/src/main/trade/stat-matcher/producers/explicits.ts
+++ b/src/main/trade/stat-matcher/producers/explicits.ts
@@ -19,6 +19,12 @@ import { accumulatePseudo, PSEUDO_CONTRIBUTIONS, type PseudoContribution } from 
 // Pin min=max=value for any mod whose cleaned text starts with "+N to Level of".
 export const GEM_LEVEL_MOD = /^\+\d+ to Level of /i
 
+/** Elder / influence hybrids: "Socketed Gems are Supported by Level N X" is a
+ *  fixed unscalable level that shares an advanced-mod block with a rolled
+ *  "% increased …" companion. The support line must keep Level N as its search
+ *  value — never inherit the companion's (min-max) bracket or T1 widening. */
+export const SOCKETED_SUPPORT_LEVEL_MOD = /^Socketed Gems are Supported by Level \d+/i
+
 // Tinctures: disambiguate duplicate stat texts (e.g. "#% increased effect" has two stat IDs)
 const TINCTURE_STAT_REMAP: Record<string, string> = {
   'explicit.stat_2448920197': 'explicit.stat_3529940209', // "#% increased effect" -> tincture-specific variant
@@ -296,16 +302,26 @@ export function processExplicits(ctx: MatchContext): StatFilter[] {
             : null
           if (normRange && normRange.min === normRange.max) isFixedValue = true
           if (!range && advMod.ranges.length === 0) isFixedValue = true
-          if (advMod.tier > 0) matchedTier = advMod.tier
-          if (normRange && normRange.min !== normRange.max) matchedRange = { min: normRange.min, max: normRange.max }
+          // Elder hybrid support lines: the shared AdvancedMod only carries the
+          // companion "% increased" (min-max) ranges. Level N must stay a fixed
+          // search value — never inherit sibling brackets / T1 widening (that made
+          // Burning support search min=31 from T1 31-35, Concentrated Level 16
+          // search min=14 via 90% floor). Also ignore a coincidental value match
+          // (Level 16 + 16% Area Damage sharing the same AdvancedMod.ranges entry).
+          if (SOCKETED_SUPPORT_LEVEL_MOD.test(cleaned)) {
+            isFixedValue = true
+          } else {
+            if (advMod.tier > 0) matchedTier = advMod.tier
+            if (normRange && normRange.min !== normRange.max) matchedRange = { min: normRange.min, max: normRange.max }
+            // Capture the full per-stat ranges and mod name for tier-ladder resolution.
+            advModRanges = advMod.ranges
+            advModName = advMod.name
+            advModMult = advMod.magnitudeMultiplier
+          }
           if (normRange && itemInfo?.rarity === 'Unique' && matched.value != null) {
             perfectRoll =
               normRange.min === normRange.max ? matched.value > normRange.max : matched.value >= normRange.max
           }
-          // Capture the full per-stat ranges and mod name for tier-ladder resolution.
-          advModRanges = advMod.ranges
-          advModName = advMod.name
-          advModMult = advMod.magnitudeMultiplier
         }
       }
       // For negative values: "reduced" mods use min (trade API expects min for beneficial reduction),
@@ -398,6 +414,12 @@ export function processExplicits(ctx: MatchContext): StatFilter[] {
       // with strictly-better pricier listings. Placed after T1 widening so T1 logic
       // cannot undo the exact pin.
       if (GEM_LEVEL_MOD.test(cleaned) && matched.value != null) {
+        minValue = matched.value
+        maxValue = matched.value
+      }
+      // Same pin for "Socketed Gems are Supported by Level N …" (Elder hybrids etc.).
+      // Support level is discrete/fixed; T1 companion widening must not rewrite it.
+      if (SOCKETED_SUPPORT_LEVEL_MOD.test(cleaned) && matched.value != null) {
         minValue = matched.value
         maxValue = matched.value
       }


### PR DESCRIPTION
## Summary
- Elder/influence hybrid mods share one advanced-mod block: fixed `Socketed Gems are Supported by Level N …` plus a rolled `% increased` companion.
- Support chips were inheriting the companion’s `(min-max)` / T1 ladder, so searches used values like **31** / **14** instead of Levels **20** / **16** and returned no listings.
- Pins support-level chips to `min = max = Level N`, and only flags Forbidden Shako `randomSupport` when the level has a rolled `N(min-max)` bracket.

## Test plan
- [ ] PoE1 Elder helmet with Burning Damage + Concentrated Effect hybrids → support chips search Level 20 and Level 16
- [ ] Companion `% increased` chips remain off by default
- [ ] Forbidden Shako still routes rolled supports via `indexable_support_*`
- [ ] `npm test -- src/main/trade/stat-matcher.test.ts -t "Elder hybrid|randomSupport"`
