### PR TITLE
fix(trade): stop Stygian Abyssal Socket matching Has 1 Socket

### DIFF
--- a/src/main/trade/stat-matcher.test.ts
+++ b/src/main/trade/stat-matcher.test.ts
@@ -362,6 +362,30 @@ describe('matchItemMods', () => {
       expect(abyssChip).toBeDefined()
       expect(abyssChip?.value).toBe(1)
     })
+
+    it('Stygian Vise: keeps Abyssal Sockets chip and does not emit Has 1 Socket', () => {
+      // Clipboard singular "Has 1 Abyssal Socket" must not resolve to trade
+      // "Has 1 Socket" (stat_4077843608) — that id is for other bases and zeros
+      // Stygian Vise searches. Socket producer owns the abyss chip.
+      _setStatEntriesForTests([
+        { id: 'implicit.stat_4077843608', text: 'Has 1 Socket', type: 'implicit' },
+        { id: 'implicit.stat_3527617737', text: 'Has # Abyssal Sockets', type: 'implicit' },
+      ])
+      const filters = matchItemMods([], ['Has 1 Abyssal Socket'], undefined, {
+        ...makeItemInfo({
+          sockets: 'A',
+          linkedSockets: 0,
+          itemClass: 'Belts',
+          baseType: 'Stygian Vise',
+          rarity: 'Rare',
+        }),
+      })
+      expect(filters.filter((f) => f.id === 'implicit.stat_4077843608')).toHaveLength(0)
+      const abyss = filters.filter((f) => f.id === 'implicit.stat_3527617737')
+      expect(abyss).toHaveLength(1)
+      expect(abyss[0]?.value).toBe(1)
+      expect(abyss[0]?.text).toBe('Abyssal Sockets')
+    })
   })
 
   describe('misc filters', () => {
@@ -1749,6 +1773,26 @@ describe('matchItemMods', () => {
       )
       const res = filters.find((f) => f.id === 'implicit.stat_3372524247')
       expect(res?.value).toBe(12)
+    })
+  })
+
+  describe('abyssal sockets (singular clipboard vs plural trade text)', () => {
+    // PoE1 trade stores "Has # Abyssal Sockets"; Stygian Vise clipboard prints
+    // "Has 1 Abyssal Socket". Without a singular->plural variant the match used to
+    // fall through to relaxed "Has 1 Socket" and break Stygian searches.
+    it('matches Has 1 Abyssal Socket to Has # Abyssal Sockets, not Has 1 Socket', () => {
+      _setStatEntriesForTests([
+        { id: 'implicit.stat_4077843608', text: 'Has 1 Socket', type: 'implicit' },
+        { id: 'implicit.stat_3527617737', text: 'Has # Abyssal Sockets', type: 'implicit' },
+      ])
+      const result = matchModToStat('Has 1 Abyssal Socket', false, 'implicit')
+      expect(result?.statId).toBe('implicit.stat_3527617737')
+      expect(result?.value).toBe(1)
+    })
+
+    it('relaxed Has 1 Socket does not swallow Has 1 Abyssal Socket', () => {
+      _setStatEntriesForTests([{ id: 'implicit.stat_4077843608', text: 'Has 1 Socket', type: 'implicit' }])
+      expect(matchModToStat('Has 1 Abyssal Socket', false, 'implicit')).toBeNull()
     })
   })
 

--- a/src/main/trade/stat-matcher/pattern.ts
+++ b/src/main/trade/stat-matcher/pattern.ts
@@ -24,8 +24,10 @@ function statTextToRelaxedPattern(text: string): RegExp {
   // Same whitespace normalization as statTextToPattern -- see that function for details.
   const normalized = text.replace(/\s+/g, ' ')
   let escaped = normalized.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/#/g, '(.+?)')
-  // Replace hardcoded numbers (e.g. "50%", "20") with capture groups
-  escaped = escaped.replace(/\d+(?:\\\.\d+)?/g, '(.+?)')
+  // Replace hardcoded numbers (e.g. "50%", "20") with numeric capture groups only.
+  // Using (.+?) here let "Has 1 Socket" match "Has 1 Abyssal Socket" by swallowing
+  // "1 Abyssal" -- wrong trade id for Stygian Vise and zero results.
+  escaped = escaped.replace(/\d+(?:\\\.\d+)?/g, '(\\d+(?:\\.\\d+)?)')
   return new RegExp(`^${escaped}$`, 'i')
 }
 

--- a/src/main/trade/stat-matcher/producers/implicits.ts
+++ b/src/main/trade/stat-matcher/producers/implicits.ts
@@ -17,6 +17,12 @@ export function processImplicits(ctx: MatchContext): StatFilter[] {
 
   for (const mod of implicits) {
     let cleaned = mod.replace(/\s*\(implicit\)\s*$/i, '').trim()
+    // Stygian Vise / abyss belts: clipboard prints "Has 1 Abyssal Socket" but the trade
+    // API indexes "Has # Abyssal Sockets". buildSocketFilters already emits the correct
+    // chip from the socket string (A). Matching this line here used to fall through to
+    // relaxed "Has 1 Socket" (implicit.stat_4077843608), which is incompatible with
+    // Stygian Vise and zeroes the search.
+    if (/^Has \d+ Abyssal Sockets?$/i.test(cleaned)) continue
     // Try implicit stats first, then fall back to explicit (non-local, then local) and remap the ID
     const matched =
       matchModToStat(cleaned, false, 'implicit', false, preferQualifier) ??

--- a/src/main/trade/stat-matcher/text-variants.ts
+++ b/src/main/trade/stat-matcher/text-variants.ts
@@ -113,6 +113,9 @@ function generateTextVariants(text: string): string[] {
     // Trade API stores the singular "Has # Charm Slot" / "# Charm Slot"; an item
     // with 2+ slots reads "Charm Slots", so without this it never matches.
     [/Charm Slots/gi, 'Charm Slot'],
+    // Inverse of Sockets->Socket below: trade stores "Has # Abyssal Sockets" (always
+    // plural) while a single-socket Stygian Vise clipboard reads "Has 1 Abyssal Socket".
+    [/Abyssal Socket(?!s)\b/gi, 'Abyssal Sockets'],
     // Tablet implicits ("Adds Abysses to a Map \n# use remaining") are stored
     // singular by the trade API, but a multi-use tablet's clipboard reads
     // "10 uses remaining" -- without this the plural form never matches and the


### PR DESCRIPTION
## Summary
- PoE1 Stygian Vise clipboard prints `Has 1 Abyssal Socket` (singular), while trade indexes `Has # Abyssal Sockets`.
- That mismatch made the unscalable/relaxed path match `Has 1 Socket` (`implicit.stat_4077843608`), which is incompatible with Stygian Vise and returned zero listings — while a duplicate correct `Abyssal Sockets` chip was already present from the socket producer.
- Fix: pluralize `Abyssal Socket` → `Abyssal Sockets` in text variants; keep relaxed hardcoded-number wildcards numeric-only; skip `Has N Abyssal Socket(s)` in `processImplicits` because `buildSocketFilters` already emits the correct chip.

## Test plan
- [x] Unit: `Has 1 Abyssal Socket` → `implicit.stat_3527617737` value 1
- [x] Unit: relaxed `Has 1 Socket` alone does not match `Has 1 Abyssal Socket`
- [x] e2e via `matchItemMods`: Stygian with abyss socket + implicit line keeps one Abyssal Sockets chip, no `Has 1 Socket`
- [ ] Price-check a Stygian Vise: only one abyss row; search no longer zeroed by `Has 1 Socket`

Made with [Cursor](https://cursor.com)