### PR TITLE
fix: use first # for Kitava-style multi-value trade mods

### DIFF
--- a/src/main/trade/stat-matcher.test.ts
+++ b/src/main/trade/stat-matcher.test.ts
@@ -3856,6 +3856,38 @@ describe('matchModToStat (PoE2 stat text without leading sign)', () => {
     const result = matchModToStat('Adds +5 to +15 Cold Damage')
     expect(result).not.toBeNull()
     expect(result?.value).toBe(10)
+    expect(result?.aggregated).toBe(true)
+  })
+
+  // Kitava's Thirst (and its foulborn Life twin) publish TWO `#` placeholders:
+  // chance% and spend threshold. Averaging them produced Exact Values=125 and
+  // zero trade hits. Prefer the first `#` (chance); do not mark aggregated.
+  it('uses the first # for Kitava-style chance+threshold mods (not the average)', () => {
+    _setStatEntriesForTests([
+      {
+        id: 'explicit.stat_2513998383',
+        text: '#% chance to Trigger Socketed Spells when you Spend at least # Life on an\nUpfront Cost to Use or Trigger a Skill, with a 0.1 second Cooldown',
+        type: 'explicit',
+      },
+      {
+        id: 'explicit.stat_723388324',
+        text: '#% chance to Trigger Socketed Spells when you Spend at least # Mana on an\nUpfront Cost to Use or Trigger a Skill, with a 0.1 second Cooldown',
+        type: 'explicit',
+      },
+    ])
+    const life = matchModToStat(
+      '50% chance to Trigger Socketed Spells when you Spend at least 200 Life on an Upfront Cost to Use or Trigger a Skill, with a 0.1 second Cooldown',
+    )
+    expect(life?.statId).toBe('explicit.stat_2513998383')
+    expect(life?.value).toBe(50)
+    expect(life?.aggregated).toBeUndefined()
+
+    const mana = matchModToStat(
+      '50% chance to Trigger Socketed Spells when you Spend at least 100 Mana on an Upfront Cost to Use or Trigger a Skill, with a 0.1 second Cooldown',
+    )
+    expect(mana?.statId).toBe('explicit.stat_723388324')
+    expect(mana?.value).toBe(50)
+    expect(mana?.aggregated).toBeUndefined()
   })
 
   // The trade API stores "fewer enemies to be Surrounded" as the inverse of its

--- a/src/main/trade/stat-matcher/mod-matcher.ts
+++ b/src/main/trade/stat-matcher/mod-matcher.ts
@@ -22,6 +22,12 @@ const BLOCKED_STAT_IDS = new Set([
   'explicit.stat_3664950032', // "#% increased Quantity of Gold Dropped by Slain Enemies" (duplicate, broken)
 ])
 
+/** True when the `#` placeholders are a contiguous min-max roll range
+ *  ("Adds # to #" / "Adds #-#"), not independent magnitudes in one line. */
+function isMinMaxRangeStat(statText: string): boolean {
+  return /#\s*(?:to|-)\s*#/.test(statText.replace(/\s+/g, ' '))
+}
+
 /** Forbidden Shako-style randomized supports live under the `indexable_support_*`
  *  stat family, which shares display text with regular `stat_*` entries. We always
  *  filter one or the other out so the matcher doesn't coin-flip between them:
@@ -121,17 +127,27 @@ function _matchModToStat(
       const pattern = statTextToPattern(textForPattern)
       const match = normalizedVariant.match(pattern)
       if (match) {
-        // For stats with two numeric values (e.g. "Adds # to # Damage"), average them
+        // For min-max roll stats (e.g. "Adds # to # Damage"), average the two
+        // numbers -- the trade site indexes that average. Other multi-# stats
+        // (e.g. "#% chance … Spend at least # Life") are independent magnitudes;
+        // averaging them (50+200)/2=125 breaks Exact Values searches for Kitava's
+        // Thirst foulborn / similar uniques. Prefer the first # (the primary
+        // filter the trade UI exposes).
         const numericCaptures = Array.from(match)
           .slice(1)
           .filter((v) => v && NUMERIC_CAPTURE.test(v))
         const rawValue = match[1]
         let value: number | null
-        const aggregated = numericCaptures.length >= 2
+        const aggregated = numericCaptures.length >= 2 && isMinMaxRangeStat(entry.text)
         if (aggregated) {
           value = numericCaptures.reduce((sum, v) => sum + parseFloat(v), 0) / numericCaptures.length
         } else {
-          value = rawValue && NUMERIC_CAPTURE.test(rawValue) ? parseFloat(rawValue) : null
+          value =
+            numericCaptures.length > 0
+              ? parseFloat(numericCaptures[0])
+              : rawValue && NUMERIC_CAPTURE.test(rawValue)
+                ? parseFloat(rawValue)
+                : null
         }
         // Restore negative sign when matching via sign-flipped variant
         if (isNegativeMod && value != null && value > 0) value = -value


### PR DESCRIPTION
﻿## Summary
- Only average contiguous min-max roll ranges (`# to #` / hash-dash-hash) when matching trade stats.
- Chance+threshold mods like Foulborn Kitava's Thirst were averaged to 125 ((50+200)/2), so Exact Values searches found nothing.
- Prefer the first hash (chance %) for non-range multi-value stats; add regression coverage.

## Test plan
- [ ] Price-check Foulborn Kitava's Thirst with the Life trigger mod enabled + Exact Values — value should be 50, not 125
- [ ] Confirm Life trigger still maps to explicit.stat_2513998383 (not Mana)
- [ ] Spot-check a normal Adds X to Y damage mod still averages correctly
- [ ] Unit: vitest run src/main/trade/stat-matcher.test.ts -t "Kitava-style|Adds"
