### PR TITLE
fix(trade): exclude minion resists from Total Elemental Resistance

### DIFF
--- a/src/main/trade/stat-matcher.test.ts
+++ b/src/main/trade/stat-matcher.test.ts
@@ -3016,6 +3016,56 @@ describe('matchItemMods', () => {
     })
   })
 
+  describe('minion resistance excluded from resistance pseudo', () => {
+    // Bone Ring / minion gear: "Minions have +#% to all Elemental Resistances"
+    // must not create a player Total Ele Res chip ((15+22)×3 = 111 false positive).
+    it('minion all-ele-res does not feed Total Elemental Resistance', () => {
+      _setStatEntriesForTests([
+        {
+          id: 'implicit.stat_minion_allres',
+          text: 'Minions have #% to all Elemental Resistances',
+          type: 'implicit',
+        },
+        {
+          id: 'explicit.stat_minion_allres',
+          text: 'Minions have #% to all Elemental Resistances',
+          type: 'explicit',
+        },
+        { id: 'explicit.stat_4220027924', text: '#% to Cold Resistance', type: 'explicit' },
+      ])
+      const filters = matchItemMods(
+        ['Minions have +22% to all Elemental Resistances', '+30% to Cold Resistance'],
+        ['Minions have +15% to all Elemental Resistances'],
+        undefined,
+        makeItemInfo({ rarity: 'Rare', itemClass: 'Rings', baseType: 'Bone Ring' }),
+      )
+      const pseudo = filters.find((f) => f.id === 'pseudo.pseudo_total_elemental_resistance')
+      expect(pseudo?.value).toBe(30)
+    })
+
+    it('Bone Ring with only minion resists emits no Total Elemental Resistance chip', () => {
+      _setStatEntriesForTests([
+        {
+          id: 'implicit.stat_minion_allres',
+          text: 'Minions have #% to all Elemental Resistances',
+          type: 'implicit',
+        },
+        {
+          id: 'explicit.stat_minion_allres',
+          text: 'Minions have #% to all Elemental Resistances',
+          type: 'explicit',
+        },
+      ])
+      const filters = matchItemMods(
+        ['Minions have +22% to all Elemental Resistances'],
+        ['Minions have +15% to all Elemental Resistances'],
+        undefined,
+        makeItemInfo({ rarity: 'Rare', itemClass: 'Rings', baseType: 'Bone Ring' }),
+      )
+      expect(filters.find((f) => f.id === 'pseudo.pseudo_total_elemental_resistance')).toBeUndefined()
+    })
+  })
+
   describe('fractured chip', () => {
     it('generates fractured chip for equipment in "any" state when no fractured mods', () => {
       const filters = matchItemMods(

--- a/src/main/trade/stat-matcher/pseudo.ts
+++ b/src/main/trade/stat-matcher/pseudo.ts
@@ -35,7 +35,7 @@ export const PSEUDO_CONTRIBUTIONS: Record<string, PseudoContribution[]> = {}
 // pseudoId -> the full universe of contributing real stat ids (deduped). The
 // trade2 weight group sums these at the implicit default weight of 1, so only the
 // ids matter here; the per-stat multiplier stays in PSEUDO_CONTRIBUTIONS for the
-// accumulator total. Built in buildPseudoMap(), cleared by resetPseudoMap().
+// accumulator total. Built in buildPseudoMap(), cleared by _resetPseudoMap().
 export const PSEUDO_WEIGHT_GROUPS: Record<string, Array<{ id: string }>> = {}
 
 function buildPseudoMap(): void {
@@ -172,6 +172,14 @@ function buildPseudoMap(): void {
     // the negative value into the player's Total Elemental Resistance pseudo.
     // Exposure mods never feed any player pseudo, so skip them outright.
     if (/\bExposure\b/i.test(entry.text)) continue
+    // "Minions have +#% to all Elemental Resistances" (and totems/allies/etc.)
+    // is likewise not player resistance. Bone Rings and other minion gear were
+    // folding those rolls into Total Elemental Resistance (e.g. 37 all-res × 3).
+    if (
+      /\b(?:Minions?|Totems?|Spectres?|Allies|Companions?)\b/i.test(entry.text) &&
+      /\bResistances?\b/i.test(entry.text)
+    )
+      continue
     for (const [pattern, pseudoId, pseudoLabel, multiplier, opts] of pseudoMappings) {
       if (pattern.test(entry.text)) {
         if (!PSEUDO_CONTRIBUTIONS[entry.id]) PSEUDO_CONTRIBUTIONS[entry.id] = []
@@ -239,17 +247,14 @@ export function accumulatePseudo(
  *  trade API fetch) well after createOverlayWindow sets the version at startup, so
  *  the first build always sees the correct game. If startup ordering ever changes
  *  so stats can be present before setPoeVersion runs, gate this on the version
- *  being known, or resetPseudoMap once it is. */
+ *  being known, or _resetPseudoMap once it is. */
 export function ensurePseudoMapBuilt(): void {
   if (Object.keys(PSEUDO_CONTRIBUTIONS).length === 0 && getStatEntries().length > 0) buildPseudoMap()
 }
 
 /** Clear the pseudo contributions map. Called by the test hook in index.ts so
  *  each test rebuilds from its own seeded entries. */
-export function resetPseudoMap(): void {
+export function _resetPseudoMap(): void {
   for (const k of Object.keys(PSEUDO_CONTRIBUTIONS)) delete PSEUDO_CONTRIBUTIONS[k]
   for (const k of Object.keys(PSEUDO_WEIGHT_GROUPS)) delete PSEUDO_WEIGHT_GROUPS[k]
 }
-
-/** @deprecated Use resetPseudoMap instead. Kept for test compatibility. */
-export const _resetPseudoMap = resetPseudoMap

--- a/src/main/trade/stat-matcher/pseudo.ts
+++ b/src/main/trade/stat-matcher/pseudo.ts
@@ -35,7 +35,7 @@ export const PSEUDO_CONTRIBUTIONS: Record<string, PseudoContribution[]> = {}
 // pseudoId -> the full universe of contributing real stat ids (deduped). The
 // trade2 weight group sums these at the implicit default weight of 1, so only the
 // ids matter here; the per-stat multiplier stays in PSEUDO_CONTRIBUTIONS for the
-// accumulator total. Built in buildPseudoMap(), cleared by _resetPseudoMap().
+// accumulator total. Built in buildPseudoMap(), cleared by resetPseudoMap().
 export const PSEUDO_WEIGHT_GROUPS: Record<string, Array<{ id: string }>> = {}
 
 function buildPseudoMap(): void {
@@ -247,14 +247,17 @@ export function accumulatePseudo(
  *  trade API fetch) well after createOverlayWindow sets the version at startup, so
  *  the first build always sees the correct game. If startup ordering ever changes
  *  so stats can be present before setPoeVersion runs, gate this on the version
- *  being known, or _resetPseudoMap once it is. */
+ *  being known, or resetPseudoMap once it is. */
 export function ensurePseudoMapBuilt(): void {
   if (Object.keys(PSEUDO_CONTRIBUTIONS).length === 0 && getStatEntries().length > 0) buildPseudoMap()
 }
 
 /** Clear the pseudo contributions map. Called by the test hook in index.ts so
  *  each test rebuilds from its own seeded entries. */
-export function _resetPseudoMap(): void {
+export function resetPseudoMap(): void {
   for (const k of Object.keys(PSEUDO_CONTRIBUTIONS)) delete PSEUDO_CONTRIBUTIONS[k]
   for (const k of Object.keys(PSEUDO_WEIGHT_GROUPS)) delete PSEUDO_WEIGHT_GROUPS[k]
 }
+
+/** @deprecated Use resetPseudoMap instead. Kept for test compatibility. */
+export const _resetPseudoMap = resetPseudoMap


### PR DESCRIPTION
## Summary
- Loose `/to all elemental resistances/i` (and single-element) pseudo patterns also matched `Minions have +#% to all Elemental Resistances`.
- Bone Rings with only minion res showed a fake **Total Elemental Resistance** chip (e.g. `(15+22)×3 = 111`) even with no player resists.
- Skip minion/totem/spectre/ally/companion resistance stats when building the pseudo map (same approach as Exposure exclusion).

## Test plan
- [x] Unit: minion all-res + player cold res → Total Ele Res = cold only
- [x] Unit: Bone Ring with only minion resists → no Total Ele Res chip
- [ ] Price-check a Bone Ring with only minion resists: no Total Elemental Resistance row

Made with [Cursor](https://cursor.com)