### PR TITLE
fix(settings): persist PoE2 private league selection

### DIFF
--- a/src/main/profiles/profile-settings.test.ts
+++ b/src/main/profiles/profile-settings.test.ts
@@ -151,6 +151,27 @@ describe('profile-settings', () => {
     expect(profiles.getProfile(poe1.id)?.league).toBe('Standard')
   })
 
+  it('prefers the active profile over a stale last-used id for the same variant', () => {
+    const profiles = setupProfiles()
+    const activePoe2 = { ...profiles.createDefault(2), league: 'Runes of Aldur' }
+    const staleLast = { ...profiles.createDefault(2), league: 'Other' }
+    profiles.saveProfile(activePoe2)
+    profiles.saveProfile(staleLast)
+
+    const store = makeStore({
+      [PROFILE_VERSION_KEY]: 1,
+      [ACTIVE_PROFILE_ID_KEY]: activePoe2.id,
+      [LAST_PROFILE_ID_POE2_KEY]: staleLast.id,
+    })
+
+    const changes = writeLastUsedProfileSettingByGameVariant(store, 2, 'league', '')
+
+    expect(changes).toHaveLength(1)
+    expect(profiles.getProfile(activePoe2.id)?.league).toBe('')
+    expect(profiles.getProfile(staleLast.id)?.league).toBe('Other')
+    expect(store.get(LAST_PROFILE_ID_POE2_KEY)).toBe(activePoe2.id)
+  })
+
   it('switches game variant with activation reason from target profile', () => {
     const profiles = setupProfiles()
     const poe1 = profiles.createDefault(1)

--- a/src/main/profiles/profile-settings.ts
+++ b/src/main/profiles/profile-settings.ts
@@ -222,7 +222,15 @@ export function writeLastUsedProfileSettingByGameVariant<K extends ProfileSettin
   key: K,
   value: ProfileSettingValue<K>,
 ): ProfileChangedSetting[] {
-  let profile = findLastUsedProfileByGameVariant(store, variant)
+  // Prefer the active profile when it already matches the target game. Otherwise
+  // a stale last-used id for the same variant can write a different profile and
+  // return no activeProfile change — settings UI then snaps back after an
+  // optimistic Private League clear.
+  const active = getActiveProfile(store)
+  let profile =
+    active && active.gameVariant === variant
+      ? active
+      : findLastUsedProfileByGameVariant(store, variant)
   if (!profile) {
     profile = profileStore().createProfile({ name: `Path of Exile ${variant}`, gameVariant: variant })
     store.set(lastProfileIdKey(variant), profile.id)
@@ -232,6 +240,7 @@ export function writeLastUsedProfileSettingByGameVariant<K extends ProfileSettin
     profile[key] = value
     profile.updatedAt = new Date().toISOString()
     profileStore().saveProfile(profile)
+    store.set(lastProfileIdKey(variant), profile.id)
   }
 
   const activeId = store.get(ACTIVE_PROFILE_ID_KEY)

--- a/src/main/profiles/profile-settings.ts
+++ b/src/main/profiles/profile-settings.ts
@@ -227,10 +227,7 @@ export function writeLastUsedProfileSettingByGameVariant<K extends ProfileSettin
   // return no activeProfile change — settings UI then snaps back after an
   // optimistic Private League clear.
   const active = getActiveProfile(store)
-  let profile =
-    active && active.gameVariant === variant
-      ? active
-      : findLastUsedProfileByGameVariant(store, variant)
+  let profile = active && active.gameVariant === variant ? active : findLastUsedProfileByGameVariant(store, variant)
   if (!profile) {
     profile = profileStore().createProfile({ name: `Path of Exile ${variant}`, gameVariant: variant })
     store.set(lastProfileIdKey(variant), profile.id)

--- a/src/main/profiles/store.ts
+++ b/src/main/profiles/store.ts
@@ -47,7 +47,10 @@ export class ProfileStore {
       updatedAt: typeof raw.updatedAt === 'string' && raw.updatedAt ? raw.updatedAt : now,
       filterDir: typeof raw.filterDir === 'string' ? raw.filterDir : '',
       filterPath: typeof raw.filterPath === 'string' ? raw.filterPath : '',
-      league: typeof raw.league === 'string' && raw.league ? raw.league : fallback.league,
+      // Empty string is valid: Private League mode clears the name until the
+      // user types a custom league. Treating '' as missing snapped settings
+      // back to the challenge-league default on every save.
+      league: typeof raw.league === 'string' ? raw.league : fallback.league,
       tradePriceOption: raw.tradePriceOption ?? fallback.tradePriceOption,
       cheatSheets: raw.cheatSheets ?? fallback.cheatSheets,
       regexPresets: Array.isArray(raw.regexPresets) ? raw.regexPresets : [],

--- a/src/renderer/src/features/settings/tabs/GeneralTab.tsx
+++ b/src/renderer/src/features/settings/tabs/GeneralTab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Github, Refresh } from '@icon-park/react'
 import type { AppSettings, ProfileSettingValue, RuntimeSettings } from '@shared/types'
 import { GITHUB_REPO_URL, KOFI_URL } from '@shared/endpoints'
@@ -9,6 +9,8 @@ import kofiIcon from '@renderer/assets/other/kofi-logo.svg'
 import { SettingToggleBox } from '@renderer/components/primitives/SettingToggleBox'
 import { LOCALE_LABELS, setAppLocale, SUPPORTED_LOCALES, useCurrentLocale } from '@renderer/shared/locale'
 import { m } from '@shared/paraglide/messages.js'
+
+const LEAGUE_PERSIST_MS = 250
 
 interface Props {
   settings: RuntimeSettings
@@ -40,6 +42,79 @@ export function GeneralTab({
   const [refreshingLeagues, setRefreshingLeagues] = useState(false)
   const leagueOptions = resolveLeagueOptions(settings, settings.poeVersion)
   const activeLeague = settings.activeProfile?.league ?? ''
+  const isListedLeague = (league: string): boolean => leagueOptions.includes(league)
+
+  // Private-league UI is intentional local state. Do NOT derive privateMode from
+  // settings on every activeLeague change: selecting Private League writes '' via
+  // async IPC, and a stale settings snapshot still holding "Runes of Aldur"
+  // would immediately flip privateMode back off (flicker).
+  const [privateMode, setPrivateMode] = useState(() => !isListedLeague(activeLeague))
+  const [draftLeague, setDraftLeague] = useState(() =>
+    isListedLeague(activeLeague) ? '' : activeLeague,
+  )
+  const leaguePersistTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (privateMode) {
+      // Stay in private mode until the user picks a listed league. Only sync the
+      // draft when settings already carry a custom (non-listed) name.
+      if (activeLeague && !isListedLeague(activeLeague)) {
+        setDraftLeague(activeLeague)
+      }
+      return
+    }
+    if (!isListedLeague(activeLeague)) {
+      setPrivateMode(true)
+      setDraftLeague(activeLeague)
+    }
+  }, [activeLeague, leagueOptions, privateMode])
+
+  useEffect(() => {
+    return () => {
+      if (leaguePersistTimer.current) clearTimeout(leaguePersistTimer.current)
+    }
+  }, [])
+
+  const persistLeague = (value: string, immediate = false): void => {
+    if (leaguePersistTimer.current) {
+      clearTimeout(leaguePersistTimer.current)
+      leaguePersistTimer.current = null
+    }
+    const write = (): void => {
+      void updateProfile('league', value)
+    }
+    if (immediate) {
+      write()
+      return
+    }
+    leaguePersistTimer.current = setTimeout(write, LEAGUE_PERSIST_MS)
+  }
+
+  const selectPrivateLeague = (): void => {
+    setPrivateMode(true)
+    setDraftLeague('')
+    // Optimistic local update so parent settings don't briefly re-show the old
+    // challenge league while IPC is in flight.
+    if (settings.activeProfile) {
+      onSettingsChange({
+        ...settings,
+        activeProfile: { ...settings.activeProfile, league: '' },
+      })
+    }
+    void updateProfile('league', '')
+  }
+
+  const selectListedLeague = (league: string): void => {
+    setPrivateMode(false)
+    setDraftLeague('')
+    if (settings.activeProfile) {
+      onSettingsChange({
+        ...settings,
+        activeProfile: { ...settings.activeProfile, league },
+      })
+    }
+    void updateProfile('league', league)
+  }
 
   // Forced so it ignores the hourly cooldown. The main process broadcasts
   // setting updates to every window except the sender, so this window has to
@@ -118,7 +193,7 @@ export function GeneralTab({
       {/* League */}
       {(() => {
         const PRIVATE_LEAGUE_LABEL = m.settings_private_league()
-        const isPrivate = !leagueOptions.includes(activeLeague)
+        const shownLeague = privateMode ? draftLeague || PRIVATE_LEAGUE_LABEL : activeLeague
         return (
           <section>
             <label>{m.settings_league_label()}</label>
@@ -126,7 +201,7 @@ export function GeneralTab({
               {/* flex-1 so the value eats the free space and both buttons sit
                   together on the right; without it justify-between strands
                   Change in the middle of the row. */}
-              <span className="value flex-1 min-w-0">{activeLeague || PRIVATE_LEAGUE_LABEL}</span>
+              <span className="value flex-1 min-w-0">{shownLeague}</span>
               <button
                 className="primary"
                 onClick={() => {
@@ -150,12 +225,12 @@ export function GeneralTab({
               </button>
               <select
                 id="league-select-unified"
-                value={isPrivate ? PRIVATE_LEAGUE_LABEL : activeLeague}
+                value={privateMode ? PRIVATE_LEAGUE_LABEL : activeLeague}
                 onChange={(e) => {
                   if (e.target.value === PRIVATE_LEAGUE_LABEL) {
-                    if (!isPrivate) updateProfile('league', '')
+                    selectPrivateLeague()
                   } else {
-                    updateProfile('league', e.target.value)
+                    selectListedLeague(e.target.value)
                   }
                 }}
                 className="absolute inset-0 opacity-0 cursor-pointer"
@@ -168,13 +243,25 @@ export function GeneralTab({
                 <option value={PRIVATE_LEAGUE_LABEL}>{PRIVATE_LEAGUE_LABEL}</option>
               </select>
             </div>
-            {isPrivate && (
+            {privateMode && (
               <input
                 type="text"
-                value={activeLeague}
-                onChange={(e) => updateProfile('league', e.target.value)}
+                value={draftLeague}
+                onChange={(e) => {
+                  setDraftLeague(e.target.value)
+                  persistLeague(e.target.value)
+                }}
+                onBlur={() => {
+                  if (leaguePersistTimer.current) {
+                    clearTimeout(leaguePersistTimer.current)
+                    leaguePersistTimer.current = null
+                  }
+                  void updateProfile('league', draftLeague)
+                }}
                 placeholder={m.settings_private_league_placeholder()}
                 className="mt-[6px] w-full text-[11px] bg-black/30 rounded px-2 py-[5px] border-none"
+                autoComplete="off"
+                spellCheck={false}
               />
             )}
           </section>

--- a/src/renderer/src/features/settings/tabs/GeneralTab.tsx
+++ b/src/renderer/src/features/settings/tabs/GeneralTab.tsx
@@ -49,9 +49,7 @@ export function GeneralTab({
   // async IPC, and a stale settings snapshot still holding "Runes of Aldur"
   // would immediately flip privateMode back off (flicker).
   const [privateMode, setPrivateMode] = useState(() => !isListedLeague(activeLeague))
-  const [draftLeague, setDraftLeague] = useState(() =>
-    isListedLeague(activeLeague) ? '' : activeLeague,
-  )
+  const [draftLeague, setDraftLeague] = useState(() => (isListedLeague(activeLeague) ? '' : activeLeague))
   const leaguePersistTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Allow empty `league` on profiles so Private League mode is not rewritten to the challenge-league default (`Runes of Aldur`) on save.
- Keep Private League selected in settings through async profile writes, with optimistic local updates while typing/selecting.
- Prefer the active same-variant profile when writing last-used game settings, so a stale last-used id cannot clobber the clear.

## Test plan
- [ ] PoE2 settings: switch League to Private League — stays selected (no flicker back to Runes of Aldur)
- [ ] Enter `THC League IV (PL83388)` (or another `Name (PL#####)`) — value persists after reopen settings / app restart
- [ ] Switch back to a listed public league — selection updates and persists
- [ ] With two PoE2 profiles where last-used ≠ active, clear league on the active profile — active profile updates
- [ ] `npx vitest run src/main/profiles/profile-settings.test.ts`

Made with [Cursor](https://cursor.com)