### PR TITLE
fix(trade): keep visible map implicits on unidentified searches

### DIFF
--- a/src/main/trade/trade.test.ts
+++ b/src/main/trade/trade.test.ts
@@ -954,6 +954,182 @@ describe('searchTrade filter-group dispatch', () => {
     expect(sentIds).not.toContain('explicit.stat_2828710986')
   })
 
+  it('unidentified map implicits survive for all influence/occupied/citadel variants', async () => {
+    setPoeVersion(1)
+    const unidMap = {
+      name: 'Map (Tier 16)',
+      baseType: 'Map (Tier 16)',
+      itemClass: 'Maps',
+      rarity: 'Normal',
+    }
+    const mapImplicits: StatFilter[] = [
+      {
+        id: 'implicit.stat_1792283443|1',
+        text: 'Area is influenced by The Shaper',
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+      {
+        id: 'implicit.stat_1792283443|2',
+        text: 'Area is influenced by The Elder',
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+      {
+        id: 'implicit.stat_3624393862|1',
+        text: 'Map is occupied by The Enslaver',
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+      {
+        id: 'implicit.stat_3624393862|2',
+        text: 'Map is occupied by The Eradicator',
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+      {
+        id: 'implicit.stat_3624393862|3',
+        text: 'Map is occupied by The Constrictor',
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+      {
+        id: 'implicit.stat_3624393862|4',
+        text: 'Map is occupied by The Purifier',
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+      {
+        id: 'implicit.stat_2563183002|1',
+        text: "Map contains Baran's Citadel",
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+        option: 1,
+      },
+      {
+        id: 'implicit.stat_2563183002|2',
+        text: "Map contains Veritania's Citadel",
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+        option: 2,
+      },
+      {
+        id: 'implicit.stat_2563183002|3',
+        text: "Map contains Al-Hezmin's Citadel",
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+        option: 3,
+      },
+      {
+        id: 'implicit.stat_2563183002|4',
+        text: "Map contains Drox's Citadel",
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+        option: 4,
+      },
+    ]
+    const filters: StatFilter[] = [
+      { id: 'misc.identified', text: 'Unidentified', type: 'misc', enabled: true, value: null, min: null, max: null },
+      ...mapImplicits,
+      {
+        id: 'explicit.stat_999999',
+        text: 'Hidden rolled map mod',
+        type: 'explicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+    ]
+    await searchTrade('Allflame', unidMap, filters, { tradeStatus: 'any', tradePriceOption: 'chaos_divine' })
+    const req = capturedRequests.find((r) => r.url.includes('/search/'))
+    const body = parseCapturedBody(req)
+    const sentIds = body.query.stats[0]?.filters?.map((f) => f.id) ?? []
+    for (const f of mapImplicits) {
+      expect(sentIds).toContain(f.id)
+    }
+    expect(sentIds).not.toContain('explicit.stat_999999')
+  })
+
+  it('unidentified Elder-occupied map still sends visible map implicits', async () => {
+    setPoeVersion(1)
+    const unidOccupiedMap = {
+      name: 'Map (Tier 16)',
+      baseType: 'Map (Tier 16)',
+      itemClass: 'Maps',
+      rarity: 'Normal',
+    }
+    const filters: StatFilter[] = [
+      { id: 'misc.identified', text: 'Unidentified', type: 'misc', enabled: true, value: null, min: null, max: null },
+      {
+        id: 'implicit.stat_1792283443|2',
+        text: 'Area is influenced by The Elder',
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+      {
+        id: 'implicit.stat_3624393862|3',
+        text: 'Map is occupied by The Constrictor',
+        type: 'implicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+      {
+        id: 'explicit.stat_999999',
+        text: 'Hidden rolled map mod',
+        type: 'explicit',
+        enabled: true,
+        value: null,
+        min: null,
+        max: null,
+      },
+    ]
+    await searchTrade('Allflame', unidOccupiedMap, filters, { tradeStatus: 'any', tradePriceOption: 'chaos_divine' })
+    const req = capturedRequests.find((r) => r.url.includes('/search/'))
+    const body = parseCapturedBody(req)
+    const sentIds = body.query.stats[0]?.filters?.map((f) => f.id) ?? []
+    expect(sentIds).toContain('implicit.stat_1792283443|2')
+    expect(sentIds).toContain('implicit.stat_3624393862|3')
+    expect(sentIds).not.toContain('explicit.stat_999999')
+    expect(body.query.filters.map_filters?.filters.map_tier).toEqual({ min: 16, max: 16 })
+    expect(body.query.filters.misc_filters?.filters.identified).toEqual({ option: 'false' })
+  })
+
   it('unidentified item still sends an enabled rune filter (rune mods survive id)', async () => {
     setPoeVersion(2)
     const unidHelm = {

--- a/src/main/trade/trade.test.ts
+++ b/src/main/trade/trade.test.ts
@@ -962,6 +962,11 @@ describe('searchTrade filter-group dispatch', () => {
       itemClass: 'Maps',
       rarity: 'Normal',
     }
+    // GGG's PoE1 /data/stats flattens these option stats into one entry per choice
+    // ("implicit.stat_2563183002|3" = Al-Hezmin) with no `option` group attached, so
+    // the producer leaves StatFilter.option unset and the query ships the bare id.
+    // That shape matters: pairing a flattened `|N` id with `value: {option: N}`
+    // matches zero listings on the live API.
     const mapImplicits: StatFilter[] = [
       {
         id: 'implicit.stat_1792283443|1',
@@ -1025,7 +1030,6 @@ describe('searchTrade filter-group dispatch', () => {
         value: null,
         min: null,
         max: null,
-        option: 1,
       },
       {
         id: 'implicit.stat_2563183002|2',
@@ -1035,7 +1039,6 @@ describe('searchTrade filter-group dispatch', () => {
         value: null,
         min: null,
         max: null,
-        option: 2,
       },
       {
         id: 'implicit.stat_2563183002|3',
@@ -1045,7 +1048,6 @@ describe('searchTrade filter-group dispatch', () => {
         value: null,
         min: null,
         max: null,
-        option: 3,
       },
       {
         id: 'implicit.stat_2563183002|4',
@@ -1055,7 +1057,6 @@ describe('searchTrade filter-group dispatch', () => {
         value: null,
         min: null,
         max: null,
-        option: 4,
       },
     ]
     const filters: StatFilter[] = [
@@ -1074,58 +1075,18 @@ describe('searchTrade filter-group dispatch', () => {
     await searchTrade('Allflame', unidMap, filters, { tradeStatus: 'any', tradePriceOption: 'chaos_divine' })
     const req = capturedRequests.find((r) => r.url.includes('/search/'))
     const body = parseCapturedBody(req)
-    const sentIds = body.query.stats[0]?.filters?.map((f) => f.id) ?? []
+    const sentFilters = body.query.stats[0]?.filters ?? []
+    const sentIds = sentFilters.map((f) => f.id)
     for (const f of mapImplicits) {
       expect(sentIds).toContain(f.id)
     }
     expect(sentIds).not.toContain('explicit.stat_999999')
-  })
-
-  it('unidentified Elder-occupied map still sends visible map implicits', async () => {
-    setPoeVersion(1)
-    const unidOccupiedMap = {
-      name: 'Map (Tier 16)',
-      baseType: 'Map (Tier 16)',
-      itemClass: 'Maps',
-      rarity: 'Normal',
+    // A flattened `|N` id already encodes the choice -- shipping value.option too
+    // returns nothing on the live API, so guard the emitted shape, not just the ids.
+    for (const f of sentFilters) {
+      if (f.id.includes('|')) expect(f.value?.option).toBeUndefined()
     }
-    const filters: StatFilter[] = [
-      { id: 'misc.identified', text: 'Unidentified', type: 'misc', enabled: true, value: null, min: null, max: null },
-      {
-        id: 'implicit.stat_1792283443|2',
-        text: 'Area is influenced by The Elder',
-        type: 'implicit',
-        enabled: true,
-        value: null,
-        min: null,
-        max: null,
-      },
-      {
-        id: 'implicit.stat_3624393862|3',
-        text: 'Map is occupied by The Constrictor',
-        type: 'implicit',
-        enabled: true,
-        value: null,
-        min: null,
-        max: null,
-      },
-      {
-        id: 'explicit.stat_999999',
-        text: 'Hidden rolled map mod',
-        type: 'explicit',
-        enabled: true,
-        value: null,
-        min: null,
-        max: null,
-      },
-    ]
-    await searchTrade('Allflame', unidOccupiedMap, filters, { tradeStatus: 'any', tradePriceOption: 'chaos_divine' })
-    const req = capturedRequests.find((r) => r.url.includes('/search/'))
-    const body = parseCapturedBody(req)
-    const sentIds = body.query.stats[0]?.filters?.map((f) => f.id) ?? []
-    expect(sentIds).toContain('implicit.stat_1792283443|2')
-    expect(sentIds).toContain('implicit.stat_3624393862|3')
-    expect(sentIds).not.toContain('explicit.stat_999999')
+    // The rest of the unid map query is untouched by the stat-filter gate.
     expect(body.query.filters.map_filters?.filters.map_tier).toEqual({ min: 16, max: 16 })
     expect(body.query.filters.misc_filters?.filters.identified).toEqual({ option: 'false' })
   })

--- a/src/main/trade/trade.ts
+++ b/src/main/trade/trade.ts
@@ -708,9 +708,9 @@ export async function searchTrade(
     status: { option: isDivCard ? 'available' : tradeStatus },
   }
 
-  // Unid items have hidden mods, so any explicit/implicit/fractured/crafted/pseudo
-  // filter would never match -- the stat-filter loop below drops those when the
-  // unid chip is on. Computed up here too because an unidentified unique must skip
+  // Unid items hide rolled explicits, so the stat-filter loop below drops those
+  // when the unid chip is on (implicits/enchants/runes that stay visible still
+  // flow through). Computed up here too because an unidentified unique must skip
   // the name search (see the Unique branch).
   const unidEnabled = statFilters.some((f) => f.id === 'misc.identified' && f.enabled)
 
@@ -1079,11 +1079,14 @@ export async function searchTrade(
     'pseudo.pseudo_map_more_map_drops',
     'pseudo.pseudo_map_more_card_drops',
   ])
-  // Unid items have hidden mods, so any explicit/implicit/fractured/crafted/pseudo
-  // filter would never match -- drop those when the unid chip is on. Enchants
-  // and imbues survive identification (cluster jewel passive count etc.), so
-  // those keep flowing through. `unidEnabled` is computed once near the top.
-  const survivesUnid = (f: StatFilter): boolean => f.type === 'enchant' || f.type === 'imbued' || f.type === 'rune'
+  // Unid items hide rolled explicits/crafted/pseudos, so those must not enter the
+  // query when the unid chip is on. Mods that remain visible on unid items still
+  // match trade listings: enchants/imbues/runes, and implicits — including every
+  // map-category implicit (Elder/Shaper influence, guardian "occupied by …", and
+  // Conqueror citadel lines like Al-Hezmin/Baran/Veritania/Drox).
+  // `unidEnabled` is computed once near the top.
+  const survivesUnid = (f: StatFilter): boolean =>
+    f.type === 'enchant' || f.type === 'imbued' || f.type === 'rune' || f.type === 'implicit'
   const enabledFilters = statFilters.filter(
     (f) =>
       f.enabled &&


### PR DESCRIPTION
## Summary
- Unidentified trade searches no longer drop **visible implicits**, so Elder/Shaper influence, guardian occupied-by, and Conqueror citadel maps (Al-Hezmin/Baran/Veritania/Drox) stop matching as random plain T16s.
- Rolled explicits remain excluded while unid is on (those mods are still hidden).

## Test plan
- [ ] Price-check an unid T16 with Elder + Constrictor occupation → Search Trade should not return ~10k generic T16s
- [ ] Same for Al-Hezmin/Baran/Veritania/Drox citadel unid maps
- [ ] Shaper-influenced unid maps still send the Shaper influence implicit
- [ ] Unid rare gear still does **not** send hidden explicits
- [ ] `npx vitest run src/main/trade/trade.test.ts -t "unidentified map implicits"`

