### PR TITLE
fix(trade): match synthesis implicits with hidden chance + fixed duration

### DIFF
--- a/src/main/trade/stat-matcher.test.ts
+++ b/src/main/trade/stat-matcher.test.ts
@@ -3906,6 +3906,24 @@ describe('matchModToStat (Unscalable Value prefix/suffix fallback)', () => {
     expect(result?.value).toBeNull()
   })
 
+  it('matches synthesis Intimidate-on-hit when the trade text keeps a fixed duration digit', () => {
+    // Clipboard: "Intimidate Enemies for 4 seconds on Hit with Attacks"
+    // Trade:     "#% chance to Intimidate Enemies for 4 seconds on Hit with Attacks"
+    // Digits must be stripped on both sides or the leftover "4" on the stat
+    // breaks endsWith and the synthesised implicit chip never appears.
+    _setStatEntriesForTests([
+      {
+        id: 'implicit.stat_3438201750',
+        text: '#% chance to Intimidate Enemies for 4 seconds on Hit with Attacks',
+        type: 'implicit',
+      },
+    ])
+    const result = matchModToStat('Intimidate Enemies for 4 seconds on Hit with Attacks', false, 'implicit')
+    expect(result).not.toBeNull()
+    expect(result?.statId).toBe('implicit.stat_3438201750')
+    expect(result?.value).toBeNull()
+  })
+
   it('still matches when clipboard text is the leading portion of the stat (existing prefix case)', () => {
     _setStatEntriesForTests([
       { id: 'explicit.stat_xxx', text: 'Bladefall deals extra Damage by #% of their value', type: 'explicit' },

--- a/src/main/trade/stat-matcher/mod-matcher.ts
+++ b/src/main/trade/stat-matcher/mod-matcher.ts
@@ -269,12 +269,7 @@ function _matchModToStat(
       if (BLOCKED_STAT_IDS.has(entry.id)) continue
       if (preferIndexableSupport ? !INDEXABLE_SUPPORT_RE.test(entry.id) : INDEXABLE_SUPPORT_RE.test(entry.id)) continue
       if (entry.text.includes('(Local)')) continue
-      const statPlain = entry.text
-        .replace(/#/g, '')
-        .replace(/\d+/g, '')
-        .replace(/\s+/g, ' ')
-        .trim()
-        .toLowerCase()
+      const statPlain = entry.text.replace(/#/g, '').replace(/\d+/g, '').replace(/\s+/g, ' ').trim().toLowerCase()
       const variantPlain = variant.replace(/\d+/g, '').replace(/\s+/g, ' ').trim().toLowerCase()
       if (variantPlain.length <= 10) continue
       // The chunk this fallback lets the clipboard hide is always an unscalable

--- a/src/main/trade/stat-matcher/mod-matcher.ts
+++ b/src/main/trade/stat-matcher/mod-matcher.ts
@@ -257,6 +257,11 @@ function _matchModToStat(
   //            "#% chance to gain Alchemist's Genius when you use a Flask" ("of the
   //            Essence" belt suffix has a hidden 100% chance, so the clipboard drops
   //            the leading "#% chance to ")
+  // Digits are stripped on BOTH sides: synthesis implicits like
+  // "Intimidate Enemies for 4 seconds on Hit with Attacks" hide the 100% chance
+  // but keep a fixed "4" in display text, while the trade stat keeps both
+  // "#% chance to" and that same "4". Stripping only the clipboard left the
+  // hardcoded duration digit on the stat side and broke endsWith.
   for (const variant of textVariants) {
     let bestMatch: { statId: string; value: number | null; aggregated?: boolean; _textLen: number } | null = null
     for (const entry of statEntries) {
@@ -264,7 +269,12 @@ function _matchModToStat(
       if (BLOCKED_STAT_IDS.has(entry.id)) continue
       if (preferIndexableSupport ? !INDEXABLE_SUPPORT_RE.test(entry.id) : INDEXABLE_SUPPORT_RE.test(entry.id)) continue
       if (entry.text.includes('(Local)')) continue
-      const statPlain = entry.text.replace(/#/g, '').replace(/\s+/g, ' ').trim().toLowerCase()
+      const statPlain = entry.text
+        .replace(/#/g, '')
+        .replace(/\d+/g, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .toLowerCase()
       const variantPlain = variant.replace(/\d+/g, '').replace(/\s+/g, ' ').trim().toLowerCase()
       if (variantPlain.length <= 10) continue
       // The chunk this fallback lets the clipboard hide is always an unscalable


### PR DESCRIPTION
## Summary
- PoE1 synthesis implicits like `Intimidate Enemies for 4 seconds on Hit with Attacks` hide the unscalable `#% chance to` prefix on the clipboard but keep a fixed duration digit (`4`).
- Trade indexes them as `#% chance to Intimidate Enemies for 4 seconds on Hit with Attacks`.
- The unscalable-value fallback already stripped digits from the clipboard side only, so `endsWith` failed on the leftover `4` and the implicit chip never appeared.
- Strip digits from **both** clipboard and trade text in that fallback so these mods resolve to the correct presence-only trade id (`implicit.stat_3438201750` for Intimidate).

## Test plan
- [x] Unit test: synthesis Intimidate clipboard line matches `implicit.stat_3438201750` with `value: null`
- [x] Existing unscalable prefix/suffix cases still pass (Alchemist's Genius, Bladefall)
- [ ] Price-check a synthesised ring with Intimidate-on-hit-with-Attacks and confirm the purple implicit chip appears enabled
- [ ] Search with only that chip: presence-only query (empty min/max). Note: sparse market + online-only status may still show 0 listings even when matching is correct

Made with [Cursor](https://cursor.com)