### PR TITLE
feat: add Scarab Atlas calculator for PoE1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "ninjaLeagues": {
     "poe1": {
-      "Mirage": "mirage",
-      "Hardcore Mirage": "miragehc",
+      "Allflame": "allflame",
+      "Hardcore Allflame": "allflamehc",
       "Standard": "standard",
       "Hardcore": "hardcore"
     },

--- a/messages/de.json
+++ b/messages/de.json
@@ -11,6 +11,7 @@
   "feature_price_checker": "Preisprüfer",
   "feature_dust_explorer": "Staub-Explorer",
   "feature_div_card_explorer": "Div-Karten-Explorer",
+  "feature_scarab_atlas": "Skarabäus-Atlas",
   "feature_regex_tool": "Regex-Werkzeug",
   "feature_extra_features": "Extra-Funktionen",
   "settings_title": "Einstellungen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -11,6 +11,7 @@
   "feature_price_checker": "Price Checker",
   "feature_dust_explorer": "Dust Explorer",
   "feature_div_card_explorer": "Div Card Explorer",
+  "feature_scarab_atlas": "Scarab Atlas",
   "feature_regex_tool": "Regex Tool",
   "feature_extra_features": "Extra Features",
   "settings_title": "Settings",

--- a/messages/es.json
+++ b/messages/es.json
@@ -11,6 +11,7 @@
   "feature_price_checker": "Verificador de precios",
   "feature_dust_explorer": "Explorador de polvo",
   "feature_div_card_explorer": "Explorador de cartas div",
+  "feature_scarab_atlas": "Atlas de escarabajos",
   "feature_regex_tool": "Herramienta de regex",
   "feature_extra_features": "Funciones extra",
   "settings_title": "Ajustes",

--- a/scripts/generate-scarab-catalog.mjs
+++ b/scripts/generate-scarab-catalog.mjs
@@ -1,0 +1,230 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..')
+const detailsPath = path.join(root, '..', 'scarab-details.json')
+const densePath = path.join(root, '..', 'dense-allflame.json')
+const outPath = path.join(
+  root,
+  'src',
+  'renderer',
+  'src',
+  'features',
+  'scarab-atlas',
+  'scarab-catalog.json',
+)
+
+const CATEGORY_META = {
+  horned: { name: 'Horned', atlasModifier: 'none', investmentBoost: false },
+  divination: { name: 'Divination', atlasModifier: 'boostable', investmentBoost: false },
+  ultimatum: { name: 'Ultimatum', atlasModifier: 'blockable', investmentBoost: true },
+  harvest: { name: 'Harvest', atlasModifier: 'blockable', investmentBoost: true },
+  trarthan: { name: 'Trarthan', atlasModifier: 'blockable', investmentBoost: true },
+  ambush: { name: 'Ambush', atlasModifier: 'boostable', investmentBoost: false },
+  cartography: { name: 'Cartography', atlasModifier: 'boostable', investmentBoost: false },
+  kalguuran: { name: 'Kalguuran', atlasModifier: 'blockable', investmentBoost: true },
+  breach: { name: 'Breach', atlasModifier: 'blockable', investmentBoost: true },
+  misc: { name: 'Miscellaneous', atlasModifier: 'none', investmentBoost: false },
+  domination: { name: 'Domination', atlasModifier: 'boostable', investmentBoost: false },
+  essence: { name: 'Essence', atlasModifier: 'boostable', investmentBoost: false },
+  legion: { name: 'Legion', atlasModifier: 'blockable', investmentBoost: true },
+  bestiary: { name: 'Bestiary', atlasModifier: 'none', investmentBoost: true },
+  delirium: { name: 'Delirium', atlasModifier: 'blockable', investmentBoost: true },
+  ritual: { name: 'Ritual', atlasModifier: 'blockable', investmentBoost: true },
+  abyss: { name: 'Abyss', atlasModifier: 'blockable', investmentBoost: true },
+  blight: { name: 'Blight', atlasModifier: 'blockable', investmentBoost: true },
+  titanic: { name: 'Titanic', atlasModifier: 'boostable', investmentBoost: false },
+  sulphite: { name: 'Sulphite', atlasModifier: 'none', investmentBoost: false },
+  anarchy: { name: 'Anarchy', atlasModifier: 'boostable', investmentBoost: false },
+  influencing: { name: 'Influencing', atlasModifier: 'blockable', investmentBoost: true },
+  betrayal: { name: 'Betrayal', atlasModifier: 'blockable', investmentBoost: true },
+  incursion: { name: 'Incursion', atlasModifier: 'blockable', investmentBoost: true },
+  torment: { name: 'Torment', atlasModifier: 'boostable', investmentBoost: false },
+  beyond: { name: 'Beyond', atlasModifier: 'boostable', investmentBoost: false },
+  expedition: { name: 'Expedition', atlasModifier: 'blockable', investmentBoost: true },
+  harbinger: { name: 'Harbinger', atlasModifier: 'boostable', investmentBoost: false },
+}
+
+const VENDOR_CATEGORY_ORDER = [
+  'titanic',
+  'sulphite',
+  'divination',
+  'anarchy',
+  'ritual',
+  'harvest',
+  'kalguuran',
+  'influencing',
+  'bestiary',
+  'trarthan',
+  'betrayal',
+  'incursion',
+  'domination',
+  'torment',
+  'cartography',
+  'beyond',
+  'ambush',
+  'ultimatum',
+  'expedition',
+  'delirium',
+  'legion',
+  'blight',
+  'abyss',
+  'essence',
+  'breach',
+  'misc',
+  'horned',
+]
+
+const PREFIXES = [
+  'Horned',
+  'Divination',
+  'Ultimatum',
+  'Harvest',
+  'Ambush',
+  'Cartography',
+  'Kalguuran',
+  'Breach',
+  'Domination',
+  'Essence',
+  'Legion',
+  'Bestiary',
+  'Delirium',
+  'Ritual',
+  'Abyss',
+  'Blight',
+  'Titanic',
+  'Harbinger',
+  'Beyond',
+  'Torment',
+  'Anarchy',
+  'Betrayal',
+  'Expedition',
+  'Incursion',
+  'Influencing',
+  'Sulphite',
+  'Reliquary',
+  'Trarthan',
+]
+
+function categoryIdForName(name) {
+  for (const p of PREFIXES) {
+    if (name === `${p} Scarab` || name.startsWith(`${p} Scarab`) || name.startsWith(`${p} `)) {
+      return p.toLowerCase()
+    }
+  }
+  return 'misc'
+}
+
+function assignSignatures(scarabs) {
+  const lowerNames = scarabs.map((s) => s.name.toLowerCase())
+  for (const scarab of scarabs) {
+    const candidates = []
+    const ofMatch = scarab.name.match(/ of (.+)$/i)
+    if (ofMatch) candidates.push(ofMatch[1])
+    for (const word of scarab.name.split(/\s+/)) {
+      if (!/^(scarab|of|the|a)$/i.test(word)) candidates.push(word)
+    }
+    candidates.push(scarab.name.replace(/ Scarab$/i, '').replace(/^Scarab of /i, ''))
+    candidates.sort((a, b) => a.length - b.length)
+
+    let sig = null
+    for (const c of candidates) {
+      const cl = c.toLowerCase()
+      if (cl.length < 2) continue
+      if (lowerNames.filter((n) => n.includes(cl)).length === 1) {
+        sig = c
+        break
+      }
+    }
+    if (!sig) {
+      const lower = scarab.name.toLowerCase()
+      outer: for (let len = 3; len <= lower.length; len++) {
+        for (let i = 0; i <= lower.length - len; i++) {
+          const sub = lower.slice(i, i + len)
+          if (lowerNames.filter((n) => n.includes(sub)).length === 1) {
+            sig = scarab.name.slice(i, i + len)
+            break outer
+          }
+        }
+      }
+    }
+    scarab.signature = sig || scarab.name
+  }
+}
+
+const details = JSON.parse(fs.readFileSync(detailsPath, 'utf8'))
+const byName = new Map(details.map((d) => [d.name, d]))
+
+if (fs.existsSync(densePath)) {
+  const dense = JSON.parse(fs.readFileSync(densePath, 'utf8'))
+  const scarabOverview = (dense.itemOverviews || []).find((o) => o.type === 'Scarab')
+  for (const line of scarabOverview?.lines || []) {
+    if (!byName.has(line.name)) {
+      byName.set(line.name, {
+        name: line.name,
+        id: line.name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-|-$/g, ''),
+        dropWeight: null,
+        limit: null,
+      })
+    }
+  }
+}
+
+const scarabs = [...byName.values()].map((d) => ({
+  id: d.id,
+  name: d.name,
+  weight: typeof d.dropWeight === 'number' ? d.dropWeight : 0,
+  categoryId: categoryIdForName(d.name),
+  signature: '',
+  limit: d.limit ?? null,
+}))
+
+assignSignatures(scarabs)
+
+const byCat = new Map()
+for (const s of scarabs) {
+  if (!byCat.has(s.categoryId)) byCat.set(s.categoryId, [])
+  byCat.get(s.categoryId).push({
+    id: s.id,
+    name: s.name,
+    weight: s.weight,
+    signature: s.signature,
+    limit: s.limit,
+  })
+}
+
+const order = [...VENDOR_CATEGORY_ORDER]
+for (const id of byCat.keys()) {
+  if (!order.includes(id)) order.push(id)
+}
+
+const categories = order
+  .filter((id) => byCat.has(id))
+  .map((id) => {
+    const meta = CATEGORY_META[id] || {
+      name: id.charAt(0).toUpperCase() + id.slice(1),
+      atlasModifier: 'none',
+      investmentBoost: false,
+    }
+    return {
+      id,
+      name: meta.name,
+      atlasModifier: meta.atlasModifier,
+      investmentBoost: meta.investmentBoost,
+      scarabs: byCat.get(id).sort((a, b) => a.name.localeCompare(b.name)),
+    }
+  })
+
+const catalog = {
+  version: 1,
+  vendorCategoryOrder: VENDOR_CATEGORY_ORDER,
+  categories,
+}
+
+fs.mkdirSync(path.dirname(outPath), { recursive: true })
+fs.writeFileSync(outPath, JSON.stringify(catalog, null, 2) + '\n')
+console.log('Wrote', outPath, 'scarabs', scarabs.length, 'categories', categories.length)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -318,6 +318,7 @@ app.whenReady().then(() => {
     openSettings: 'setup',
     openDust: 'dust',
     openDivCards: 'divcards',
+    openScarabs: 'scarabs',
     openRegex: 'regex',
   }
   const pasteRegexToSearch = (regex: string): void => {

--- a/src/renderer/src/features/scarab-atlas/ScarabAtlas.tsx
+++ b/src/renderer/src/features/scarab-atlas/ScarabAtlas.tsx
@@ -1,0 +1,576 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import itemIcons from '@shared/data/items/item-icons-poe1.json'
+import { Button } from '../../components/primitives/Button'
+import { Toggle } from '../../components/Toggle'
+import { IconGlow } from '../../shared/IconGlow'
+import { zebraRowBg } from '../../shared/utils'
+import catalogJson from './scarab-catalog.json'
+import type { ScarabCategory } from './types'
+import {
+  buildVendorSearchString,
+  calculateCategoryEV,
+  calculateOptimalStrategy,
+  calculatePoolEV,
+  formatChaos,
+  getEffectivePrice,
+  getEffectiveWeight,
+  loadState,
+  saveState,
+  shortenScarabName,
+  toggleInList,
+} from './calc'
+import type { ScarabCalcState, ScarabCatalog, TabId } from './types'
+
+const catalog = catalogJson as ScarabCatalog
+const SCARAB_ICONS = itemIcons as Record<string, string>
+
+function scarabIconUrl(name: string): string | null {
+  return SCARAB_ICONS[name] ?? null
+}
+
+/** Prefer the plain "{Category} Scarab" art, else first scarab with an icon. */
+function categoryIconUrl(cat: ScarabCategory): string | null {
+  const plain = `${cat.name} Scarab`
+  if (SCARAB_ICONS[plain]) return SCARAB_ICONS[plain]
+  for (const s of cat.scarabs) {
+    const url = scarabIconUrl(s.name)
+    if (url) return url
+  }
+  return null
+}
+
+function ScarabIcon({
+  name,
+  url,
+  size = 20,
+}: {
+  name?: string
+  url?: string | null
+  size?: number
+}): JSX.Element {
+  const src = url !== undefined ? url : name ? scarabIconUrl(name) : null
+  if (!src) {
+    return (
+      <div
+        className="shrink-0 rounded bg-white/[0.04] border border-white/[0.06]"
+        style={{ width: size, height: size }}
+        aria-hidden
+      />
+    )
+  }
+  return <IconGlow src={src} size={size} blur={8} saturate={2.2} opacity={0.35} />
+}
+
+function tabClass(active: boolean): string {
+  return [
+    'px-3 py-1.5 text-xs rounded border transition-colors',
+    active
+      ? 'border-white/20 bg-white/10 font-semibold text-text'
+      : 'border-white/10 bg-black/20 text-text-dim hover:text-text',
+  ].join(' ')
+}
+
+export function ScarabAtlas(): JSX.Element {
+  const [tab, setTab] = useState<TabId>('calculator')
+  const [state, setState] = useState<ScarabCalcState>(() => loadState())
+  const [prices, setPrices] = useState<Record<string, number>>({})
+  const [league, setLeague] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [vendorSearch, setVendorSearch] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+
+  const updateState = useCallback((patch: Partial<ScarabCalcState> | ((prev: ScarabCalcState) => ScarabCalcState)) => {
+    setState((prev) => {
+      const next = typeof patch === 'function' ? patch(prev) : { ...prev, ...patch }
+      saveState(next)
+      return next
+    })
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    const fetchPrices = async (attempt = 0): Promise<void> => {
+      try {
+        const settings = await window.api.getSettings()
+        const activeLeague = settings.activeProfile?.league ?? ''
+        if (!cancelled) setLeague(activeLeague)
+        const names = catalog.categories.flatMap((c) => c.scarabs.map((s) => s.name))
+        const result: Record<string, number> = {}
+        const chunkSize = 200
+        for (let i = 0; i < names.length; i += chunkSize) {
+          const chunk = names.slice(i, i + chunkSize)
+          const p = await window.api.batchLookupPrices(chunk, activeLeague)
+          for (const [name, info] of Object.entries(p)) {
+            if (info?.chaosValue) result[name] = info.chaosValue
+          }
+        }
+        if (cancelled) return
+        if (Object.keys(result).length === 0 && attempt < 3) {
+          await new Promise((r) => setTimeout(r, 2000))
+          if (!cancelled) return fetchPrices(attempt + 1)
+          return
+        }
+        setPrices(result)
+      } catch {
+        if (!cancelled && attempt < 3) {
+          await new Promise((r) => setTimeout(r, 2000))
+          if (!cancelled) return fetchPrices(attempt + 1)
+          return
+        }
+      }
+      if (!cancelled) setLoading(false)
+    }
+    void fetchPrices()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const baselineEV = useMemo(
+    () =>
+      calculatePoolEV(catalog, state, prices, {
+        blocks: [],
+        boosts: [],
+        investments: [],
+      }),
+    [state, prices],
+  )
+  const currentEV = useMemo(() => calculatePoolEV(catalog, state, prices), [state, prices])
+  const optimal = useMemo(() => calculateOptimalStrategy(catalog, state, prices), [state, prices])
+
+  const sortedCategories = useMemo(() => {
+    return [...catalog.categories]
+      .map((cat) => ({ cat, ...calculateCategoryEV(cat, state, prices) }))
+      .sort((a, b) => b.ev - a.ev)
+  }, [state, prices])
+
+  const applyOptimize = (): void => {
+    updateState({
+      blocked: optimal.blocks,
+      boosted: optimal.boosts,
+      invested: optimal.investments,
+    })
+  }
+
+  const resetBiases = (): void => {
+    updateState({ blocked: [], boosted: [], invested: [] })
+  }
+
+  const generateVendor = (): void => {
+    const result = buildVendorSearchString(catalog, state, prices)
+    setVendorSearch(result.search)
+  }
+
+  const copyVendor = async (): Promise<void> => {
+    if (!vendorSearch || vendorSearch.startsWith('(')) return
+    try {
+      await navigator.clipboard.writeText(vendorSearch)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const pricedCount = Object.keys(prices).length
+  const totalScarabs = catalog.categories.reduce((n, c) => n + c.scarabs.length, 0)
+
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      <div className="bg-bg-card px-3 py-[10px] border-b border-border shrink-0 space-y-2">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <span className="section-title">Scarab Atlas</span>
+            <p className="text-[11px] text-text-dim mt-1 mb-0 leading-relaxed">
+              Block low-EV categories, boost high-EV ones. Prices follow your Scalpel league
+              {league ? ` (${league})` : ''}.
+            </p>
+          </div>
+          <div className="flex items-center gap-2 shrink-0 pt-0.5">
+            <span className="text-[10px] text-text-dim">Remarkable Relics</span>
+            <Toggle
+              checked={state.remarkableRelics}
+              onChange={(checked) => updateState({ remarkableRelics: checked })}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          <button type="button" className={tabClass(tab === 'calculator')} onClick={() => setTab('calculator')}>
+            Calculator
+          </button>
+          <button type="button" className={tabClass(tab === 'vendor')} onClick={() => setTab('vendor')}>
+            Vendor Guide
+          </button>
+          <button type="button" className={tabClass(tab === 'weights')} onClick={() => setTab('weights')}>
+            Weights & Prices
+          </button>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
+          <span>
+            <span className="text-text-dim">Baseline </span>
+            <span className="text-text font-medium">{loading ? '…' : formatChaos(baselineEV)}</span>
+          </span>
+          <span>
+            <span className="text-text-dim">Current </span>
+            <span className="text-accent font-semibold">{loading ? '…' : formatChaos(currentEV)}</span>
+          </span>
+          <span>
+            <span className="text-text-dim">Optimal </span>
+            <span className="text-emerald-400 font-medium">{loading ? '…' : formatChaos(optimal.ev)}</span>
+          </span>
+          <span className="text-text-dim">
+            {pricedCount}/{totalScarabs} priced
+          </span>
+          <div className="flex gap-1.5 ml-auto">
+            <Button size="sm" variant="ghost" onClick={resetBiases}>
+              Reset
+            </Button>
+            <Button size="sm" variant="primary" onClick={applyOptimize} disabled={loading}>
+              Optimize
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto bg-bg-solid min-h-0">
+        {tab === 'calculator' && (
+          <div className="p-2 space-y-2">
+            <div className="px-2 py-1.5 text-[10px] text-text-dim border border-white/10 rounded bg-black/20">
+              Optimize suggests blocks (below pool EV), atlas boosts (2×), and investments (1.5×). Marginals show ΔEV
+              vs optimal.
+            </div>
+            {sortedCategories.map(({ cat, ev, weight }, i) => {
+              const blocked = state.blocked.includes(cat.id)
+              const boosted = state.boosted.includes(cat.id)
+              const invested = state.invested.includes(cat.id)
+              const mg = optimal.marginals[cat.id]
+              return (
+                <div
+                  key={cat.id}
+                  className="rounded border border-white/10 px-2.5 py-2"
+                  style={{ background: zebraRowBg(i), opacity: blocked ? 0.55 : 1 }}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <ScarabIcon url={categoryIconUrl(cat)} size={22} />
+                      <span className="text-[12px] font-medium text-text truncate">{cat.name}</span>
+                      <span className="text-[9px] uppercase tracking-wide text-text-dim shrink-0">
+                        {cat.atlasModifier}
+                      </span>
+                    </div>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      {cat.atlasModifier === 'blockable' && (
+                        <Button
+                          size="sm"
+                          variant={blocked ? 'danger' : 'ghost'}
+                          onClick={() =>
+                            updateState((prev) => ({
+                              ...prev,
+                              blocked: toggleInList(prev.blocked, cat.id),
+                              invested: prev.invested.filter((id) => id !== cat.id),
+                            }))
+                          }
+                        >
+                          Block
+                        </Button>
+                      )}
+                      {cat.atlasModifier === 'boostable' && (
+                        <Button
+                          size="sm"
+                          variant={boosted ? 'primary' : 'ghost'}
+                          onClick={() =>
+                            updateState((prev) => ({
+                              ...prev,
+                              boosted: toggleInList(prev.boosted, cat.id),
+                            }))
+                          }
+                        >
+                          Boost
+                        </Button>
+                      )}
+                      {cat.investmentBoost && (
+                        <Button
+                          size="sm"
+                          variant={invested ? 'primary' : 'ghost'}
+                          disabled={blocked}
+                          onClick={() =>
+                            updateState((prev) => ({
+                              ...prev,
+                              invested: toggleInList(prev.invested, cat.id),
+                              blocked: prev.blocked.filter((id) => id !== cat.id),
+                            }))
+                          }
+                        >
+                          Invest
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                  <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-text-dim">
+                    <span>
+                      EV <span className="text-text">{formatChaos(ev)}</span>
+                    </span>
+                    <span>
+                      Weight <span className="text-text">{Math.round(weight)}</span>
+                    </span>
+                    <span>
+                      Count <span className="text-text">{cat.scarabs.length}</span>
+                    </span>
+                    {mg?.block != null && (
+                      <span className={mg.block >= 0 ? 'text-emerald-400' : 'text-red-400'}>
+                        block {mg.block >= 0 ? '+' : ''}
+                        {formatChaos(mg.block)}
+                      </span>
+                    )}
+                    {mg?.boost != null && (
+                      <span className={mg.boost >= 0 ? 'text-emerald-400' : 'text-red-400'}>
+                        boost {mg.boost >= 0 ? '+' : ''}
+                        {formatChaos(mg.boost)}
+                      </span>
+                    )}
+                    {mg?.invest != null && (
+                      <span className={mg.invest >= 0 ? 'text-emerald-400' : 'text-red-400'}>
+                        invest {mg.invest >= 0 ? '+' : ''}
+                        {formatChaos(mg.invest)}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        )}
+
+        {tab === 'vendor' && (
+          <VendorTab
+            state={state}
+            prices={prices}
+            vendorSearch={vendorSearch}
+            copied={copied}
+            onGenerate={generateVendor}
+            onCopy={() => void copyVendor()}
+          />
+        )}
+
+        {tab === 'weights' && (
+          <WeightsTab
+            state={state}
+            prices={prices}
+            onSetWeight={(id, value) =>
+              updateState((prev) => {
+                const next = { ...prev.weightOverrides }
+                if (value == null) delete next[id]
+                else next[id] = value
+                return { ...prev, weightOverrides: next }
+              })
+            }
+            onSetPrice={(id, value) =>
+              updateState((prev) => {
+                const next = { ...prev.priceOverrides }
+                if (value == null) delete next[id]
+                else next[id] = value
+                return { ...prev, priceOverrides: next }
+              })
+            }
+            onResetWeights={() => updateState({ weightOverrides: {} })}
+            onResetPrices={() => updateState({ priceOverrides: {} })}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+function VendorTab({
+  state,
+  prices,
+  vendorSearch,
+  copied,
+  onGenerate,
+  onCopy,
+}: {
+  state: ScarabCalcState
+  prices: Record<string, number>
+  vendorSearch: string | null
+  copied: boolean
+  onGenerate: () => void
+  onCopy: () => void
+}): JSX.Element {
+  const baseline = calculatePoolEV(catalog, state, prices, {
+    blocks: [],
+    boosts: [],
+    investments: [],
+    applyRemarkable: false,
+  })
+  const threshold = baseline / 3
+  const order = catalog.vendorCategoryOrder
+
+  const categories = [...catalog.categories].sort(
+    (a, b) => order.indexOf(a.id) - order.indexOf(b.id) || a.name.localeCompare(b.name),
+  )
+
+  return (
+    <div className="p-2 space-y-2">
+      <div className="px-2 py-1.5 text-[11px] text-text-dim border border-white/10 rounded bg-black/20 leading-relaxed">
+        Sell any 3 scarabs → 1 random. Random EV{' '}
+        <span className="text-accent font-medium">{formatChaos(baseline)}</span> (raw weights). Vendor if under{' '}
+        <span className="text-accent font-medium">{formatChaos(threshold)}</span>.
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button size="sm" variant="primary" onClick={onGenerate}>
+          Generate Search String
+        </Button>
+        {vendorSearch && (
+          <>
+            <input
+              readOnly
+              value={vendorSearch}
+              className="flex-1 min-w-[140px] text-[11px] px-2 py-1 rounded border border-white/10 bg-black/30 text-text"
+            />
+            <Button size="sm" variant="secondary" onClick={onCopy}>
+              {copied ? 'Copied' : 'Copy'}
+            </Button>
+          </>
+        )}
+      </div>
+      {categories.map((cat, i) => {
+        const vendorable = cat.scarabs
+          .filter((s) => getEffectivePrice(s, state, prices) < threshold)
+          .sort((a, b) => getEffectivePrice(a, state, prices) - getEffectivePrice(b, state, prices))
+        return (
+          <div
+            key={cat.id}
+            className="rounded border border-white/10 px-2.5 py-2"
+            style={{ background: zebraRowBg(i), opacity: vendorable.length ? 1 : 0.45 }}
+          >
+            <div className="flex justify-between text-[12px] items-center gap-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <ScarabIcon url={categoryIconUrl(cat)} size={18} />
+                <span className="font-medium truncate">{cat.name}</span>
+              </div>
+              <span className="text-text-dim text-[10px] shrink-0">
+                {vendorable.length}/{cat.scarabs.length}
+              </span>
+            </div>
+            {vendorable.length > 0 && (
+              <div className="mt-1.5 space-y-0.5">
+                {vendorable.map((s) => {
+                  const price = getEffectivePrice(s, state, prices)
+                  const profit = baseline - price * 3
+                  return (
+                    <div key={s.id} className="flex justify-between gap-2 text-[10px] items-center">
+                      <div className="flex items-center gap-1.5 min-w-0">
+                        <ScarabIcon name={s.name} size={16} />
+                        <span className="truncate text-text-dim" title={s.name}>
+                          {shortenScarabName(s.name)}
+                        </span>
+                      </div>
+                      <span className="shrink-0">
+                        <span className="text-text">{formatChaos(price)}</span>
+                        <span className="text-emerald-400 ml-2">+{formatChaos(profit)}</span>
+                      </span>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function WeightsTab({
+  state,
+  prices,
+  onSetWeight,
+  onSetPrice,
+  onResetWeights,
+  onResetPrices,
+}: {
+  state: ScarabCalcState
+  prices: Record<string, number>
+  onSetWeight: (id: string, value: number | null) => void
+  onSetPrice: (id: string, value: number | null) => void
+  onResetWeights: () => void
+  onResetPrices: () => void
+}): JSX.Element {
+  const sorted = useMemo(() => {
+    return [...catalog.categories]
+      .map((cat) => ({ cat, ...calculateCategoryEV(cat, state, prices) }))
+      .sort((a, b) => b.ev - a.ev)
+  }, [state, prices])
+
+  return (
+    <div className="p-2 space-y-2">
+      <div className="flex gap-1.5">
+        <Button size="sm" variant="ghost" onClick={onResetWeights}>
+          Reset Weights
+        </Button>
+        <Button size="sm" variant="ghost" onClick={onResetPrices}>
+          Reset Prices
+        </Button>
+      </div>
+      {sorted.map(({ cat, ev }, i) => (
+        <div key={cat.id} className="rounded border border-white/10 px-2.5 py-2" style={{ background: zebraRowBg(i) }}>
+          <div className="flex justify-between text-[12px] mb-1.5 items-center gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <ScarabIcon url={categoryIconUrl(cat)} size={18} />
+              <span className="font-medium truncate">{cat.name}</span>
+            </div>
+            <span className="text-text-dim text-[10px] shrink-0">EV {formatChaos(ev)}</span>
+          </div>
+          <div className="space-y-1">
+            {cat.scarabs.map((s) => {
+              const wOverride = state.weightOverrides[s.id]
+              const pOverride = state.priceOverrides[s.id]
+              const market = prices[s.name]
+              return (
+                <div key={s.id} className="grid grid-cols-[1fr_64px_72px] gap-1.5 items-center text-[10px]">
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    <ScarabIcon name={s.name} size={16} />
+                    <span className="truncate text-text-dim" title={s.name}>
+                      {shortenScarabName(s.name)}
+                    </span>
+                  </div>
+                  <input
+                    className={`px-1.5 py-0.5 rounded border bg-black/30 text-text text-right ${
+                      wOverride !== undefined ? 'border-accent' : 'border-white/10'
+                    }`}
+                    value={wOverride !== undefined ? wOverride : s.weight}
+                    title={`Base ${s.weight}, effective ${Math.round(getEffectiveWeight(s, state))}`}
+                    onChange={(e) => {
+                      const n = parseFloat(e.target.value)
+                      onSetWeight(s.id, Number.isFinite(n) && n >= 0 ? n : null)
+                    }}
+                  />
+                  <input
+                    className={`px-1.5 py-0.5 rounded border bg-black/30 text-text text-right ${
+                      pOverride !== undefined ? 'border-amber-400' : 'border-white/10'
+                    }`}
+                    value={
+                      pOverride !== undefined
+                        ? pOverride
+                        : market != null
+                          ? Math.round(market * 100) / 100
+                          : ''
+                    }
+                    placeholder={market != null ? String(Math.round(market * 100) / 100) : ''}
+                    title={market != null ? `Market ${formatChaos(market)}` : 'No market price'}
+                    onChange={(e) => {
+                      const n = parseFloat(e.target.value)
+                      onSetPrice(s.id, Number.isFinite(n) && n >= 0 ? n : null)
+                    }}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/features/scarab-atlas/ScarabAtlas.tsx
+++ b/src/renderer/src/features/scarab-atlas/ScarabAtlas.tsx
@@ -39,15 +39,7 @@ function categoryIconUrl(cat: ScarabCategory): string | null {
   return null
 }
 
-function ScarabIcon({
-  name,
-  url,
-  size = 20,
-}: {
-  name?: string
-  url?: string | null
-  size?: number
-}): JSX.Element {
+function ScarabIcon({ name, url, size = 20 }: { name?: string; url?: string | null; size?: number }): JSX.Element {
   const src = url !== undefined ? url : name ? scarabIconUrl(name) : null
   if (!src) {
     return (
@@ -238,8 +230,8 @@ export function ScarabAtlas(): JSX.Element {
         {tab === 'calculator' && (
           <div className="p-2 space-y-2">
             <div className="px-2 py-1.5 text-[10px] text-text-dim border border-white/10 rounded bg-black/20">
-              Optimize suggests blocks (below pool EV), atlas boosts (2×), and investments (1.5×). Marginals show ΔEV
-              vs optimal.
+              Optimize suggests blocks (below pool EV), atlas boosts (2×), and investments (1.5×). Marginals show ΔEV vs
+              optimal.
             </div>
             {sortedCategories.map(({ cat, ev, weight }, i) => {
               const blocked = state.blocked.includes(cat.id)
@@ -551,13 +543,7 @@ function WeightsTab({
                     className={`px-1.5 py-0.5 rounded border bg-black/30 text-text text-right ${
                       pOverride !== undefined ? 'border-amber-400' : 'border-white/10'
                     }`}
-                    value={
-                      pOverride !== undefined
-                        ? pOverride
-                        : market != null
-                          ? Math.round(market * 100) / 100
-                          : ''
-                    }
+                    value={pOverride !== undefined ? pOverride : market != null ? Math.round(market * 100) / 100 : ''}
                     placeholder={market != null ? String(Math.round(market * 100) / 100) : ''}
                     title={market != null ? `Market ${formatChaos(market)}` : 'No market price'}
                     onChange={(e) => {

--- a/src/renderer/src/features/scarab-atlas/ScarabAtlas.tsx
+++ b/src/renderer/src/features/scarab-atlas/ScarabAtlas.tsx
@@ -19,6 +19,16 @@ import {
   shortenScarabName,
   toggleInList,
 } from './calc'
+import {
+  ADVANCED_DELTAS_KEY,
+  EV_LABELS,
+  GUIDE_DISMISS_KEY,
+  HOW_TO_STEPS,
+  TAB_BLURBS,
+  atlasModifierLabel,
+  loadBool,
+  saveBool,
+} from './guidance'
 import type { ScarabCalcState, ScarabCatalog, TabId } from './types'
 
 const catalog = catalogJson as ScarabCatalog
@@ -62,6 +72,112 @@ function tabClass(active: boolean): string {
   ].join(' ')
 }
 
+function HowToGuide({ onDismiss }: { onDismiss: () => void }): JSX.Element {
+  return (
+    <div className="rounded border border-accent/40 bg-accent/10 px-2.5 py-2 space-y-2">
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <div className="text-[12px] font-semibold text-accent">How to use Scarab Atlas</div>
+          <p className="text-[10px] text-text-dim mt-0.5 mb-0 leading-relaxed">
+            Goal: raise the average chaos value of scarabs that drop from maps by shaping your atlas tree.
+          </p>
+        </div>
+        <Button size="sm" variant="ghost" onClick={onDismiss}>
+          Got it
+        </Button>
+      </div>
+      <ol className="m-0 pl-4 space-y-1.5">
+        {HOW_TO_STEPS.map((step, i) => (
+          <li key={step.title} className="text-[10px] text-text-dim leading-relaxed">
+            <span className="text-text font-medium">
+              {i + 1}. {step.title}
+            </span>
+            <span className="text-text-dim"> — {step.body}</span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  )
+}
+
+function GlossaryPanel(): JSX.Element {
+  return (
+    <div className="rounded border border-white/10 bg-black/20 px-2.5 py-2 text-[10px] text-text-dim leading-relaxed space-y-1">
+      <div className="text-[11px] font-medium text-text mb-1">Quick glossary</div>
+      <p className="m-0">
+        <span className="text-text">EV</span> — expected chaos value of one random scarab from the drop pool.
+      </p>
+      <p className="m-0">
+        <span className="text-text">Block</span> — remove that category from map drops (atlas block notable).
+      </p>
+      <p className="m-0">
+        <span className="text-text">Boost</span> — 2× drop weight for that category (“more X scarabs”).
+      </p>
+      <p className="m-0">
+        <span className="text-text">Invest</span> — 1.5× drop weight (investment tree). Stacks with Boost → 3×.
+      </p>
+      <p className="m-0">
+        <span className="text-text">Remarkable Relics</span> — atlas keystone model that flattens weights (weight^0.9).
+        Leave on if you take that keystone.
+      </p>
+    </div>
+  )
+}
+
+function RecommendedChecklist({
+  catalogCats,
+  optimal,
+  onApply,
+  loading,
+}: {
+  catalogCats: ScarabCategory[]
+  optimal: ReturnType<typeof calculateOptimalStrategy>
+  onApply: () => void
+  loading: boolean
+}): JSX.Element {
+  const nameOf = (id: string) => catalogCats.find((c) => c.id === id)?.name ?? id
+  const hasRecs = optimal.blocks.length + optimal.boosts.length + optimal.investments.length > 0
+
+  return (
+    <div className="rounded border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-2 space-y-1.5">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-[11px] font-semibold text-emerald-300">Recommended atlas setup</div>
+        <Button size="sm" variant="primary" onClick={onApply} disabled={loading}>
+          Apply to list
+        </Button>
+      </div>
+      <p className="text-[10px] text-text-dim m-0 leading-relaxed">
+        Mirror these on your atlas tree. “Apply to list” only updates the buttons below — it does not change Path of
+        Exile for you.
+      </p>
+      {!hasRecs ? (
+        <p className="text-[10px] text-text-dim m-0">No blocks/boosts/invests beat the current pool.</p>
+      ) : (
+        <div className="grid grid-cols-1 gap-1 text-[10px]">
+          {optimal.blocks.length > 0 && (
+            <div>
+              <span className="text-red-300 font-medium">Block: </span>
+              <span className="text-text">{optimal.blocks.map(nameOf).join(', ')}</span>
+            </div>
+          )}
+          {optimal.boosts.length > 0 && (
+            <div>
+              <span className="text-accent font-medium">Boost ×2: </span>
+              <span className="text-text">{optimal.boosts.map(nameOf).join(', ')}</span>
+            </div>
+          )}
+          {optimal.investments.length > 0 && (
+            <div>
+              <span className="text-sky-300 font-medium">Invest ×1.5: </span>
+              <span className="text-text">{optimal.investments.map(nameOf).join(', ')}</span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function ScarabAtlas(): JSX.Element {
   const [tab, setTab] = useState<TabId>('calculator')
   const [state, setState] = useState<ScarabCalcState>(() => loadState())
@@ -70,6 +186,9 @@ export function ScarabAtlas(): JSX.Element {
   const [loading, setLoading] = useState(true)
   const [vendorSearch, setVendorSearch] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const [guideOpen, setGuideOpen] = useState(() => !loadBool(GUIDE_DISMISS_KEY, false))
+  const [glossaryOpen, setGlossaryOpen] = useState(false)
+  const [showDeltas, setShowDeltas] = useState(() => loadBool(ADVANCED_DELTAS_KEY, false))
 
   const updateState = useCallback((patch: Partial<ScarabCalcState> | ((prev: ScarabCalcState) => ScarabCalcState)) => {
     setState((prev) => {
@@ -164,212 +283,308 @@ export function ScarabAtlas(): JSX.Element {
     }
   }
 
+  const dismissGuide = (): void => {
+    setGuideOpen(false)
+    saveBool(GUIDE_DISMISS_KEY, true)
+  }
+
+  const openGuide = (): void => {
+    setGuideOpen(true)
+    saveBool(GUIDE_DISMISS_KEY, false)
+  }
+
+  const toggleDeltas = (checked: boolean): void => {
+    setShowDeltas(checked)
+    saveBool(ADVANCED_DELTAS_KEY, checked)
+  }
+
   const pricedCount = Object.keys(prices).length
   const totalScarabs = catalog.categories.reduce((n, c) => n + c.scarabs.length, 0)
+  const setupMatchesOptimal =
+    state.blocked.length === optimal.blocks.length &&
+    state.boosted.length === optimal.boosts.length &&
+    state.invested.length === optimal.investments.length &&
+    optimal.blocks.every((id) => state.blocked.includes(id)) &&
+    optimal.boosts.every((id) => state.boosted.includes(id)) &&
+    optimal.investments.every((id) => state.invested.includes(id))
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
       <div className="bg-bg-card px-3 py-[10px] border-b border-border shrink-0 space-y-2">
         <div className="flex items-start justify-between gap-3">
-          <div>
-            <span className="section-title">Scarab Atlas</span>
-            <p className="text-[11px] text-text-dim mt-1 mb-0 leading-relaxed">
-              Block low-EV categories, boost high-EV ones. Prices follow your Scalpel league
-              {league ? ` (${league})` : ''}.
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="section-title">Scarab Atlas</span>
+              <Button size="sm" variant="ghost" onClick={guideOpen ? dismissGuide : openGuide}>
+                {guideOpen ? 'Hide guide' : 'How to use'}
+              </Button>
+              <Button size="sm" variant="ghost" onClick={() => setGlossaryOpen((v) => !v)}>
+                {glossaryOpen ? 'Hide glossary' : 'Glossary'}
+              </Button>
+            </div>
+            <p className="text-[11px] text-text-dim mt-1 mb-0 leading-relaxed">{TAB_BLURBS[tab]}</p>
+            <p className="text-[10px] text-text-dim mt-0.5 mb-0">
+              Prices: {league || 'your Scalpel league'} · {pricedCount}/{totalScarabs} priced
+              {loading ? ' · loading…' : ''}
             </p>
           </div>
-          <div className="flex items-center gap-2 shrink-0 pt-0.5">
-            <span className="text-[10px] text-text-dim">Remarkable Relics</span>
-            <Toggle
-              checked={state.remarkableRelics}
-              onChange={(checked) => updateState({ remarkableRelics: checked })}
-            />
+          <div className="flex flex-col items-end gap-1 shrink-0 pt-0.5">
+            <div className="flex items-center gap-2">
+              <span className="text-[10px] text-text-dim" title="Leave on if you allocated Remarkable Relics">
+                Remarkable Relics
+              </span>
+              <Toggle
+                checked={state.remarkableRelics}
+                onChange={(checked) => updateState({ remarkableRelics: checked })}
+              />
+            </div>
           </div>
         </div>
 
         <div className="flex flex-wrap gap-1.5">
           <button type="button" className={tabClass(tab === 'calculator')} onClick={() => setTab('calculator')}>
-            Calculator
+            Atlas planner
           </button>
           <button type="button" className={tabClass(tab === 'vendor')} onClick={() => setTab('vendor')}>
-            Vendor Guide
+            Vendor junk
           </button>
           <button type="button" className={tabClass(tab === 'weights')} onClick={() => setTab('weights')}>
-            Weights & Prices
+            Weights & prices
           </button>
         </div>
 
-        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
-          <span>
-            <span className="text-text-dim">Baseline </span>
-            <span className="text-text font-medium">{loading ? '…' : formatChaos(baselineEV)}</span>
-          </span>
-          <span>
-            <span className="text-text-dim">Current </span>
-            <span className="text-accent font-semibold">{loading ? '…' : formatChaos(currentEV)}</span>
-          </span>
-          <span>
-            <span className="text-text-dim">Optimal </span>
-            <span className="text-emerald-400 font-medium">{loading ? '…' : formatChaos(optimal.ev)}</span>
-          </span>
-          <span className="text-text-dim">
-            {pricedCount}/{totalScarabs} priced
-          </span>
-          <div className="flex gap-1.5 ml-auto">
-            <Button size="sm" variant="ghost" onClick={resetBiases}>
-              Reset
-            </Button>
-            <Button size="sm" variant="primary" onClick={applyOptimize} disabled={loading}>
-              Optimize
-            </Button>
+        {tab === 'calculator' && (
+          <div className="flex flex-wrap items-end gap-x-4 gap-y-2 text-[11px]">
+            <span title={EV_LABELS.baseline.hint}>
+              <span className="text-text-dim block text-[9px] uppercase tracking-wide">{EV_LABELS.baseline.label}</span>
+              <span className="text-text font-medium">{loading ? '…' : formatChaos(baselineEV)}</span>
+            </span>
+            <span title={EV_LABELS.current.hint}>
+              <span className="text-text-dim block text-[9px] uppercase tracking-wide">{EV_LABELS.current.label}</span>
+              <span className="text-accent font-semibold">{loading ? '…' : formatChaos(currentEV)}</span>
+            </span>
+            <span title={EV_LABELS.optimal.hint}>
+              <span className="text-text-dim block text-[9px] uppercase tracking-wide">{EV_LABELS.optimal.label}</span>
+              <span className="text-emerald-400 font-medium">{loading ? '…' : formatChaos(optimal.ev)}</span>
+            </span>
+            {!loading && !setupMatchesOptimal && (
+              <span className="text-[10px] text-amber-300/90 self-center">Your setup ≠ recommended</span>
+            )}
+            <div className="flex gap-1.5 ml-auto">
+              <Button size="sm" variant="ghost" onClick={resetBiases} title="Clear all Block / Boost / Invest">
+                Reset setup
+              </Button>
+              <Button
+                size="sm"
+                variant="primary"
+                onClick={applyOptimize}
+                disabled={loading}
+                title="Apply the recommended Block / Boost / Invest to the list below"
+              >
+                Optimize
+              </Button>
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       <div className="flex-1 overflow-y-auto bg-bg-solid min-h-0">
-        {tab === 'calculator' && (
-          <div className="p-2 space-y-2">
-            <div className="px-2 py-1.5 text-[10px] text-text-dim border border-white/10 rounded bg-black/20">
-              Optimize suggests blocks (below pool EV), atlas boosts (2×), and investments (1.5×). Marginals show ΔEV vs
-              optimal.
-            </div>
-            {sortedCategories.map(({ cat, ev, weight }, i) => {
-              const blocked = state.blocked.includes(cat.id)
-              const boosted = state.boosted.includes(cat.id)
-              const invested = state.invested.includes(cat.id)
-              const mg = optimal.marginals[cat.id]
-              return (
-                <div
-                  key={cat.id}
-                  className="rounded border border-white/10 px-2.5 py-2"
-                  style={{ background: zebraRowBg(i), opacity: blocked ? 0.55 : 1 }}
-                >
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2 min-w-0">
-                      <ScarabIcon url={categoryIconUrl(cat)} size={22} />
-                      <span className="text-[12px] font-medium text-text truncate">{cat.name}</span>
-                      <span className="text-[9px] uppercase tracking-wide text-text-dim shrink-0">
-                        {cat.atlasModifier}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-1.5 shrink-0">
-                      {cat.atlasModifier === 'blockable' && (
-                        <Button
-                          size="sm"
-                          variant={blocked ? 'danger' : 'ghost'}
-                          onClick={() =>
-                            updateState((prev) => ({
-                              ...prev,
-                              blocked: toggleInList(prev.blocked, cat.id),
-                              invested: prev.invested.filter((id) => id !== cat.id),
-                            }))
-                          }
-                        >
-                          Block
-                        </Button>
-                      )}
-                      {cat.atlasModifier === 'boostable' && (
-                        <Button
-                          size="sm"
-                          variant={boosted ? 'primary' : 'ghost'}
-                          onClick={() =>
-                            updateState((prev) => ({
-                              ...prev,
-                              boosted: toggleInList(prev.boosted, cat.id),
-                            }))
-                          }
-                        >
-                          Boost
-                        </Button>
-                      )}
-                      {cat.investmentBoost && (
-                        <Button
-                          size="sm"
-                          variant={invested ? 'primary' : 'ghost'}
-                          disabled={blocked}
-                          onClick={() =>
-                            updateState((prev) => ({
-                              ...prev,
-                              invested: toggleInList(prev.invested, cat.id),
-                              blocked: prev.blocked.filter((id) => id !== cat.id),
-                            }))
-                          }
-                        >
-                          Invest
-                        </Button>
-                      )}
-                    </div>
-                  </div>
-                  <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-text-dim">
-                    <span>
-                      EV <span className="text-text">{formatChaos(ev)}</span>
-                    </span>
-                    <span>
-                      Weight <span className="text-text">{Math.round(weight)}</span>
-                    </span>
-                    <span>
-                      Count <span className="text-text">{cat.scarabs.length}</span>
-                    </span>
-                    {mg?.block != null && (
-                      <span className={mg.block >= 0 ? 'text-emerald-400' : 'text-red-400'}>
-                        block {mg.block >= 0 ? '+' : ''}
-                        {formatChaos(mg.block)}
-                      </span>
-                    )}
-                    {mg?.boost != null && (
-                      <span className={mg.boost >= 0 ? 'text-emerald-400' : 'text-red-400'}>
-                        boost {mg.boost >= 0 ? '+' : ''}
-                        {formatChaos(mg.boost)}
-                      </span>
-                    )}
-                    {mg?.invest != null && (
-                      <span className={mg.invest >= 0 ? 'text-emerald-400' : 'text-red-400'}>
-                        invest {mg.invest >= 0 ? '+' : ''}
-                        {formatChaos(mg.invest)}
-                      </span>
-                    )}
-                  </div>
+        <div className="p-2 space-y-2">
+          {guideOpen && <HowToGuide onDismiss={dismissGuide} />}
+          {glossaryOpen && <GlossaryPanel />}
+
+          {tab === 'calculator' && (
+            <>
+              <RecommendedChecklist
+                catalogCats={catalog.categories}
+                optimal={optimal}
+                onApply={applyOptimize}
+                loading={loading}
+              />
+              <div className="flex items-center justify-between gap-2 px-1">
+                <p className="text-[10px] text-text-dim m-0 leading-relaxed">
+                  Categories sorted by value. Yellow “Recommended” badges match Optimize. Toggle actions, then take the
+                  same notables on your atlas.
+                </p>
+                <div className="flex items-center gap-1.5 shrink-0">
+                  <span className="text-[9px] text-text-dim whitespace-nowrap">Advanced ΔEV</span>
+                  <Toggle checked={showDeltas} onChange={toggleDeltas} />
                 </div>
-              )
-            })}
-          </div>
-        )}
+              </div>
+              {sortedCategories.map(({ cat, ev, weight }, i) => {
+                const blocked = state.blocked.includes(cat.id)
+                const boosted = state.boosted.includes(cat.id)
+                const invested = state.invested.includes(cat.id)
+                const mg = optimal.marginals[cat.id]
+                const recBlock = optimal.blocks.includes(cat.id)
+                const recBoost = optimal.boosts.includes(cat.id)
+                const recInvest = optimal.investments.includes(cat.id)
+                const isRecommended = recBlock || recBoost || recInvest
+                return (
+                  <div
+                    key={cat.id}
+                    className={`rounded border px-2.5 py-2 ${
+                      isRecommended ? 'border-emerald-500/35' : 'border-white/10'
+                    }`}
+                    style={{ background: zebraRowBg(i), opacity: blocked ? 0.55 : 1 }}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <ScarabIcon url={categoryIconUrl(cat)} size={22} />
+                        <span className="text-[12px] font-medium text-text truncate">{cat.name}</span>
+                        <span
+                          className="text-[9px] text-text-dim shrink-0"
+                          title="What atlas levers exist for this category"
+                        >
+                          {atlasModifierLabel(cat.atlasModifier)}
+                        </span>
+                        {recBlock && (
+                          <span className="text-[9px] px-1.5 py-0.5 rounded bg-red-500/20 text-red-300 shrink-0">
+                            Rec: Block
+                          </span>
+                        )}
+                        {recBoost && (
+                          <span className="text-[9px] px-1.5 py-0.5 rounded bg-accent/20 text-accent shrink-0">
+                            Rec: Boost
+                          </span>
+                        )}
+                        {recInvest && (
+                          <span className="text-[9px] px-1.5 py-0.5 rounded bg-sky-500/20 text-sky-300 shrink-0">
+                            Rec: Invest
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-1.5 shrink-0">
+                        {cat.atlasModifier === 'blockable' && (
+                          <Button
+                            size="sm"
+                            variant={blocked ? 'danger' : 'ghost'}
+                            title="Remove this category from map scarab drops"
+                            onClick={() =>
+                              updateState((prev) => ({
+                                ...prev,
+                                blocked: toggleInList(prev.blocked, cat.id),
+                                invested: prev.invested.filter((id) => id !== cat.id),
+                              }))
+                            }
+                          >
+                            Block
+                          </Button>
+                        )}
+                        {cat.atlasModifier === 'boostable' && (
+                          <Button
+                            size="sm"
+                            variant={boosted ? 'primary' : 'ghost'}
+                            title="2× drop weight (atlas “more scarabs” for this category)"
+                            onClick={() =>
+                              updateState((prev) => ({
+                                ...prev,
+                                boosted: toggleInList(prev.boosted, cat.id),
+                              }))
+                            }
+                          >
+                            Boost
+                          </Button>
+                        )}
+                        {cat.investmentBoost && (
+                          <Button
+                            size="sm"
+                            variant={invested ? 'primary' : 'ghost'}
+                            disabled={blocked}
+                            title="1.5× drop weight from investment notables"
+                            onClick={() =>
+                              updateState((prev) => ({
+                                ...prev,
+                                invested: toggleInList(prev.invested, cat.id),
+                                blocked: prev.blocked.filter((id) => id !== cat.id),
+                              }))
+                            }
+                          >
+                            Invest
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                    <div className="mt-1.5 flex flex-wrap gap-x-3 gap-y-0.5 text-[10px] text-text-dim">
+                      <span title="Average chaos value of scarabs in this category">
+                        Category EV <span className="text-text">{formatChaos(ev)}</span>
+                      </span>
+                      <span title="Total drop weight in this category">
+                        Weight <span className="text-text">{Math.round(weight)}</span>
+                      </span>
+                      <span>
+                        Scarabs <span className="text-text">{cat.scarabs.length}</span>
+                      </span>
+                      {showDeltas && mg?.block != null && (
+                        <span
+                          className={mg.block >= 0 ? 'text-emerald-400' : 'text-red-400'}
+                          title="Change to recommended pool EV if you block this category"
+                        >
+                          Δ block {mg.block >= 0 ? '+' : ''}
+                          {formatChaos(mg.block)}
+                        </span>
+                      )}
+                      {showDeltas && mg?.boost != null && (
+                        <span
+                          className={mg.boost >= 0 ? 'text-emerald-400' : 'text-red-400'}
+                          title="Change to recommended pool EV if you boost this category"
+                        >
+                          Δ boost {mg.boost >= 0 ? '+' : ''}
+                          {formatChaos(mg.boost)}
+                        </span>
+                      )}
+                      {showDeltas && mg?.invest != null && (
+                        <span
+                          className={mg.invest >= 0 ? 'text-emerald-400' : 'text-red-400'}
+                          title="Change to recommended pool EV if you invest this category"
+                        >
+                          Δ invest {mg.invest >= 0 ? '+' : ''}
+                          {formatChaos(mg.invest)}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </>
+          )}
 
-        {tab === 'vendor' && (
-          <VendorTab
-            state={state}
-            prices={prices}
-            vendorSearch={vendorSearch}
-            copied={copied}
-            onGenerate={generateVendor}
-            onCopy={() => void copyVendor()}
-          />
-        )}
+          {tab === 'vendor' && (
+            <VendorTab
+              state={state}
+              prices={prices}
+              vendorSearch={vendorSearch}
+              copied={copied}
+              onGenerate={generateVendor}
+              onCopy={() => void copyVendor()}
+            />
+          )}
 
-        {tab === 'weights' && (
-          <WeightsTab
-            state={state}
-            prices={prices}
-            onSetWeight={(id, value) =>
-              updateState((prev) => {
-                const next = { ...prev.weightOverrides }
-                if (value == null) delete next[id]
-                else next[id] = value
-                return { ...prev, weightOverrides: next }
-              })
-            }
-            onSetPrice={(id, value) =>
-              updateState((prev) => {
-                const next = { ...prev.priceOverrides }
-                if (value == null) delete next[id]
-                else next[id] = value
-                return { ...prev, priceOverrides: next }
-              })
-            }
-            onResetWeights={() => updateState({ weightOverrides: {} })}
-            onResetPrices={() => updateState({ priceOverrides: {} })}
-          />
-        )}
+          {tab === 'weights' && (
+            <WeightsTab
+              state={state}
+              prices={prices}
+              onSetWeight={(id, value) =>
+                updateState((prev) => {
+                  const next = { ...prev.weightOverrides }
+                  if (value == null) delete next[id]
+                  else next[id] = value
+                  return { ...prev, weightOverrides: next }
+                })
+              }
+              onSetPrice={(id, value) =>
+                updateState((prev) => {
+                  const next = { ...prev.priceOverrides }
+                  if (value == null) delete next[id]
+                  else next[id] = value
+                  return { ...prev, priceOverrides: next }
+                })
+              }
+              onResetWeights={() => updateState({ weightOverrides: {} })}
+              onResetPrices={() => updateState({ priceOverrides: {} })}
+            />
+          )}
+        </div>
       </div>
     </div>
   )
@@ -404,15 +619,27 @@ function VendorTab({
   )
 
   return (
-    <div className="p-2 space-y-2">
-      <div className="px-2 py-1.5 text-[11px] text-text-dim border border-white/10 rounded bg-black/20 leading-relaxed">
-        Sell any 3 scarabs → 1 random. Random EV{' '}
-        <span className="text-accent font-medium">{formatChaos(baseline)}</span> (raw weights). Vendor if under{' '}
-        <span className="text-accent font-medium">{formatChaos(threshold)}</span>.
+    <div className="space-y-2">
+      <div className="rounded border border-white/10 bg-black/20 px-2.5 py-2 text-[11px] text-text-dim leading-relaxed space-y-1.5">
+        <div className="text-[12px] font-medium text-text">Vendor recipe helper</div>
+        <p className="m-0">
+          In PoE, selling <span className="text-text">any 3 scarabs</span> returns{' '}
+          <span className="text-text">1 random</span> scarab. If the three you sell are cheap enough, the random one is
+          profit on average.
+        </p>
+        <p className="m-0">
+          Expected random return: <span className="text-accent font-medium">{formatChaos(baseline)}</span> (ignores
+          atlas biases &amp; Remarkable Relics). Vendor a scarab when its price is under{' '}
+          <span className="text-accent font-medium">{formatChaos(threshold)}</span> (return ÷ 3).
+        </p>
+        <p className="m-0 text-[10px]">
+          Green <span className="text-emerald-400">+Xc</span> is estimated profit vs selling three of that scarab. Then
+          generate a stash search to find them quickly.
+        </p>
       </div>
       <div className="flex flex-wrap items-center gap-2">
         <Button size="sm" variant="primary" onClick={onGenerate}>
-          Generate Search String
+          Generate stash search
         </Button>
         {vendorSearch && (
           <>
@@ -442,8 +669,8 @@ function VendorTab({
                 <ScarabIcon url={categoryIconUrl(cat)} size={18} />
                 <span className="font-medium truncate">{cat.name}</span>
               </div>
-              <span className="text-text-dim text-[10px] shrink-0">
-                {vendorable.length}/{cat.scarabs.length}
+              <span className="text-text-dim text-[10px] shrink-0" title="Vendorable / total in category">
+                {vendorable.length}/{cat.scarabs.length} to vendor
               </span>
             </div>
             {vendorable.length > 0 && (
@@ -460,8 +687,12 @@ function VendorTab({
                         </span>
                       </div>
                       <span className="shrink-0">
-                        <span className="text-text">{formatChaos(price)}</span>
-                        <span className="text-emerald-400 ml-2">+{formatChaos(profit)}</span>
+                        <span className="text-text" title="Market price">
+                          {formatChaos(price)}
+                        </span>
+                        <span className="text-emerald-400 ml-2" title="Est. profit vs 3× this price">
+                          +{formatChaos(profit)}
+                        </span>
                       </span>
                     </div>
                   )
@@ -497,14 +728,26 @@ function WeightsTab({
   }, [state, prices])
 
   return (
-    <div className="p-2 space-y-2">
+    <div className="space-y-2">
+      <div className="rounded border border-amber-500/30 bg-amber-500/10 px-2.5 py-2 text-[11px] text-text-dim leading-relaxed">
+        <div className="text-[12px] font-medium text-amber-200 mb-1">Advanced overrides</div>
+        <p className="m-0">
+          Left column = drop weight (how often it appears). Right = chaos price. Gold/amber borders mean you overrode
+          the default. Reset buttons restore datamined weights and live market prices.
+        </p>
+      </div>
       <div className="flex gap-1.5">
         <Button size="sm" variant="ghost" onClick={onResetWeights}>
-          Reset Weights
+          Reset weights
         </Button>
         <Button size="sm" variant="ghost" onClick={onResetPrices}>
-          Reset Prices
+          Reset prices
         </Button>
+      </div>
+      <div className="grid grid-cols-[1fr_64px_72px] gap-1.5 px-1 text-[9px] text-text-dim uppercase tracking-wide">
+        <span>Scarab</span>
+        <span className="text-right">Weight</span>
+        <span className="text-right">Price (c)</span>
       </div>
       {sorted.map(({ cat, ev }, i) => (
         <div key={cat.id} className="rounded border border-white/10 px-2.5 py-2" style={{ background: zebraRowBg(i) }}>

--- a/src/renderer/src/features/scarab-atlas/calc.test.ts
+++ b/src/renderer/src/features/scarab-atlas/calc.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  calculateOptimalStrategy,
-  calculatePoolEV,
-  getEffectiveWeight,
-} from './calc'
+import { calculateOptimalStrategy, calculatePoolEV, getEffectiveWeight } from './calc'
 import type { ScarabCalcState, ScarabCatalog } from './types'
 
 const catalog: ScarabCatalog = {

--- a/src/renderer/src/features/scarab-atlas/calc.test.ts
+++ b/src/renderer/src/features/scarab-atlas/calc.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import {
+  calculateOptimalStrategy,
+  calculatePoolEV,
+  getEffectiveWeight,
+} from './calc'
+import type { ScarabCalcState, ScarabCatalog } from './types'
+
+const catalog: ScarabCatalog = {
+  version: 1,
+  vendorCategoryOrder: ['cheap', 'rich', 'boosty'],
+  categories: [
+    {
+      id: 'cheap',
+      name: 'Cheap',
+      atlasModifier: 'blockable',
+      investmentBoost: true,
+      scarabs: [{ id: 'c1', name: 'Cheap Scarab', weight: 1000, signature: 'Cheap', limit: null }],
+    },
+    {
+      id: 'rich',
+      name: 'Rich',
+      atlasModifier: 'blockable',
+      investmentBoost: true,
+      scarabs: [{ id: 'r1', name: 'Rich Scarab', weight: 100, signature: 'Rich', limit: null }],
+    },
+    {
+      id: 'boosty',
+      name: 'Boosty',
+      atlasModifier: 'boostable',
+      investmentBoost: false,
+      scarabs: [{ id: 'b1', name: 'Boosty Scarab', weight: 200, signature: 'Boosty', limit: null }],
+    },
+  ],
+}
+
+const state: ScarabCalcState = {
+  remarkableRelics: false,
+  blocked: [],
+  boosted: [],
+  invested: [],
+  weightOverrides: {},
+  priceOverrides: {},
+}
+
+const prices = {
+  'Cheap Scarab': 1,
+  'Rich Scarab': 50,
+  'Boosty Scarab': 20,
+}
+
+describe('scarab atlas calc', () => {
+  it('applies remarkable relics as weight^0.9', () => {
+    const w = getEffectiveWeight(catalog.categories[0].scarabs[0], {
+      ...state,
+      remarkableRelics: true,
+    })
+    expect(w).toBeCloseTo(Math.pow(1000, 0.9), 5)
+  })
+
+  it('blocks the cheap category below pool EV', () => {
+    const optimal = calculateOptimalStrategy(catalog, state, prices)
+    expect(optimal.blocks).toContain('cheap')
+    expect(optimal.blocks).not.toContain('rich')
+    expect(optimal.ev).toBeGreaterThan(
+      calculatePoolEV(catalog, state, prices, { blocks: [], boosts: [], investments: [] }),
+    )
+  })
+})

--- a/src/renderer/src/features/scarab-atlas/calc.ts
+++ b/src/renderer/src/features/scarab-atlas/calc.ts
@@ -1,0 +1,293 @@
+import type { ScarabCalcState, ScarabCatalog, ScarabCategory, ScarabDef } from './types'
+
+
+export const STORAGE_KEY = 'scarab-atlas-state'
+
+export const DEFAULT_STATE: ScarabCalcState = {
+  remarkableRelics: true,
+  blocked: [],
+  boosted: [],
+  invested: [],
+  weightOverrides: {},
+  priceOverrides: {},
+}
+
+export function loadState(): ScarabCalcState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { ...DEFAULT_STATE }
+    const parsed = JSON.parse(raw) as Partial<ScarabCalcState>
+    return {
+      remarkableRelics: parsed.remarkableRelics ?? true,
+      blocked: parsed.blocked ?? [],
+      boosted: parsed.boosted ?? [],
+      invested: parsed.invested ?? [],
+      weightOverrides: parsed.weightOverrides ?? {},
+      priceOverrides: parsed.priceOverrides ?? {},
+    }
+  } catch {
+    return { ...DEFAULT_STATE }
+  }
+}
+
+export function saveState(state: ScarabCalcState): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    /* ignore quota */
+  }
+}
+
+export function formatChaos(chaos: number | null | undefined): string {
+  if (chaos == null || Number.isNaN(chaos)) return '—'
+  if (Math.abs(chaos) >= 100) return `${Math.round(chaos)}c`
+  return `${chaos.toFixed(1)}c`
+}
+
+export function shortenScarabName(name: string): string {
+  return name.replace(/Scarab of /i, '').replace(/ Scarab$/i, '')
+}
+
+export function getEffectiveWeight(
+  scarab: ScarabDef,
+  state: ScarabCalcState,
+  applyRemarkable = true,
+): number {
+  let weight =
+    state.weightOverrides[scarab.id] !== undefined
+      ? state.weightOverrides[scarab.id]
+      : scarab.weight
+  if (applyRemarkable && state.remarkableRelics && weight > 0) {
+    weight = Math.pow(weight, 0.9)
+  }
+  return weight
+}
+
+export function getEffectivePrice(scarab: ScarabDef, state: ScarabCalcState, prices: Record<string, number>): number {
+  if (state.priceOverrides[scarab.id] !== undefined) return state.priceOverrides[scarab.id]
+  return prices[scarab.name] ?? 0
+}
+
+export function calculatePoolEV(
+  catalog: ScarabCatalog,
+  state: ScarabCalcState,
+  prices: Record<string, number>,
+  opts?: {
+    blocks?: string[]
+    boosts?: string[]
+    investments?: string[]
+    applyRemarkable?: boolean
+  },
+): number {
+  const blocks = new Set(opts?.blocks ?? state.blocked)
+  const boosts = new Set(opts?.boosts ?? state.boosted)
+  const investments = new Set(opts?.investments ?? state.invested)
+  const applyRemarkable = opts?.applyRemarkable ?? true
+
+  let totalWeight = 0
+  let totalValue = 0
+  for (const cat of catalog.categories) {
+    if (blocks.has(cat.id)) continue
+    let mult = 1
+    if (boosts.has(cat.id)) mult *= 2
+    if (investments.has(cat.id)) mult *= 1.5
+    for (const scarab of cat.scarabs) {
+      const w = getEffectiveWeight(scarab, state, applyRemarkable) * mult
+      totalWeight += w
+      totalValue += w * getEffectivePrice(scarab, state, prices)
+    }
+  }
+  return totalWeight > 0 ? totalValue / totalWeight : 0
+}
+
+export function calculateCategoryEV(
+  cat: ScarabCategory,
+  state: ScarabCalcState,
+  prices: Record<string, number>,
+): { ev: number; weight: number } {
+  let weight = 0
+  let value = 0
+  for (const scarab of cat.scarabs) {
+    const w = getEffectiveWeight(scarab, state)
+    weight += w
+    value += w * getEffectivePrice(scarab, state, prices)
+  }
+  return { ev: weight > 0 ? value / weight : 0, weight }
+}
+
+export interface OptimalStrategy {
+  blocks: string[]
+  boosts: string[]
+  investments: string[]
+  ev: number
+  marginals: Record<string, { block?: number; boost?: number; invest?: number }>
+}
+
+export function calculateOptimalStrategy(
+  catalog: ScarabCatalog,
+  state: ScarabCalcState,
+  prices: Record<string, number>,
+): OptimalStrategy {
+  const blockable = catalog.categories.filter((c) => c.atlasModifier === 'blockable')
+  const boostable = catalog.categories.filter((c) => c.atlasModifier === 'boostable')
+  const investable = catalog.categories.filter((c) => c.investmentBoost)
+
+  const calcEV = (blocks: string[], boosts: string[], investments: string[]): number =>
+    calculatePoolEV(catalog, state, prices, { blocks, boosts, investments })
+
+  const categoryEV = (cat: ScarabCategory): number => calculateCategoryEV(cat, state, prices).ev
+
+  // Block categories below unblocked pool EV
+  let poolWeight = 0
+  let poolValue = 0
+  for (const cat of catalog.categories) {
+    for (const scarab of cat.scarabs) {
+      const w = getEffectiveWeight(scarab, state)
+      poolWeight += w
+      poolValue += w * getEffectivePrice(scarab, state, prices)
+    }
+  }
+  let currentPoolEV = poolWeight > 0 ? poolValue / poolWeight : 0
+
+  const optimalBlocks: string[] = []
+  for (const cat of blockable) {
+    if (categoryEV(cat) < currentPoolEV) optimalBlocks.push(cat.id)
+  }
+
+  // Recalc pool after blocks
+  poolWeight = 0
+  poolValue = 0
+  for (const cat of catalog.categories) {
+    if (optimalBlocks.includes(cat.id)) continue
+    for (const scarab of cat.scarabs) {
+      const w = getEffectiveWeight(scarab, state)
+      poolWeight += w
+      poolValue += w * getEffectivePrice(scarab, state, prices)
+    }
+  }
+  currentPoolEV = poolWeight > 0 ? poolValue / poolWeight : 0
+
+  // Greedy boosts (2x)
+  const boostCandidates = boostable
+    .filter((c) => !optimalBlocks.includes(c.id))
+    .map((c) => ({ id: c.id, ev: categoryEV(c) }))
+    .sort((a, b) => b.ev - a.ev)
+
+  const optimalBoosts: string[] = []
+  for (const candidate of boostCandidates) {
+    if (candidate.ev > currentPoolEV) {
+      optimalBoosts.push(candidate.id)
+      currentPoolEV = calcEV(optimalBlocks, optimalBoosts, [])
+    } else break
+  }
+
+  // Greedy investments (1.5x)
+  const investCandidates = investable
+    .filter((c) => !optimalBlocks.includes(c.id))
+    .map((c) => ({ id: c.id, ev: categoryEV(c) }))
+    .sort((a, b) => b.ev - a.ev)
+
+  const optimalInvestments: string[] = []
+  for (const candidate of investCandidates) {
+    if (candidate.ev > currentPoolEV) {
+      optimalInvestments.push(candidate.id)
+      currentPoolEV = calcEV(optimalBlocks, optimalBoosts, optimalInvestments)
+    } else break
+  }
+
+  const optimalEV = currentPoolEV
+  const marginals: OptimalStrategy['marginals'] = {}
+
+  for (const id of optimalBlocks) {
+    const without = optimalBlocks.filter((b) => b !== id)
+    marginals[id] = { block: optimalEV - calcEV(without, optimalBoosts, optimalInvestments) }
+  }
+  for (const id of optimalBoosts) {
+    const without = optimalBoosts.filter((b) => b !== id)
+    if (!marginals[id]) marginals[id] = {}
+    marginals[id].boost = optimalEV - calcEV(optimalBlocks, without, optimalInvestments)
+  }
+  for (const id of optimalInvestments) {
+    const without = optimalInvestments.filter((i) => i !== id)
+    if (!marginals[id]) marginals[id] = {}
+    marginals[id].invest = optimalEV - calcEV(optimalBlocks, optimalBoosts, without)
+  }
+
+  // Alternatives for non-selected actions
+  for (const cat of blockable) {
+    if (optimalBlocks.includes(cat.id)) continue
+    if (!marginals[cat.id]) marginals[cat.id] = {}
+    const withBlock = [...optimalBlocks, cat.id]
+    marginals[cat.id].block = calcEV(withBlock, optimalBoosts, optimalInvestments) - optimalEV
+  }
+  for (const cat of boostable) {
+    if (optimalBoosts.includes(cat.id) || optimalBlocks.includes(cat.id)) continue
+    if (!marginals[cat.id]) marginals[cat.id] = {}
+    const withBoost = [...optimalBoosts, cat.id]
+    marginals[cat.id].boost = calcEV(optimalBlocks, withBoost, optimalInvestments) - optimalEV
+  }
+  for (const cat of investable) {
+    if (optimalInvestments.includes(cat.id) || optimalBlocks.includes(cat.id)) continue
+    if (cat.atlasModifier === 'blockable') continue
+    if (!marginals[cat.id]) marginals[cat.id] = {}
+    const withInvest = [...optimalInvestments, cat.id]
+    marginals[cat.id].invest = calcEV(optimalBlocks, optimalBoosts, withInvest) - optimalEV
+  }
+
+  return {
+    blocks: optimalBlocks,
+    boosts: optimalBoosts,
+    investments: optimalInvestments,
+    ev: optimalEV,
+    marginals,
+  }
+}
+
+export function buildVendorSearchString(
+  catalog: ScarabCatalog,
+  state: ScarabCalcState,
+  prices: Record<string, number>,
+): { search: string; included: number; total: number; missingSig: number } {
+  const MAX_LENGTH = 248
+  const baseline = calculatePoolEV(catalog, state, prices, {
+    blocks: [],
+    boosts: [],
+    investments: [],
+    applyRemarkable: false,
+  })
+  const threshold = baseline / 3
+
+  const vendorable = catalog.categories
+    .flatMap((c) => c.scarabs)
+    .filter((s) => getEffectivePrice(s, state, prices) < threshold)
+    .map((s) => ({
+      ...s,
+      profit: baseline - getEffectivePrice(s, state, prices) * 3,
+    }))
+    .sort((a, b) => b.profit - a.profit)
+
+  const withSig = vendorable.filter((s) => s.signature)
+  const missingSig = vendorable.length - withSig.length
+
+  const signatures: string[] = []
+  let currentLength = 0
+  for (const scarab of withSig) {
+    const sig = scarab.signature
+    const addLength = signatures.length === 0 ? sig.length : sig.length + 1
+    if (currentLength + addLength <= MAX_LENGTH) {
+      signatures.push(sig)
+      currentLength += addLength
+    }
+  }
+
+  return {
+    search: signatures.length ? `"${signatures.join('|')}"` : '(no vendorable scarabs)',
+    included: signatures.length,
+    total: vendorable.length,
+    missingSig,
+  }
+}
+
+export function toggleInList(list: string[], id: string): string[] {
+  return list.includes(id) ? list.filter((x) => x !== id) : [...list, id]
+}

--- a/src/renderer/src/features/scarab-atlas/calc.ts
+++ b/src/renderer/src/features/scarab-atlas/calc.ts
@@ -1,6 +1,5 @@
 import type { ScarabCalcState, ScarabCatalog, ScarabCategory, ScarabDef } from './types'
 
-
 export const STORAGE_KEY = 'scarab-atlas-state'
 
 export const DEFAULT_STATE: ScarabCalcState = {
@@ -48,15 +47,8 @@ export function shortenScarabName(name: string): string {
   return name.replace(/Scarab of /i, '').replace(/ Scarab$/i, '')
 }
 
-export function getEffectiveWeight(
-  scarab: ScarabDef,
-  state: ScarabCalcState,
-  applyRemarkable = true,
-): number {
-  let weight =
-    state.weightOverrides[scarab.id] !== undefined
-      ? state.weightOverrides[scarab.id]
-      : scarab.weight
+export function getEffectiveWeight(scarab: ScarabDef, state: ScarabCalcState, applyRemarkable = true): number {
+  let weight = state.weightOverrides[scarab.id] !== undefined ? state.weightOverrides[scarab.id] : scarab.weight
   if (applyRemarkable && state.remarkableRelics && weight > 0) {
     weight = Math.pow(weight, 0.9)
   }

--- a/src/renderer/src/features/scarab-atlas/guidance.ts
+++ b/src/renderer/src/features/scarab-atlas/guidance.ts
@@ -1,0 +1,76 @@
+/** User-facing copy for Scarab Atlas guidance. Keep jargon out of the default path. */
+
+export const GUIDE_DISMISS_KEY = 'scarab-atlas-guide-dismissed'
+export const ADVANCED_DELTAS_KEY = 'scarab-atlas-show-deltas'
+
+export const TAB_BLURBS: Record<'calculator' | 'vendor' | 'weights', string> = {
+  calculator:
+    'Plan your atlas tree for scarab drops. Block junk categories, boost valuable ones, then mirror those choices in-game.',
+  vendor:
+    'Separate from the atlas: find cheap scarabs to sell 3-for-1 to the vendor when the random return is worth more.',
+  weights:
+    'Advanced. Override drop weights or chaos prices if you disagree with the defaults. Most players can skip this.',
+}
+
+export const HOW_TO_STEPS = [
+  {
+    title: 'Prices load from your league',
+    body: 'Uses Scalpel’s active league (shown in the subtitle). Wait until “priced” looks full.',
+  },
+  {
+    title: 'Press Optimize',
+    body: 'Applies suggested Block / Boost / Invest on this list. That is what to put on your atlas tree.',
+  },
+  {
+    title: 'Mirror it in Path of Exile',
+    body: 'Take those same blocks and “more scarabs” / investment notables on your real atlas.',
+  },
+  {
+    title: 'Optional: Vendor Guide',
+    body: 'Use the other tab to dump worthless scarabs via the 3→1 vendor recipe.',
+  },
+] as const
+
+export const EV_LABELS = {
+  baseline: {
+    label: 'No bias',
+    hint: 'Average chaos value of a random scarab drop with no blocks, boosts, or invests.',
+  },
+  current: {
+    label: 'Your setup',
+    hint: 'Average drop value with the Block / Boost / Invest buttons you have selected below.',
+  },
+  optimal: {
+    label: 'Recommended',
+    hint: 'Best average drop value this tool’s strategy found. Press Optimize to apply it.',
+  },
+} as const
+
+export function atlasModifierLabel(mod: 'none' | 'blockable' | 'boostable'): string {
+  switch (mod) {
+    case 'blockable':
+      return 'Can block'
+    case 'boostable':
+      return 'Can boost ×2'
+    default:
+      return 'No atlas lever'
+  }
+}
+
+export function loadBool(key: string, fallback: boolean): boolean {
+  try {
+    const raw = localStorage.getItem(key)
+    if (raw === null) return fallback
+    return raw === '1'
+  } catch {
+    return fallback
+  }
+}
+
+export function saveBool(key: string, value: boolean): void {
+  try {
+    localStorage.setItem(key, value ? '1' : '0')
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/renderer/src/features/scarab-atlas/index.ts
+++ b/src/renderer/src/features/scarab-atlas/index.ts
@@ -1,0 +1,1 @@
+export { ScarabAtlas } from './ScarabAtlas'

--- a/src/renderer/src/features/scarab-atlas/scarab-catalog.json
+++ b/src/renderer/src/features/scarab-atlas/scarab-catalog.json
@@ -1,0 +1,1069 @@
+{
+  "version": 1,
+  "vendorCategoryOrder": [
+    "titanic",
+    "sulphite",
+    "divination",
+    "anarchy",
+    "ritual",
+    "harvest",
+    "kalguuran",
+    "influencing",
+    "bestiary",
+    "trarthan",
+    "betrayal",
+    "incursion",
+    "domination",
+    "torment",
+    "cartography",
+    "beyond",
+    "ambush",
+    "ultimatum",
+    "expedition",
+    "delirium",
+    "legion",
+    "blight",
+    "abyss",
+    "essence",
+    "breach",
+    "misc",
+    "horned"
+  ],
+  "categories": [
+    {
+      "id": "titanic",
+      "name": "Titanic",
+      "atlasModifier": "boostable",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "titanic-scarab",
+          "name": "Titanic Scarab",
+          "weight": 616,
+          "signature": "Titanic Scarab",
+          "limit": 1
+        },
+        {
+          "id": "titanic-scarab-of-legend",
+          "name": "Titanic Scarab of Legend",
+          "weight": 212,
+          "signature": "Legend",
+          "limit": 1
+        },
+        {
+          "id": "titanic-scarab-of-treasures",
+          "name": "Titanic Scarab of Treasures",
+          "weight": 187,
+          "signature": "Titanic Scarab of Treasures",
+          "limit": 3
+        }
+      ]
+    },
+    {
+      "id": "sulphite",
+      "name": "Sulphite",
+      "atlasModifier": "none",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "sulphite-scarab",
+          "name": "Sulphite Scarab",
+          "weight": 657,
+          "signature": "Sulphite Scarab",
+          "limit": 1
+        },
+        {
+          "id": "sulphite-scarab-of-fumes",
+          "name": "Sulphite Scarab of Fumes",
+          "weight": 224,
+          "signature": "Fumes",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "divination",
+      "name": "Divination",
+      "atlasModifier": "boostable",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "divination-scarab-of-pilfering",
+          "name": "Divination Scarab of Pilfering",
+          "weight": 19,
+          "signature": "Pilfering",
+          "limit": 1
+        },
+        {
+          "id": "divination-scarab-of-plenty",
+          "name": "Divination Scarab of Plenty",
+          "weight": 211,
+          "signature": "Plenty",
+          "limit": 5
+        },
+        {
+          "id": "divination-scarab-of-the-cloister",
+          "name": "Divination Scarab of The Cloister",
+          "weight": 661,
+          "signature": "Cloister",
+          "limit": 5
+        }
+      ]
+    },
+    {
+      "id": "anarchy",
+      "name": "Anarchy",
+      "atlasModifier": "boostable",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "anarchy-scarab",
+          "name": "Anarchy Scarab",
+          "weight": 628,
+          "signature": "Anarchy Scarab",
+          "limit": 5
+        },
+        {
+          "id": "anarchy-scarab-of-gigantification",
+          "name": "Anarchy Scarab of Gigantification",
+          "weight": 414,
+          "signature": "Gigantification",
+          "limit": 2
+        },
+        {
+          "id": "anarchy-scarab-of-partnership",
+          "name": "Anarchy Scarab of Partnership",
+          "weight": 239,
+          "signature": "Partnership",
+          "limit": 1
+        },
+        {
+          "id": "anarchy-scarab-of-the-exceptional",
+          "name": "Anarchy Scarab of the Exceptional",
+          "weight": 0,
+          "signature": "Exceptional",
+          "limit": 2
+        }
+      ]
+    },
+    {
+      "id": "ritual",
+      "name": "Ritual",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "ritual-scarab-of-abundance",
+          "name": "Ritual Scarab of Abundance",
+          "weight": 226,
+          "signature": "Abundance",
+          "limit": 2
+        },
+        {
+          "id": "ritual-scarab-of-corpses",
+          "name": "Ritual Scarab of Corpses",
+          "weight": 0,
+          "signature": "Corpses",
+          "limit": 2
+        },
+        {
+          "id": "ritual-scarab-of-selectiveness",
+          "name": "Ritual Scarab of Selectiveness",
+          "weight": 674,
+          "signature": "Selectiveness",
+          "limit": 2
+        },
+        {
+          "id": "ritual-scarab-of-wisps",
+          "name": "Ritual Scarab of Wisps",
+          "weight": 421,
+          "signature": "Ritual Scarab of Wisps",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "harvest",
+      "name": "Harvest",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "harvest-scarab",
+          "name": "Harvest Scarab",
+          "weight": 649,
+          "signature": "Harvest Scarab",
+          "limit": 1
+        },
+        {
+          "id": "harvest-scarab-of-cornucopia",
+          "name": "Harvest Scarab of Cornucopia",
+          "weight": 25,
+          "signature": "Cornucopia",
+          "limit": 1
+        },
+        {
+          "id": "harvest-scarab-of-doubling",
+          "name": "Harvest Scarab of Doubling",
+          "weight": 218,
+          "signature": "Doubling",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "kalguuran",
+      "name": "Kalguuran",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "kalguuran-scarab",
+          "name": "Kalguuran Scarab",
+          "weight": 612,
+          "signature": "Kalguuran Scarab",
+          "limit": 2
+        },
+        {
+          "id": "kalguuran-scarab-of-enriching",
+          "name": "Kalguuran Scarab of Enriching",
+          "weight": 0,
+          "signature": "Enriching",
+          "limit": 1
+        },
+        {
+          "id": "kalguuran-scarab-of-guarded-riches",
+          "name": "Kalguuran Scarab of Guarded Riches",
+          "weight": 420,
+          "signature": "Riches",
+          "limit": 1
+        },
+        {
+          "id": "kalguuran-scarab-of-refinement",
+          "name": "Kalguuran Scarab of Refinement",
+          "weight": 29,
+          "signature": "Refinement",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "influencing",
+      "name": "Influencing",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "influencing-scarab-of-hordes",
+          "name": "Influencing Scarab of Hordes",
+          "weight": 436,
+          "signature": "Hordes",
+          "limit": 1
+        },
+        {
+          "id": "influencing-scarab-of-interference",
+          "name": "Influencing Scarab of Interference",
+          "weight": 0,
+          "signature": "Interference",
+          "limit": 1
+        },
+        {
+          "id": "influencing-scarab-of-the-elder",
+          "name": "Influencing Scarab of the Elder",
+          "weight": 518,
+          "signature": "Elder",
+          "limit": 1
+        },
+        {
+          "id": "influencing-scarab-of-the-shaper",
+          "name": "Influencing Scarab of the Shaper",
+          "weight": 558,
+          "signature": "Shaper",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "bestiary",
+      "name": "Bestiary",
+      "atlasModifier": "none",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "bestiary-scarab",
+          "name": "Bestiary Scarab",
+          "weight": 576,
+          "signature": "Bestiary Scarab",
+          "limit": 1
+        },
+        {
+          "id": "bestiary-scarab-of-duplicating",
+          "name": "Bestiary Scarab of Duplicating",
+          "weight": 217,
+          "signature": "Duplicating",
+          "limit": 1
+        },
+        {
+          "id": "bestiary-scarab-of-the-herd",
+          "name": "Bestiary Scarab of the Herd",
+          "weight": 389,
+          "signature": "Herd",
+          "limit": 2
+        }
+      ]
+    },
+    {
+      "id": "trarthan",
+      "name": "Trarthan",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "trarthan-scarab",
+          "name": "Trarthan Scarab",
+          "weight": 0,
+          "signature": "Trarthan Scarab",
+          "limit": null
+        },
+        {
+          "id": "trarthan-scarab-of-infamy",
+          "name": "Trarthan Scarab of Infamy",
+          "weight": 0,
+          "signature": "Infamy",
+          "limit": null
+        },
+        {
+          "id": "trarthan-scarab-of-renown",
+          "name": "Trarthan Scarab of Renown",
+          "weight": 0,
+          "signature": "Renown",
+          "limit": null
+        },
+        {
+          "id": "trarthan-scarab-of-surprising-alliances",
+          "name": "Trarthan Scarab of Surprising Alliances",
+          "weight": 0,
+          "signature": "Alliances",
+          "limit": null
+        }
+      ]
+    },
+    {
+      "id": "betrayal",
+      "name": "Betrayal",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "betrayal-scarab",
+          "name": "Betrayal Scarab",
+          "weight": 593,
+          "signature": "Betrayal Scarab",
+          "limit": 1
+        },
+        {
+          "id": "betrayal-scarab-of-reinforcements",
+          "name": "Betrayal Scarab of Reinforcements",
+          "weight": 439,
+          "signature": "Reinforcements",
+          "limit": 1
+        },
+        {
+          "id": "betrayal-scarab-of-the-allflame",
+          "name": "Betrayal Scarab of the Allflame",
+          "weight": 426,
+          "signature": "Allflame",
+          "limit": 1
+        },
+        {
+          "id": "betrayal-scarab-of-unbreaking",
+          "name": "Betrayal Scarab of Unbreaking",
+          "weight": 0,
+          "signature": "Unbreaking",
+          "limit": 2
+        }
+      ]
+    },
+    {
+      "id": "incursion",
+      "name": "Incursion",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "incursion-scarab",
+          "name": "Incursion Scarab",
+          "weight": 617,
+          "signature": "Incursion Scarab",
+          "limit": 1
+        },
+        {
+          "id": "incursion-scarab-of-champions",
+          "name": "Incursion Scarab of Champions",
+          "weight": 187,
+          "signature": "Champions",
+          "limit": 2
+        },
+        {
+          "id": "incursion-scarab-of-invasion",
+          "name": "Incursion Scarab of Invasion",
+          "weight": 421,
+          "signature": "Incursion Scarab of Invasion",
+          "limit": 3
+        },
+        {
+          "id": "incursion-scarab-of-timelines",
+          "name": "Incursion Scarab of Timelines",
+          "weight": 24,
+          "signature": "Timelines",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "domination",
+      "name": "Domination",
+      "atlasModifier": "boostable",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "domination-scarab",
+          "name": "Domination Scarab",
+          "weight": 652,
+          "signature": "Domination Scarab",
+          "limit": 4
+        },
+        {
+          "id": "domination-scarab-of-apparitions",
+          "name": "Domination Scarab of Apparitions",
+          "weight": 365,
+          "signature": "Apparitions",
+          "limit": 1
+        },
+        {
+          "id": "domination-scarab-of-evolution",
+          "name": "Domination Scarab of Evolution",
+          "weight": 215,
+          "signature": "Evolution",
+          "limit": 2
+        },
+        {
+          "id": "domination-scarab-of-terrors",
+          "name": "Domination Scarab of Terrors",
+          "weight": 26,
+          "signature": "Terrors",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "torment",
+      "name": "Torment",
+      "atlasModifier": "boostable",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "torment-scarab",
+          "name": "Torment Scarab",
+          "weight": 605,
+          "signature": "Torment Scarab",
+          "limit": 2
+        },
+        {
+          "id": "torment-scarab-of-peculiarity",
+          "name": "Torment Scarab of Peculiarity",
+          "weight": 403,
+          "signature": "Peculiarity",
+          "limit": 1
+        },
+        {
+          "id": "torment-scarab-of-possession",
+          "name": "Torment Scarab of Possession",
+          "weight": 197,
+          "signature": "Possession",
+          "limit": 3
+        }
+      ]
+    },
+    {
+      "id": "cartography",
+      "name": "Cartography",
+      "atlasModifier": "boostable",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "cartography-scarab-of-corruption",
+          "name": "Cartography Scarab of Corruption",
+          "weight": 192,
+          "signature": "Corruption",
+          "limit": 1
+        },
+        {
+          "id": "cartography-scarab-of-escalation",
+          "name": "Cartography Scarab of Escalation",
+          "weight": 645,
+          "signature": "Escalation",
+          "limit": 1
+        },
+        {
+          "id": "cartography-scarab-of-risk",
+          "name": "Cartography Scarab of Risk",
+          "weight": 30,
+          "signature": "Risk",
+          "limit": 1
+        },
+        {
+          "id": "cartography-scarab-of-the-multitude",
+          "name": "Cartography Scarab of the Multitude",
+          "weight": 430,
+          "signature": "the Multitude",
+          "limit": 3
+        }
+      ]
+    },
+    {
+      "id": "beyond",
+      "name": "Beyond",
+      "atlasModifier": "boostable",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "beyond-scarab",
+          "name": "Beyond Scarab",
+          "weight": 558,
+          "signature": "Beyond Scarab",
+          "limit": 1
+        },
+        {
+          "id": "beyond-scarab-of-haemophilia",
+          "name": "Beyond Scarab of Haemophilia",
+          "weight": 418,
+          "signature": "Haemophilia",
+          "limit": 2
+        },
+        {
+          "id": "beyond-scarab-of-resurgence",
+          "name": "Beyond Scarab of Resurgence",
+          "weight": 208,
+          "signature": "Resurgence",
+          "limit": 1
+        },
+        {
+          "id": "beyond-scarab-of-the-invasion",
+          "name": "Beyond Scarab of the Invasion",
+          "weight": 213,
+          "signature": "the Invasion",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "ambush",
+      "name": "Ambush",
+      "atlasModifier": "boostable",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "ambush-scarab",
+          "name": "Ambush Scarab",
+          "weight": 646,
+          "signature": "Ambush Scarab",
+          "limit": 3
+        },
+        {
+          "id": "ambush-scarab-of-containment",
+          "name": "Ambush Scarab of Containment",
+          "weight": 13,
+          "signature": "Containment",
+          "limit": 1
+        },
+        {
+          "id": "ambush-scarab-of-discernment",
+          "name": "Ambush Scarab of Discernment",
+          "weight": 210,
+          "signature": "Discernment",
+          "limit": 1
+        },
+        {
+          "id": "ambush-scarab-of-hidden-compartments",
+          "name": "Ambush Scarab of Hidden Compartments",
+          "weight": 415,
+          "signature": "Hidden",
+          "limit": 1
+        },
+        {
+          "id": "ambush-scarab-of-potency",
+          "name": "Ambush Scarab of Potency",
+          "weight": 400,
+          "signature": "Potency",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "ultimatum",
+      "name": "Ultimatum",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "ultimatum-scarab",
+          "name": "Ultimatum Scarab",
+          "weight": 514,
+          "signature": "Ultimatum Scarab",
+          "limit": 1
+        },
+        {
+          "id": "ultimatum-scarab-of-bribing",
+          "name": "Ultimatum Scarab of Bribing",
+          "weight": 420,
+          "signature": "Bribing",
+          "limit": 2
+        },
+        {
+          "id": "ultimatum-scarab-of-catalysing",
+          "name": "Ultimatum Scarab of Catalysing",
+          "weight": 22,
+          "signature": "Catalysing",
+          "limit": 1
+        },
+        {
+          "id": "ultimatum-scarab-of-dueling",
+          "name": "Ultimatum Scarab of Dueling",
+          "weight": 18,
+          "signature": "Dueling",
+          "limit": 1
+        },
+        {
+          "id": "ultimatum-scarab-of-inscription",
+          "name": "Ultimatum Scarab of Inscription",
+          "weight": 179,
+          "signature": "Inscription",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "expedition",
+      "name": "Expedition",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "expedition-scarab",
+          "name": "Expedition Scarab",
+          "weight": 652,
+          "signature": "Expedition Scarab",
+          "limit": 1
+        },
+        {
+          "id": "expedition-scarab-of-archaeology",
+          "name": "Expedition Scarab of Archaeology",
+          "weight": 234,
+          "signature": "Archaeology",
+          "limit": 1
+        },
+        {
+          "id": "expedition-scarab-of-infusion",
+          "name": "Expedition Scarab of Infusion",
+          "weight": 0,
+          "signature": "Infusion",
+          "limit": 1
+        },
+        {
+          "id": "expedition-scarab-of-runefinding",
+          "name": "Expedition Scarab of Runefinding",
+          "weight": 406,
+          "signature": "Runefinding",
+          "limit": 2
+        },
+        {
+          "id": "expedition-scarab-of-verisium-powder",
+          "name": "Expedition Scarab of Verisium Powder",
+          "weight": 412,
+          "signature": "Powder",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "delirium",
+      "name": "Delirium",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "delirium-scarab",
+          "name": "Delirium Scarab",
+          "weight": 631,
+          "signature": "Delirium Scarab",
+          "limit": 1
+        },
+        {
+          "id": "delirium-scarab-of-delusions",
+          "name": "Delirium Scarab of Delusions",
+          "weight": 193,
+          "signature": "Delusions",
+          "limit": 1
+        },
+        {
+          "id": "delirium-scarab-of-mania",
+          "name": "Delirium Scarab of Mania",
+          "weight": 434,
+          "signature": "Mania",
+          "limit": 2
+        },
+        {
+          "id": "delirium-scarab-of-neuroses",
+          "name": "Delirium Scarab of Neuroses",
+          "weight": 210,
+          "signature": "Neuroses",
+          "limit": 1
+        },
+        {
+          "id": "delirium-scarab-of-paranoia",
+          "name": "Delirium Scarab of Paranoia",
+          "weight": 413,
+          "signature": "Paranoia",
+          "limit": 5
+        }
+      ]
+    },
+    {
+      "id": "legion",
+      "name": "Legion",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "legion-scarab",
+          "name": "Legion Scarab",
+          "weight": 630,
+          "signature": "Legion Scarab",
+          "limit": 5
+        },
+        {
+          "id": "legion-scarab-of-eternal-conflict",
+          "name": "Legion Scarab of Eternal Conflict",
+          "weight": 24,
+          "signature": "Eternal",
+          "limit": 1
+        },
+        {
+          "id": "legion-scarab-of-officers",
+          "name": "Legion Scarab of Officers",
+          "weight": 208,
+          "signature": "Officers",
+          "limit": 1
+        },
+        {
+          "id": "legion-scarab-of-treasures",
+          "name": "Legion Scarab of Treasures",
+          "weight": 0,
+          "signature": "Legion Scarab of Treasures",
+          "limit": 3
+        }
+      ]
+    },
+    {
+      "id": "blight",
+      "name": "Blight",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "blight-scarab",
+          "name": "Blight Scarab",
+          "weight": 479,
+          "signature": "Blight Scarab",
+          "limit": 1
+        },
+        {
+          "id": "blight-scarab-of-blooming",
+          "name": "Blight Scarab of Blooming",
+          "weight": 32,
+          "signature": "Blooming",
+          "limit": 1
+        },
+        {
+          "id": "blight-scarab-of-invigoration",
+          "name": "Blight Scarab of Invigoration",
+          "weight": 23,
+          "signature": "Invigoration",
+          "limit": 1
+        },
+        {
+          "id": "blight-scarab-of-the-blightheart",
+          "name": "Blight Scarab of the Blightheart",
+          "weight": 201,
+          "signature": "Blightheart",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "abyss",
+      "name": "Abyss",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "abyss-scarab",
+          "name": "Abyss Scarab",
+          "weight": 601,
+          "signature": "Abyss Scarab",
+          "limit": 2
+        },
+        {
+          "id": "abyss-scarab-of-crystals",
+          "name": "Abyss Scarab of Crystals",
+          "weight": 0,
+          "signature": "Crystals",
+          "limit": null
+        },
+        {
+          "id": "abyss-scarab-of-descending",
+          "name": "Abyss Scarab of Descending",
+          "weight": 0,
+          "signature": "Descending",
+          "limit": 1
+        },
+        {
+          "id": "abyss-scarab-of-edifice",
+          "name": "Abyss Scarab of Edifice",
+          "weight": 190,
+          "signature": "Edifice",
+          "limit": 1
+        },
+        {
+          "id": "abyss-scarab-of-multitudes",
+          "name": "Abyss Scarab of Multitudes",
+          "weight": 411,
+          "signature": "Multitudes",
+          "limit": 2
+        },
+        {
+          "id": "abyss-scarab-of-profound-depth",
+          "name": "Abyss Scarab of Profound Depth",
+          "weight": 26,
+          "signature": "Depth",
+          "limit": 1
+        },
+        {
+          "id": "abyss-scarab-of-the-consort",
+          "name": "Abyss Scarab of the Consort",
+          "weight": 0,
+          "signature": "Consort",
+          "limit": null
+        }
+      ]
+    },
+    {
+      "id": "essence",
+      "name": "Essence",
+      "atlasModifier": "boostable",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "essence-scarab",
+          "name": "Essence Scarab",
+          "weight": 603,
+          "signature": "Essence Scarab",
+          "limit": 5
+        },
+        {
+          "id": "essence-scarab-of-adaptation",
+          "name": "Essence Scarab of Adaptation",
+          "weight": 21,
+          "signature": "Adaptation",
+          "limit": 1
+        },
+        {
+          "id": "essence-scarab-of-ascent",
+          "name": "Essence Scarab of Ascent",
+          "weight": 203,
+          "signature": "Ascent",
+          "limit": 1
+        },
+        {
+          "id": "essence-scarab-of-calcification",
+          "name": "Essence Scarab of Calcification",
+          "weight": 24,
+          "signature": "Calcification",
+          "limit": 1
+        },
+        {
+          "id": "essence-scarab-of-stability",
+          "name": "Essence Scarab of Stability",
+          "weight": 407,
+          "signature": "Essence Scarab of Stability",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "breach",
+      "name": "Breach",
+      "atlasModifier": "blockable",
+      "investmentBoost": true,
+      "scarabs": [
+        {
+          "id": "breach-scarab-of-instability",
+          "name": "Breach Scarab of Instability",
+          "weight": 0,
+          "signature": "Instability",
+          "limit": 2
+        },
+        {
+          "id": "breach-scarab-of-resonant-cascade",
+          "name": "Breach Scarab of Resonant Cascade",
+          "weight": 0,
+          "signature": "Cascade",
+          "limit": 1
+        },
+        {
+          "id": "breach-scarab-of-the-hive",
+          "name": "Breach Scarab of the Hive",
+          "weight": 0,
+          "signature": "Hive",
+          "limit": 1
+        },
+        {
+          "id": "breach-scarab-of-the-incensed-swarm",
+          "name": "Breach Scarab of the Incensed Swarm",
+          "weight": 0,
+          "signature": "Swarm",
+          "limit": 1
+        },
+        {
+          "id": "breach-scarab-of-the-marshal",
+          "name": "Breach Scarab of the Marshal",
+          "weight": 0,
+          "signature": "Marshal",
+          "limit": 1
+        }
+      ]
+    },
+    {
+      "id": "misc",
+      "name": "Miscellaneous",
+      "atlasModifier": "none",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "scarab-of-adversaries",
+          "name": "Scarab of Adversaries",
+          "weight": 634,
+          "signature": "Adversaries",
+          "limit": 2
+        },
+        {
+          "id": "scarab-of-divinity",
+          "name": "Scarab of Divinity",
+          "weight": 403,
+          "signature": "Divinity",
+          "limit": 3
+        },
+        {
+          "id": "scarab-of-monstrous-lineage",
+          "name": "Scarab of Monstrous Lineage",
+          "weight": 613,
+          "signature": "Lineage",
+          "limit": 2
+        },
+        {
+          "id": "scarab-of-radiant-storms",
+          "name": "Scarab of Radiant Storms",
+          "weight": 32,
+          "signature": "Storms",
+          "limit": 1
+        },
+        {
+          "id": "scarab-of-stability",
+          "name": "Scarab of Stability",
+          "weight": 183,
+          "signature": "Scarab of Stability",
+          "limit": 1
+        },
+        {
+          "id": "scarab-of-the-dextral",
+          "name": "Scarab of the Dextral",
+          "weight": 0,
+          "signature": "Dextral",
+          "limit": 1
+        },
+        {
+          "id": "scarab-of-the-sinistral",
+          "name": "Scarab of the Sinistral",
+          "weight": 0,
+          "signature": "Sinistral",
+          "limit": 1
+        },
+        {
+          "id": "scarab-of-wisps",
+          "name": "Scarab of Wisps",
+          "weight": 212,
+          "signature": "Scarab of Wisps",
+          "limit": 2
+        }
+      ]
+    },
+    {
+      "id": "horned",
+      "name": "Horned",
+      "atlasModifier": "none",
+      "investmentBoost": false,
+      "scarabs": [
+        {
+          "id": "horned-scarab-of-awakening",
+          "name": "Horned Scarab of Awakening",
+          "weight": 19,
+          "signature": "Awakening",
+          "limit": 1
+        },
+        {
+          "id": "horned-scarab-of-bloodlines",
+          "name": "Horned Scarab of Bloodlines",
+          "weight": 34,
+          "signature": "Bloodlines",
+          "limit": 1
+        },
+        {
+          "id": "horned-scarab-of-glittering",
+          "name": "Horned Scarab of Glittering",
+          "weight": 24,
+          "signature": "Glittering",
+          "limit": 1
+        },
+        {
+          "id": "horned-scarab-of-nemeses",
+          "name": "Horned Scarab of Nemeses",
+          "weight": 219,
+          "signature": "Nemeses",
+          "limit": 2
+        },
+        {
+          "id": "horned-scarab-of-pandemonium",
+          "name": "Horned Scarab of Pandemonium",
+          "weight": 19,
+          "signature": "Pandemonium",
+          "limit": 1
+        },
+        {
+          "id": "horned-scarab-of-preservation",
+          "name": "Horned Scarab of Preservation",
+          "weight": 3,
+          "signature": "Preservation",
+          "limit": 1
+        },
+        {
+          "id": "horned-scarab-of-tradition",
+          "name": "Horned Scarab of Tradition",
+          "weight": 23,
+          "signature": "Tradition",
+          "limit": 1
+        }
+      ]
+    }
+  ]
+}

--- a/src/renderer/src/features/scarab-atlas/types.ts
+++ b/src/renderer/src/features/scarab-atlas/types.ts
@@ -1,0 +1,34 @@
+export type AtlasModifier = 'none' | 'blockable' | 'boostable'
+
+export interface ScarabDef {
+  id: string
+  name: string
+  weight: number
+  signature: string
+  limit: number | null
+}
+
+export interface ScarabCategory {
+  id: string
+  name: string
+  atlasModifier: AtlasModifier
+  investmentBoost: boolean
+  scarabs: ScarabDef[]
+}
+
+export interface ScarabCatalog {
+  version: number
+  vendorCategoryOrder: string[]
+  categories: ScarabCategory[]
+}
+
+export type TabId = 'calculator' | 'vendor' | 'weights'
+
+export interface ScarabCalcState {
+  remarkableRelics: boolean
+  blocked: string[]
+  boosted: string[]
+  invested: string[]
+  weightOverrides: Record<string, number>
+  priceOverrides: Record<string, number>
+}

--- a/src/renderer/src/features/settings/tabs/ViewTab.tsx
+++ b/src/renderer/src/features/settings/tabs/ViewTab.tsx
@@ -88,6 +88,18 @@ export function ViewTab({ settings, update, updateMany }: Props): JSX.Element {
       show: features.divCards,
     },
     {
+      key: 'scarabs',
+      icon: (
+        <img
+          src="https://web.poecdn.com/gen/image/WzI1LDE0LHsiZiI6IjJESXRlbXMvQ3VycmVuY3kvU2NhcmFicy9MZXNzZXJTY2FyYWJBYnlzcyIsInNjYWxlIjoxfV0/05f3ac3c5c/LesserScarabAbyss.png"
+          alt=""
+          className="w-[18px] h-[18px] object-contain"
+        />
+      ),
+      title: m.feature_scarab_atlas(),
+      show: features.scarabAtlas,
+    },
+    {
       key: 'regex',
       icon: <img src={poereIcon} alt="" className="w-[18px] h-[18px] object-contain" />,
       title: m.feature_regex_tool(),

--- a/src/renderer/src/features/settings/tabs/utils.ts
+++ b/src/renderer/src/features/settings/tabs/utils.ts
@@ -5,6 +5,7 @@ export const APP_MACRO_DEFS = [
   { id: 'openAudit', label: 'Open Audit' },
   { id: 'openDust', label: 'Open Dust Explorer' },
   { id: 'openDivCards', label: 'Open Div Card Explorer' },
+  { id: 'openScarabs', label: 'Open Scarab Atlas' },
   { id: 'openRegex', label: 'Open Regex Tool' },
   { id: 'openWiki', label: 'Open Wiki' },
   { id: 'openPoeDb', label: 'Open PoEDB' },

--- a/src/renderer/src/overlay/App.tsx
+++ b/src/renderer/src/overlay/App.tsx
@@ -17,6 +17,7 @@ import { SettingsPanel } from '../features/settings/SettingsPanel'
 import { SocketRecolor } from '../features/socket-recolor'
 import { DustExplorer } from '../features/dust-explorer'
 import { DivCardExplorer } from '../features/div-card-explorer'
+import { ScarabAtlas } from '../features/scarab-atlas'
 import { RegexTool } from '../features/regex'
 import { ExtraFeaturesPanel } from '../components/extra-features/ExtraFeaturesPanel'
 import { PriceCheck } from '../features/price-check'
@@ -409,12 +410,13 @@ export default function App(): JSX.Element {
         if (v === 'audit') {
           auditPending.current = true
         } else {
-          const valid = ['setup', 'dust', 'divcards', 'regex'] as const
+          const valid = ['setup', 'dust', 'divcards', 'scarabs', 'regex'] as const
           if (!valid.includes(v as (typeof valid)[number])) return
           // Don't reopen tabs that the active game has disabled (e.g. regex on PoE2).
           const active = getGameFeatures(settings?.poeVersion ?? 1)
           if (v === 'dust' && !active.dustExplorer) return
           if (v === 'divcards' && !active.divCards) return
+          if (v === 'scarabs' && !active.scarabAtlas) return
           if (v === 'regex' && !active.regexTool) return
           setView(v as View)
           // Optional second arg: the settings sub-tab to focus. Bump a
@@ -674,6 +676,7 @@ export default function App(): JSX.Element {
   const isFullHeightView =
     view === 'dust' ||
     view === 'divcards' ||
+    view === 'scarabs' ||
     view === 'pricecheck' ||
     view === 'item' ||
     view === 'regex' ||
@@ -1045,6 +1048,11 @@ export default function App(): JSX.Element {
                 {features.divCards && (
                   <div className="flex-col flex-1 min-h-0" style={{ display: view === 'divcards' ? 'flex' : 'none' }}>
                     <DivCardExplorer onSelectItem={() => setView('item')} />
+                  </div>
+                )}
+                {features.scarabAtlas && (
+                  <div className="flex-col flex-1 min-h-0" style={{ display: view === 'scarabs' ? 'flex' : 'none' }}>
+                    <ScarabAtlas />
                   </div>
                 )}
                 {features.regexTool && poeVersion !== null && settings && (

--- a/src/renderer/src/overlay/TitleBar.tsx
+++ b/src/renderer/src/overlay/TitleBar.tsx
@@ -148,6 +148,22 @@ export function TitleBar({
             <img src={DIV_CARD_ICON_URL} alt="" className="w-[18px] h-[18px] object-contain" />
           </button>
         )}
+        {features.scarabAtlas && !hiddenTabs.has('scarabs') && (
+          <button
+            onClick={() => onSetView('scarabs')}
+            title={m.feature_scarab_atlas()}
+            className="btn-bounce w-[30px] h-[30px] flex items-center justify-center p-0.5"
+            style={{
+              background: view === 'scarabs' ? 'var(--accent)' : undefined,
+            }}
+          >
+            <img
+              src="https://web.poecdn.com/gen/image/WzI1LDE0LHsiZiI6IjJESXRlbXMvQ3VycmVuY3kvU2NhcmFicy9MZXNzZXJTY2FyYWJBYnlzcyIsInNjYWxlIjoxfV0/05f3ac3c5c/LesserScarabAbyss.png"
+              alt=""
+              className="w-[18px] h-[18px] object-contain"
+            />
+          </button>
+        )}
         {features.regexTool && !hiddenTabs.has('regex') && (
           <button
             onClick={() => onSetView('regex')}

--- a/src/renderer/src/overlay/view.ts
+++ b/src/renderer/src/overlay/view.ts
@@ -8,6 +8,7 @@ export type BuiltinView =
   | 'tools'
   | 'dust'
   | 'divcards'
+  | 'scarabs'
   | 'pricecheck'
   | 'regex'
   | 'extras'

--- a/src/shared/contracts/items.ts
+++ b/src/shared/contracts/items.ts
@@ -226,7 +226,7 @@ export interface SearchableItem {
   flags?: { zanaMemory?: boolean }
 }
 
-export const HIDEABLE_TAB_KEYS = ['item', 'pricecheck', 'dust', 'divcards', 'regex', 'extras'] as const
+export const HIDEABLE_TAB_KEYS = ['item', 'pricecheck', 'dust', 'divcards', 'scarabs', 'regex', 'extras'] as const
 
 export type HideableTabKey = (typeof HIDEABLE_TAB_KEYS)[number]
 

--- a/src/shared/game-features.ts
+++ b/src/shared/game-features.ts
@@ -16,6 +16,8 @@ export interface GameFeatures {
   socketRecolor: boolean
   /** Regex generator tab in the overlay's tool tray. */
   regexTool: boolean
+  /** Scarab Atlas calculator tab (block / boost / invest EV optimizer). */
+  scarabAtlas: boolean
   /** Baseline currency for the bulk-exchange "pay with" choice when the item
    *  isn't priced in divines. PoE1's PriceInfo.chaosValue is denominated in
    *  chaos; PoE2 reuses the same field for exalted, so the currency we offer
@@ -39,9 +41,10 @@ const FEATURES_BY_VERSION: Record<GameVariant, GameFeatures> = {
     divCards: true,
     socketRecolor: true,
     regexTool: true,
+    scarabAtlas: true,
     bulkBaselineCurrency: 'chaos',
     bulkExchangeBanner: 'faustus',
-    leagues: ['Mirage', 'Hardcore Mirage', 'Standard', 'Hardcore'],
+    leagues: ['Allflame', 'Hardcore Allflame', 'Standard', 'Hardcore'],
     filterFolderHint: 'Documents\\My Games\\Path of Exile',
   },
   2: {
@@ -49,6 +52,7 @@ const FEATURES_BY_VERSION: Record<GameVariant, GameFeatures> = {
     divCards: false,
     socketRecolor: false,
     regexTool: true,
+    scarabAtlas: false,
     bulkBaselineCurrency: 'exalted',
     bulkExchangeBanner: 'ange',
     leagues: ['Runes of Aldur', 'HC Runes of Aldur', 'Standard', 'Hardcore'],

--- a/src/shared/macro-scope.test.ts
+++ b/src/shared/macro-scope.test.ts
@@ -37,9 +37,10 @@ describe('chatCommandScope', () => {
 })
 
 describe('appMacroScope', () => {
-  it('returns poe1 for openDust and openDivCards', () => {
+  it('returns poe1 for openDust, openDivCards, and openScarabs', () => {
     expect(appMacroScope('openDust')).toBe('poe1')
     expect(appMacroScope('openDivCards')).toBe('poe1')
+    expect(appMacroScope('openScarabs')).toBe('poe1')
   })
 
   it('returns both for all other known app macro action ids', () => {

--- a/src/shared/macro-scope.ts
+++ b/src/shared/macro-scope.ts
@@ -2,7 +2,7 @@ export type MacroScope = 'poe1' | 'poe2' | 'both'
 
 const POE1_ONLY_CHAT_COMMANDS: ReadonlySet<string> = new Set(['/menagerie', '/delve', '/kingsmarch', '/monastery'])
 
-const POE1_ONLY_APP_MACROS: ReadonlySet<string> = new Set(['openDust', 'openDivCards'])
+const POE1_ONLY_APP_MACROS: ReadonlySet<string> = new Set(['openDust', 'openDivCards', 'openScarabs'])
 
 export function chatCommandScope(command: string): MacroScope {
   const normalized = command.trim().toLowerCase()


### PR DESCRIPTION
## Summary
- Adds a native PoE1 overlay tab (**Scarab Atlas**) for atlas scarab drop EV: block / boost / invest, Remarkable Relics, Optimize
- Includes Vendor Guide (3→1 recipe threshold + stash search string) and Weights & Prices with live league prices + icons
- Rotates PoE1 fallback leagues / ninja league map to **Allflame** / Hardcore Allflame

## Test plan
- [ ] PoE1: Scarab Atlas title-bar icon appears; PoE2: hidden
- [ ] Calculator: Optimize sets block/boost/invest; Remarkable Relics changes EV
- [ ] Vendor Guide: generate/copy stash search string for sub-threshold scarabs
- [ ] Weights & Prices: edit overrides; icons render for scarabs
- [ ] League = Allflame prices load via existing dense ninja path
- [ ] Settings → View can hide the Scarabs tab; Open Scarab Atlas macro listed for PoE1
