### PR TITLE
feat(regex): import poe.re Maps profile export strings

### DIFF
--- a/src/renderer/src/features/regex/MapsGenerator.tsx
+++ b/src/renderer/src/features/regex/MapsGenerator.tsx
@@ -17,6 +17,8 @@ import {
 } from '@icon-park/react'
 import { TAB_COLORS, loadSet, loadStorage, useRegexKey } from './mapmods-helpers'
 import { FilterChip } from '../../components/primitives/FilterChip'
+import { PoeReImportPanel } from './PoeReImportPanel'
+import poereIconTight from '../../assets/other/poere-logo-tight.svg'
 import { TradeResults } from './TradeResults'
 import { MAP_TIER_ICONS, ORIGINATOR_TIER_ICONS, TierPicker } from './TierPicker'
 import { ModList } from './ModList'
@@ -34,7 +36,7 @@ type WantMode = 'any' | 'all'
 
 /** Maps-scoped panel state -- mutually exclusive with the container's save/load panels
  *  via the shared-panel plumbing. */
-type MapsPanel = 'search' | 'tier' | 'trade' | null
+type MapsPanel = 'search' | 'tier' | 'trade' | 'import' | null
 
 export const MapsGenerator = forwardRef<GeneratorHandle, GeneratorProps>(function MapsGenerator(
   {
@@ -85,6 +87,7 @@ export const MapsGenerator = forwardRef<GeneratorHandle, GeneratorProps>(functio
   const searchOpen = panel === 'search'
   const showTierPicker = panel === 'tier'
   const showTradeResults = panel === 'trade'
+  const showImport = panel === 'import'
   // Tell the container to collapse Save/Load whenever one of this generator's own
   // panels opens, so only one chip is open at a time across the row. Ref keeps the
   // callback identity out of the effect deps.
@@ -208,6 +211,16 @@ export const MapsGenerator = forwardRef<GeneratorHandle, GeneratorProps>(functio
     setPanel('trade')
   }
 
+  // Hydrate every piece of Maps state a preset carries. Shared by the container's
+  // load-a-saved-preset path and the poe.re import, which builds the same shape.
+  const hydrate = (preset: RegexPreset): void => {
+    setAvoid(new Set(preset.avoid))
+    setWant(new Set(preset.want))
+    setWantMode(preset.wantMode)
+    setQualifiers(preset.qualifiers)
+    setShowNightmare(preset.nightmare)
+  }
+
   // ---- Imperative handle ---------------------------------------------------
   useImperativeHandle(
     ref,
@@ -223,13 +236,7 @@ export const MapsGenerator = forwardRef<GeneratorHandle, GeneratorProps>(functio
         >,
         nightmare: showNightmare,
       }),
-      applyPreset: (preset: RegexPreset) => {
-        setAvoid(new Set(preset.avoid))
-        setWant(new Set(preset.want))
-        setWantMode(preset.wantMode)
-        setQualifiers(preset.qualifiers)
-        setShowNightmare(preset.nightmare)
-      },
+      applyPreset: hydrate,
       // Maps presets match on sorted auto-tag text set (ignoring user custom tags).
       matchesPreset: (preset: RegexPreset) => {
         if ((preset.generator ?? 'maps') !== 'maps') return false
@@ -294,6 +301,13 @@ export const MapsGenerator = forwardRef<GeneratorHandle, GeneratorProps>(functio
           {sharedSaveChip}
           {sharedLoadChip}
           <FilterChip
+            label="Import"
+            icon={poereIconTight}
+            active={showImport}
+            solidInactive
+            onClick={() => openPanel('import')}
+          />
+          <FilterChip
             label={
               <>
                 <Buy size={12} theme="outline" fill="currentColor" /> {trade.searching ? 'Searching...' : 'Trade'}
@@ -336,6 +350,11 @@ export const MapsGenerator = forwardRef<GeneratorHandle, GeneratorProps>(functio
             )}
           </div>
         </div>
+
+        {/* poe.re profile import drawer. Applies straight to Maps state rather than
+            going through the container's loadPreset, so pasting an export does not
+            open an editing session against a preset id that was never saved. */}
+        <PoeReImportPanel open={showImport} onImport={hydrate} />
 
         {/* Shared save panel (collapsible). */}
         {sharedSavePanel}

--- a/src/renderer/src/features/regex/PoeReImportPanel.tsx
+++ b/src/renderer/src/features/regex/PoeReImportPanel.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from 'react'
+import type { RegexPreset } from '@shared/types'
+import {
+  decodePoeReExport,
+  extractPoeReMapSettings,
+  mapPoeReToMapsPreset,
+  poeReExportToMapsPreset,
+} from './poe-re-import'
+
+interface PoeReImportPanelProps {
+  onImport: (preset: RegexPreset) => void
+}
+
+/** Paste UI for poe.re Maps profile export strings (Load panel, Maps tab only). */
+export function PoeReImportPanel({ onImport }: PoeReImportPanelProps): JSX.Element {
+  const [raw, setRaw] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [importedNote, setImportedNote] = useState<string | null>(null)
+
+  const preview = useMemo(() => {
+    if (!raw.trim()) return null
+    try {
+      const decoded = decodePoeReExport(raw)
+      const { map, profileName } = extractPoeReMapSettings(decoded)
+      const result = mapPoeReToMapsPreset(map, { profileName, id: 'poe-re-preview' })
+      return { ok: true as const, result }
+    } catch (e) {
+      return { ok: false as const, message: e instanceof Error ? e.message : String(e) }
+    }
+  }, [raw])
+
+  const apply = (): void => {
+    setError(null)
+    setImportedNote(null)
+    try {
+      const result = poeReExportToMapsPreset(raw)
+      onImport(result.preset)
+      const bits: string[] = []
+      bits.push(`${result.preset.avoid.length} avoid`)
+      bits.push(`${result.preset.want.length} want`)
+      const q = Object.keys(result.preset.qualifiers).length
+      if (q) bits.push(`${q} qualifier${q === 1 ? '' : 's'}`)
+      if (result.unknownModIds.length) bits.push(`${result.unknownModIds.length} unknown mod(s) skipped`)
+      if (result.unsupported.length) bits.push(`${result.unsupported.length} trade-only option(s) not applied`)
+      setImportedNote(`Loaded ${result.preset.name}: ${bits.join(' · ')}`)
+      setRaw('')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  return (
+    <div className="border-b border-border bg-bg-card px-3 py-2">
+      <span className="text-[9px] text-text-dim font-semibold uppercase tracking-wider mb-1 block">
+        Import from poe.re
+      </span>
+      <p className="text-[10px] text-text-dim m-0 mb-2 leading-relaxed">
+        On poe.re → Maps → profile → Export, copy the string, paste here. Avoid/want mods and
+        qualifiers load into Scalpel; trade-only toggles are skipped.
+      </p>
+      <textarea
+        value={raw}
+        onChange={(e) => {
+          setRaw(e.target.value)
+          setError(null)
+          setImportedNote(null)
+        }}
+        rows={3}
+        spellCheck={false}
+        placeholder="Paste poe.re export string…"
+        className="w-full box-border text-[11px] font-mono bg-black/30 rounded px-2 py-1.5 text-text outline-none resize-y border border-white/10"
+      />
+      {preview?.ok && (
+        <div className="mt-1.5 text-[10px] text-text-dim leading-relaxed">
+          Preview:{' '}
+          <span className="text-text">
+            {(preview.result.profileName ?? preview.result.preset.name) || 'unnamed'}
+          </span>
+          {' · '}
+          {preview.result.preset.avoid.length} avoid / {preview.result.preset.want.length} want
+          {preview.result.unknownModIds.length > 0 && (
+            <span className="text-[#ff9800]">
+              {' '}
+              · {preview.result.unknownModIds.length} unknown id(s)
+            </span>
+          )}
+        </div>
+      )}
+      {preview && !preview.ok && raw.trim() && (
+        <div className="mt-1.5 text-[10px] text-[#ef5350]">{preview.message}</div>
+      )}
+      {error && <div className="mt-1.5 text-[10px] text-[#ef5350]">{error}</div>}
+      {importedNote && <div className="mt-1.5 text-[10px] text-[#81c784]">{importedNote}</div>}
+      <div className="mt-2 flex justify-end">
+        <button
+          type="button"
+          className="primary text-[11px] disabled:opacity-40"
+          disabled={!preview?.ok}
+          onClick={apply}
+        >
+          Import into Maps
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/features/regex/PoeReImportPanel.tsx
+++ b/src/renderer/src/features/regex/PoeReImportPanel.tsx
@@ -43,7 +43,8 @@ export function PoeReImportPanel({ open, onImport }: PoeReImportPanelProps): JSX
       const q = Object.keys(result.preset.qualifiers).length
       if (q) bits.push(`${q} qualifier${q === 1 ? '' : 's'}`)
       if (result.unknownModIds.length) bits.push(`${result.unknownModIds.length} unknown mod(s) skipped`)
-      if (result.unsupported.length) bits.push(`${result.unsupported.length} trade-only option(s) not applied`)
+      if (result.nightmareSkipped) bits.push(`${result.nightmareSkipped} nightmare mod(s) skipped`)
+      if (result.unsupported.length) bits.push(`${result.unsupported.length} option(s) not applied`)
       setImportedNote(`Loaded ${result.preset.name}: ${bits.join(' · ')}`)
       setRaw('')
     } catch (e) {
@@ -87,6 +88,14 @@ export function PoeReImportPanel({ open, onImport }: PoeReImportPanelProps): JSX
           {preview.result.preset.avoid.length} avoid / {preview.result.preset.want.length} want
           {preview.result.unknownModIds.length > 0 && (
             <span className="text-[#ff9800]"> · {preview.result.unknownModIds.length} unknown id(s)</span>
+          )}
+          {preview.result.nightmareSkipped > 0 && (
+            <span className="text-[#ff9800]"> · {preview.result.nightmareSkipped} nightmare skipped</span>
+          )}
+          {/* Named rather than counted: "quality match-any" changes what the regex
+              matches, so it needs to be readable before the user commits to it. */}
+          {preview.result.unsupported.length > 0 && (
+            <div className="text-text-dim opacity-70">Not applied: {preview.result.unsupported.join(', ')}</div>
           )}
         </div>
       )}

--- a/src/renderer/src/features/regex/PoeReImportPanel.tsx
+++ b/src/renderer/src/features/regex/PoeReImportPanel.tsx
@@ -55,8 +55,8 @@ export function PoeReImportPanel({ onImport }: PoeReImportPanelProps): JSX.Eleme
         Import from poe.re
       </span>
       <p className="text-[10px] text-text-dim m-0 mb-2 leading-relaxed">
-        On poe.re → Maps → profile → Export, copy the string, paste here. Avoid/want mods and
-        qualifiers load into Scalpel; trade-only toggles are skipped.
+        On poe.re → Maps → profile → Export, copy the string, paste here. Avoid/want mods and qualifiers load into
+        Scalpel; trade-only toggles are skipped.
       </p>
       <textarea
         value={raw}
@@ -73,16 +73,11 @@ export function PoeReImportPanel({ onImport }: PoeReImportPanelProps): JSX.Eleme
       {preview?.ok && (
         <div className="mt-1.5 text-[10px] text-text-dim leading-relaxed">
           Preview:{' '}
-          <span className="text-text">
-            {(preview.result.profileName ?? preview.result.preset.name) || 'unnamed'}
-          </span>
+          <span className="text-text">{(preview.result.profileName ?? preview.result.preset.name) || 'unnamed'}</span>
           {' · '}
           {preview.result.preset.avoid.length} avoid / {preview.result.preset.want.length} want
           {preview.result.unknownModIds.length > 0 && (
-            <span className="text-[#ff9800]">
-              {' '}
-              · {preview.result.unknownModIds.length} unknown id(s)
-            </span>
+            <span className="text-[#ff9800]"> · {preview.result.unknownModIds.length} unknown id(s)</span>
           )}
         </div>
       )}

--- a/src/renderer/src/features/regex/PoeReImportPanel.tsx
+++ b/src/renderer/src/features/regex/PoeReImportPanel.tsx
@@ -8,11 +8,13 @@ import {
 } from './poe-re-import'
 
 interface PoeReImportPanelProps {
+  /** Drawer visibility, driven by the Maps chip row's one-open-at-a-time panel state. */
+  open: boolean
   onImport: (preset: RegexPreset) => void
 }
 
-/** Paste UI for poe.re Maps profile export strings (Load panel, Maps tab only). */
-export function PoeReImportPanel({ onImport }: PoeReImportPanelProps): JSX.Element {
+/** Paste drawer for poe.re Maps profile export strings, opened from the Maps chip row. */
+export function PoeReImportPanel({ open, onImport }: PoeReImportPanelProps): JSX.Element {
   const [raw, setRaw] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [importedNote, setImportedNote] = useState<string | null>(null)
@@ -50,10 +52,17 @@ export function PoeReImportPanel({ onImport }: PoeReImportPanelProps): JSX.Eleme
   }
 
   return (
-    <div className="border-b border-border bg-bg-card px-3 py-2">
-      <span className="text-[9px] text-text-dim font-semibold uppercase tracking-wider mb-1 block">
-        Import from poe.re
-      </span>
+    <div
+      className="overflow-hidden transition-all duration-150"
+      style={{
+        maxHeight: open ? 240 : 0,
+        opacity: open ? 1 : 0,
+        margin: open ? '8px -12px 0' : '0',
+        padding: open ? '0 12px' : '0',
+        borderTop: '1px solid var(--border)',
+        paddingTop: open ? 8 : 0,
+      }}
+    >
       <p className="text-[10px] text-text-dim m-0 mb-2 leading-relaxed">
         On poe.re → Maps → profile → Export, copy the string, paste here. Avoid/want mods and qualifiers load into
         Scalpel; trade-only toggles are skipped.
@@ -68,7 +77,7 @@ export function PoeReImportPanel({ onImport }: PoeReImportPanelProps): JSX.Eleme
         rows={3}
         spellCheck={false}
         placeholder="Paste poe.re export string…"
-        className="w-full box-border text-[11px] font-mono bg-black/30 rounded px-2 py-1.5 text-text outline-none resize-y border border-white/10"
+        className="w-full box-border text-[11px] font-mono bg-black/30 rounded px-2 py-1.5 text-text outline-none resize-none border border-white/10"
       />
       {preview?.ok && (
         <div className="mt-1.5 text-[10px] text-text-dim leading-relaxed">

--- a/src/renderer/src/features/regex/RegexGenerator.tsx
+++ b/src/renderer/src/features/regex/RegexGenerator.tsx
@@ -377,7 +377,7 @@ export function RegexGenerator({ settings, update, tryHotkey }: Props): JSX.Elem
     <FilterChip
       label={
         <>
-          <FSevenKey size={12} theme="outline" fill="currentColor" /> Save &amp; Bind Macro
+          <FSevenKey size={12} theme="outline" fill="currentColor" /> Save &amp; Bind
         </>
       }
       active={saveOpen}
@@ -405,7 +405,7 @@ export function RegexGenerator({ settings, update, tryHotkey }: Props): JSX.Elem
     <FilterChip
       label={
         <>
-          <Plus size={12} theme="outline" fill="currentColor" /> Start New Regex
+          <Plus size={12} theme="outline" fill="currentColor" /> Start New
         </>
       }
       solidInactive

--- a/src/renderer/src/features/regex/RegexGenerator.tsx
+++ b/src/renderer/src/features/regex/RegexGenerator.tsx
@@ -13,7 +13,6 @@ import poereIconTight from '../../assets/other/poere-logo-tight.svg'
 import { POE_RE_URL, POE2_RE_URL } from '@shared/endpoints'
 import { FilterChip } from '../../components/primitives/FilterChip'
 import { SavedPresetsGrid } from './SavedPresetsGrid'
-import { PoeReImportPanel } from './PoeReImportPanel'
 import { InfoChip } from '../../shared/InfoChip'
 import { MapsGenerator } from './MapsGenerator'
 import { CustomGenerator } from './CustomGenerator'
@@ -338,8 +337,8 @@ export function RegexGenerator({ settings, update, tryHotkey }: Props): JSX.Elem
     pendingIdRef.current = null
   }
 
-  // Load is available when this generator has presets, or on Maps (poe.re import).
-  const loadable = generator === 'maps' || presets.some((p) => (p.generator ?? 'maps') === generator)
+  // Load is disabled when the active generator has no saved presets to show.
+  const loadable = presets.some((p) => (p.generator ?? 'maps') === generator)
 
   // One-open-at-a-time across the chip row. Opening Save/Load closes the other and
   // tells the active generator to collapse its own panels (search/tier/trade).
@@ -461,24 +460,15 @@ export function RegexGenerator({ settings, update, tryHotkey }: Props): JSX.Elem
     </div>
   )
   const sharedSavedPresets = loadOpen ? (
-    <>
-      {generator === 'maps' && (
-        <PoeReImportPanel
-          onImport={(preset) => {
-            loadPreset(preset)
-          }}
-        />
-      )}
-      <SavedPresetsGrid
-        presets={presets}
-        generator={generator}
-        loadPreset={loadPreset}
-        deletePreset={deletePreset}
-        boundHotkeyFor={(preset) =>
-          (settings.appMacros ?? []).find((m) => m.action === 'useSavedRegex' && m.presetId === preset.id)?.hotkey
-        }
-      />
-    </>
+    <SavedPresetsGrid
+      presets={presets}
+      generator={generator}
+      loadPreset={loadPreset}
+      deletePreset={deletePreset}
+      boundHotkeyFor={(preset) =>
+        (settings.appMacros ?? []).find((m) => m.action === 'useSavedRegex' && m.presetId === preset.id)?.hotkey
+      }
+    />
   ) : null
 
   const sharedProps = {

--- a/src/renderer/src/features/regex/RegexGenerator.tsx
+++ b/src/renderer/src/features/regex/RegexGenerator.tsx
@@ -13,6 +13,7 @@ import poereIconTight from '../../assets/other/poere-logo-tight.svg'
 import { POE_RE_URL, POE2_RE_URL } from '@shared/endpoints'
 import { FilterChip } from '../../components/primitives/FilterChip'
 import { SavedPresetsGrid } from './SavedPresetsGrid'
+import { PoeReImportPanel } from './PoeReImportPanel'
 import { InfoChip } from '../../shared/InfoChip'
 import { MapsGenerator } from './MapsGenerator'
 import { CustomGenerator } from './CustomGenerator'
@@ -337,8 +338,8 @@ export function RegexGenerator({ settings, update, tryHotkey }: Props): JSX.Elem
     pendingIdRef.current = null
   }
 
-  // Load is disabled when the active generator has no saved presets to show.
-  const loadable = presets.some((p) => (p.generator ?? 'maps') === generator)
+  // Load is available when this generator has presets, or on Maps (poe.re import).
+  const loadable = generator === 'maps' || presets.some((p) => (p.generator ?? 'maps') === generator)
 
   // One-open-at-a-time across the chip row. Opening Save/Load closes the other and
   // tells the active generator to collapse its own panels (search/tier/trade).
@@ -460,15 +461,24 @@ export function RegexGenerator({ settings, update, tryHotkey }: Props): JSX.Elem
     </div>
   )
   const sharedSavedPresets = loadOpen ? (
-    <SavedPresetsGrid
-      presets={presets}
-      generator={generator}
-      loadPreset={loadPreset}
-      deletePreset={deletePreset}
-      boundHotkeyFor={(preset) =>
-        (settings.appMacros ?? []).find((m) => m.action === 'useSavedRegex' && m.presetId === preset.id)?.hotkey
-      }
-    />
+    <>
+      {generator === 'maps' && (
+        <PoeReImportPanel
+          onImport={(preset) => {
+            loadPreset(preset)
+          }}
+        />
+      )}
+      <SavedPresetsGrid
+        presets={presets}
+        generator={generator}
+        loadPreset={loadPreset}
+        deletePreset={deletePreset}
+        boundHotkeyFor={(preset) =>
+          (settings.appMacros ?? []).find((m) => m.action === 'useSavedRegex' && m.presetId === preset.id)?.hotkey
+        }
+      />
+    </>
   ) : null
 
   const sharedProps = {

--- a/src/renderer/src/features/regex/poe-re-import.test.ts
+++ b/src/renderer/src/features/regex/poe-re-import.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decodePoeReExport,
+  extractPoeReMapSettings,
+  poeReExportToMapsPreset,
+} from './poe-re-import'
+
+/** Encode the way poe.re does (UTF-8-safe Base64). */
+function encodePoeRe(obj: unknown): string {
+  const json = JSON.stringify(obj)
+  return btoa(unescape(encodeURIComponent(json)))
+}
+
+describe('decodePoeReExport', () => {
+  it('round-trips a UTF-8 profile delta', () => {
+    const encoded = encodePoeRe({ map: { badIds: [1], goodIds: [2] }, name: 'My Maps' })
+    expect(decodePoeReExport(encoded)).toEqual({
+      map: { badIds: [1], goodIds: [2] },
+      name: 'My Maps',
+    })
+  })
+
+  it('rejects garbage', () => {
+    expect(() => decodePoeReExport('not-base64!!!')).toThrow(/Base64/i)
+  })
+})
+
+describe('extractPoeReMapSettings', () => {
+  it('reads nested map from a SavedSettings-shaped export', () => {
+    const { map, profileName } = extractPoeReMapSettings({
+      name: 'juice',
+      map: { badIds: [-2050206104], goodIds: [] },
+    })
+    expect(profileName).toBe('juice')
+    expect(map.badIds).toEqual([-2050206104])
+  })
+
+  it('reads a multi-profile bag', () => {
+    const { map, profileName } = extractPoeReMapSettings({
+      active: 'default',
+      profiles: {
+        default: { name: 'default', map: { goodIds: [-2038489408], allGoodMods: false } },
+      },
+    })
+    expect(profileName).toBe('default')
+    expect(map.goodIds).toEqual([-2038489408])
+    expect(map.allGoodMods).toBe(false)
+  })
+})
+
+describe('poeReExportToMapsPreset', () => {
+  it('maps avoid/want IDs, wantMode, qualifiers, and nightmare', () => {
+    const encoded = encodePoeRe({
+      name: 'League start',
+      map: {
+        badIds: [-2050206104, -2038489408, 999999999],
+        goodIds: [-2038489408],
+        allGoodMods: false,
+        quantity: '80',
+        packsize: '40',
+        itemRarity: '50',
+        mapDropChance: '15',
+        displayNightmareMods: true,
+        quality: { regular: '20', scarab: '10' },
+        tradeExcludeValdo: true,
+      },
+    })
+    const result = poeReExportToMapsPreset(encoded)
+    expect(result.preset.generator).toBe('maps')
+    expect(result.preset.name).toBe('League start')
+    expect(result.preset.avoid).toEqual([-2050206104, -2038489408])
+    expect(result.preset.want).toEqual([-2038489408])
+    expect(result.preset.wantMode).toBe('any')
+    expect(result.preset.nightmare).toBe(true)
+    expect(result.preset.qualifiers).toEqual({
+      quantity: 80,
+      packsize: 40,
+      rarity: 50,
+      moremaps: 15,
+      quality: 20,
+      quality_scarab: 10,
+    })
+    expect(result.unknownModIds).toContain(999999999)
+    expect(result.unsupported).toContain('exclude Valdo maps')
+  })
+
+  it('defaults wantMode to all and nightmare to true when omitted (poe.re defaults)', () => {
+    const encoded = encodePoeRe({
+      map: { badIds: [-2050206104] },
+    })
+    const result = poeReExportToMapsPreset(encoded)
+    expect(result.preset.wantMode).toBe('all')
+    expect(result.preset.nightmare).toBe(true)
+    expect(result.preset.name).toBe('Imported from poe.re')
+  })
+})

--- a/src/renderer/src/features/regex/poe-re-import.test.ts
+++ b/src/renderer/src/features/regex/poe-re-import.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import {
-  decodePoeReExport,
-  extractPoeReMapSettings,
-  poeReExportToMapsPreset,
-} from './poe-re-import'
+import { decodePoeReExport, extractPoeReMapSettings, poeReExportToMapsPreset } from './poe-re-import'
 
 /** Encode the way poe.re does (UTF-8-safe Base64). */
 function encodePoeRe(obj: unknown): string {

--- a/src/renderer/src/features/regex/poe-re-import.test.ts
+++ b/src/renderer/src/features/regex/poe-re-import.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import { MAP_MODS } from '@shared/data/regex/map-mods'
 import { decodePoeReExport, extractPoeReMapSettings, poeReExportToMapsPreset } from './poe-re-import'
+
+const NIGHTMARE_ID = MAP_MODS.find((m) => m.nightmare)!.id
+const REGULAR_ID = MAP_MODS.find((m) => !m.nightmare)!.id
 
 /** Encode the way poe.re does (UTF-8-safe Base64). */
 function encodePoeRe(obj: unknown): string {
@@ -88,5 +92,42 @@ describe('poeReExportToMapsPreset', () => {
     expect(result.preset.wantMode).toBe('all')
     expect(result.preset.nightmare).toBe(true)
     expect(result.preset.name).toBe('Imported from poe.re')
+  })
+
+  // poe.re's getSelectedIds strips nightmare mods out of the generated regex when the
+  // toggle is off, so keeping them would import a stricter filter than the profile.
+  it('drops nightmare ids when the profile had displayNightmareMods off', () => {
+    const encoded = encodePoeRe({
+      map: { badIds: [REGULAR_ID, NIGHTMARE_ID], goodIds: [NIGHTMARE_ID], displayNightmareMods: false },
+    })
+    const result = poeReExportToMapsPreset(encoded)
+    expect(result.preset.avoid).toEqual([REGULAR_ID])
+    expect(result.preset.want).toEqual([])
+    expect(result.nightmareSkipped).toBe(2)
+  })
+
+  it('keeps nightmare ids when the toggle is on (the poe.re default)', () => {
+    const encoded = encodePoeRe({ map: { badIds: [REGULAR_ID, NIGHTMARE_ID] } })
+    const result = poeReExportToMapsPreset(encoded)
+    expect(result.preset.avoid).toEqual([REGULAR_ID, NIGHTMARE_ID])
+    expect(result.nightmareSkipped).toBe(0)
+  })
+
+  // anyQuality defaults on and so never appears in a delta export; the divergence has
+  // to be inferred from the number of quality values instead of read off a key.
+  it('flags quality match-any once more than one quality value is set', () => {
+    const encoded = encodePoeRe({ map: { quality: { regular: '20', scarab: '12' } } })
+    const result = poeReExportToMapsPreset(encoded)
+    expect(result.unsupported).toContain('quality match-any (Scalpel requires all of them)')
+  })
+
+  it('does not flag quality match-any for a single value, or when anyQuality is off', () => {
+    const single = poeReExportToMapsPreset(encodePoeRe({ map: { quality: { regular: '20' } } }))
+    expect(single.unsupported).toEqual([])
+
+    const allOf = poeReExportToMapsPreset(
+      encodePoeRe({ map: { quality: { regular: '20', scarab: '12' }, anyQuality: false } }),
+    )
+    expect(allOf.unsupported).toEqual([])
   })
 })

--- a/src/renderer/src/features/regex/poe-re-import.ts
+++ b/src/renderer/src/features/regex/poe-re-import.ts
@@ -1,0 +1,234 @@
+import { MAP_MODS } from '@shared/data/regex/map-mods'
+import type { RegexPreset } from '@shared/types'
+
+/** Known Scalpel Maps qualifier IDs (see Qualifiers.tsx). */
+const KNOWN_QUALIFIERS = new Set([
+  'quantity',
+  'packsize',
+  'morecurrency',
+  'morescarabs',
+  'moremaps',
+  'rarity',
+  'quality',
+  'quality_packsize',
+  'quality_rarity',
+  'quality_currency',
+  'quality_divination',
+  'quality_scarab',
+])
+
+const KNOWN_MOD_IDS = new Set(MAP_MODS.map((m) => m.id))
+
+/** Subset of poe.re `SavedSettings.map` we understand. */
+export interface PoeReMapSettings {
+  badIds?: number[]
+  goodIds?: number[]
+  allGoodMods?: boolean
+  quantity?: string
+  packsize?: string
+  itemRarity?: string
+  mapDropChance?: string
+  displayNightmareMods?: boolean
+  quality?: {
+    regular?: string
+    currency?: string
+    divination?: string
+    rarity?: string
+    packSize?: string
+    scarab?: string
+  }
+  rarity?: unknown
+  corrupted?: unknown
+  unidentified?: unknown
+  tradeEightModOnly?: unknown
+  tradeExcludeValdo?: unknown
+  tradeExcludeShaperElder?: unknown
+  customText?: unknown
+  optimizeQuant?: unknown
+  optimizePacksize?: unknown
+  optimizeQuality?: unknown
+}
+
+export interface PoeReImportResult {
+  /** Preset ready for MapsGenerator.applyPreset / loadPreset. */
+  preset: RegexPreset
+  /** Mod IDs from the export that aren't in Scalpel's vendored map-mod list. */
+  unknownModIds: number[]
+  /** poe.re fields we saw but don't map into Scalpel Maps yet. */
+  unsupported: string[]
+  /** Profile name from the export, if present. */
+  profileName: string | null
+}
+
+function parseMin(raw: unknown): number | null {
+  if (raw == null || raw === '') return null
+  const n = typeof raw === 'number' ? raw : Number(String(raw).trim())
+  if (!Number.isFinite(n) || n <= 0) return null
+  return n
+}
+
+function setQualifier(out: Record<string, number>, id: string, raw: unknown): void {
+  if (!KNOWN_QUALIFIERS.has(id)) return
+  const n = parseMin(raw)
+  if (n != null) out[id] = n
+}
+
+/** Decode a poe.re profile export string (Base64 JSON, UTF-8-safe). */
+export function decodePoeReExport(raw: string): unknown {
+  const trimmed = raw.trim().replace(/\s+/g, '')
+  if (!trimmed) throw new Error('Paste a poe.re export string first.')
+  let binary: string
+  try {
+    binary = atob(trimmed)
+  } catch {
+    throw new Error('Not a valid Base64 export string.')
+  }
+  // Mirror poe.re's btoa(unescape(encodeURIComponent(...))) encode path.
+  let json: string
+  try {
+    json = new TextDecoder().decode(Uint8Array.from(binary, (c) => c.charCodeAt(0)))
+  } catch {
+    throw new Error('Could not decode export bytes as UTF-8.')
+  }
+  try {
+    return JSON.parse(json) as unknown
+  } catch {
+    throw new Error('Export string is not valid JSON after decode.')
+  }
+}
+
+/** Pull the map settings object out of a decoded export (delta or full profile). */
+export function extractPoeReMapSettings(decoded: unknown): {
+  map: PoeReMapSettings
+  profileName: string | null
+  version: number | null
+} {
+  if (!decoded || typeof decoded !== 'object') {
+    throw new Error('Export payload is empty.')
+  }
+  const root = decoded as Record<string, unknown>
+
+  // Full / delta SavedSettings shape: { name?, map: {...}, ... }
+  if (root.map && typeof root.map === 'object') {
+    return {
+      map: root.map as PoeReMapSettings,
+      profileName: typeof root.name === 'string' ? root.name : null,
+      version: typeof root.version === 'number' ? root.version : null,
+    }
+  }
+
+  // Bare map object paste (goodIds/badIds at top level).
+  if (Array.isArray(root.goodIds) || Array.isArray(root.badIds)) {
+    return { map: root as PoeReMapSettings, profileName: null, version: null }
+  }
+
+  // Multi-profile bag: { active, profiles: { [name]: SavedSettings } }
+  if (root.profiles && typeof root.profiles === 'object') {
+    const profiles = root.profiles as Record<string, Record<string, unknown>>
+    const active = typeof root.active === 'string' ? root.active : null
+    const name =
+      (active && profiles[active] ? active : null) ??
+      Object.keys(profiles)[0] ??
+      null
+    if (!name || !profiles[name]) throw new Error('Export has no profiles to import.')
+    const profile = profiles[name]
+    if (!profile.map || typeof profile.map !== 'object') {
+      throw new Error(`Profile "${name}" has no map settings.`)
+    }
+    return {
+      map: profile.map as PoeReMapSettings,
+      profileName: typeof profile.name === 'string' ? profile.name : name,
+      version: typeof profile.version === 'number' ? profile.version : null,
+    }
+  }
+
+  throw new Error('No map settings found in this export (Maps page profile only).')
+}
+
+function collectUnsupported(map: PoeReMapSettings): string[] {
+  const out: string[] = []
+  if (map.rarity != null) out.push('map rarity include/exclude')
+  if (map.corrupted != null) out.push('corrupted filter')
+  if (map.unidentified != null) out.push('unidentified filter')
+  if (map.tradeEightModOnly != null) out.push('8-mod trade filter')
+  if (map.tradeExcludeValdo != null) out.push('exclude Valdo maps')
+  if (map.tradeExcludeShaperElder != null) out.push('exclude Shaper/Elder maps')
+  if (map.customText != null) out.push('custom text')
+  if (map.optimizeQuant != null || map.optimizePacksize != null || map.optimizeQuality != null) {
+    out.push('optimize number scrubbing')
+  }
+  return out
+}
+
+function filterKnownIds(ids: unknown): { kept: number[]; unknown: number[] } {
+  const kept: number[] = []
+  const unknown: number[] = []
+  if (!Array.isArray(ids)) return { kept, unknown }
+  for (const raw of ids) {
+    const id = typeof raw === 'number' ? raw : Number(raw)
+    if (!Number.isFinite(id)) continue
+    if (KNOWN_MOD_IDS.has(id)) kept.push(id)
+    else unknown.push(id)
+  }
+  return { kept, unknown }
+}
+
+/**
+ * Convert a decoded poe.re export into a Scalpel Maps `RegexPreset` payload.
+ * Mod IDs share poe.re's Generated.MapModsV3 namespace.
+ */
+export function mapPoeReToMapsPreset(
+  map: PoeReMapSettings,
+  opts?: { profileName?: string | null; id?: string },
+): PoeReImportResult {
+  const bad = filterKnownIds(map.badIds)
+  const good = filterKnownIds(map.goodIds)
+  const unknownModIds = [...new Set([...bad.unknown, ...good.unknown])]
+
+  const qualifiers: Record<string, number> = {}
+  setQualifier(qualifiers, 'quantity', map.quantity)
+  setQualifier(qualifiers, 'packsize', map.packsize)
+  setQualifier(qualifiers, 'rarity', map.itemRarity)
+  setQualifier(qualifiers, 'moremaps', map.mapDropChance)
+  if (map.quality) {
+    setQualifier(qualifiers, 'quality', map.quality.regular)
+    setQualifier(qualifiers, 'quality_packsize', map.quality.packSize)
+    setQualifier(qualifiers, 'quality_rarity', map.quality.rarity)
+    setQualifier(qualifiers, 'quality_currency', map.quality.currency)
+    setQualifier(qualifiers, 'quality_divination', map.quality.divination)
+    setQualifier(qualifiers, 'quality_scarab', map.quality.scarab)
+  }
+
+  const wantMode: 'any' | 'all' = map.allGoodMods === false ? 'any' : 'all'
+  const nightmare = map.displayNightmareMods !== false
+  const profileName = opts?.profileName ?? null
+
+  const name =
+    profileName?.trim() && profileName.trim().toLowerCase() !== 'default'
+      ? profileName.trim()
+      : 'Imported from poe.re'
+
+  const preset: RegexPreset = {
+    id: opts?.id ?? `poe-re-${Date.now()}`,
+    name,
+    generator: 'maps',
+    avoid: bad.kept,
+    want: good.kept,
+    wantMode,
+    qualifiers,
+    nightmare,
+  }
+
+  return {
+    preset,
+    unknownModIds,
+    unsupported: collectUnsupported(map),
+    profileName,
+  }
+}
+
+export function poeReExportToMapsPreset(raw: string): PoeReImportResult {
+  const decoded = decodePoeReExport(raw)
+  const { map, profileName } = extractPoeReMapSettings(decoded)
+  return mapPoeReToMapsPreset(map, { profileName })
+}

--- a/src/renderer/src/features/regex/poe-re-import.ts
+++ b/src/renderer/src/features/regex/poe-re-import.ts
@@ -19,6 +19,11 @@ const KNOWN_QUALIFIERS = new Set([
 
 const KNOWN_MOD_IDS = new Set(MAP_MODS.map((m) => m.id))
 
+/** Mods poe.re flags `nm`. Matches its own `isNightmareId` (a raw `options.nm` test),
+ *  so this is the same set upstream filters on -- Scalpel's NIGHTMARE_REGROUPED is a
+ *  display-grouping concern only and deliberately plays no part here. */
+const NIGHTMARE_MOD_IDS = new Set(MAP_MODS.filter((m) => m.nightmare).map((m) => m.id))
+
 /** Subset of poe.re `SavedSettings.map` we understand. */
 export interface PoeReMapSettings {
   badIds?: number[]
@@ -37,6 +42,7 @@ export interface PoeReMapSettings {
     packSize?: string
     scarab?: string
   }
+  anyQuality?: boolean
   rarity?: unknown
   corrupted?: unknown
   unidentified?: unknown
@@ -54,6 +60,8 @@ export interface PoeReImportResult {
   preset: RegexPreset
   /** Mod IDs from the export that aren't in Scalpel's vendored map-mod list. */
   unknownModIds: number[]
+  /** Nightmare mods dropped because the profile had poe.re's Nightmare toggle off. */
+  nightmareSkipped: number
   /** poe.re fields we saw but don't map into Scalpel Maps yet. */
   unsupported: string[]
   /** Profile name from the export, if present. */
@@ -144,6 +152,12 @@ export function extractPoeReMapSettings(decoded: unknown): {
 
 function collectUnsupported(map: PoeReMapSettings): string[] {
   const out: string[] = []
+  // poe.re's anyQuality (on by default) ORs every quality qualifier into one term;
+  // Scalpel's buildQualifierRegex always ANDs them. Only diverges past one value.
+  // The default never shows up in a delta export, so this cannot be read off a key.
+  if (map.anyQuality !== false && countQualityValues(map) > 1) {
+    out.push('quality match-any (Scalpel requires all of them)')
+  }
   if (map.rarity != null) out.push('map rarity include/exclude')
   if (map.corrupted != null) out.push('corrupted filter')
   if (map.unidentified != null) out.push('unidentified filter')
@@ -155,6 +169,12 @@ function collectUnsupported(map: PoeReMapSettings): string[] {
     out.push('optimize number scrubbing')
   }
   return out
+}
+
+function countQualityValues(map: PoeReMapSettings): number {
+  const q = map.quality
+  if (!q) return 0
+  return [q.regular, q.currency, q.divination, q.rarity, q.packSize, q.scarab].filter((v) => parseMin(v) != null).length
 }
 
 function filterKnownIds(ids: unknown): { kept: number[]; unknown: number[] } {
@@ -182,6 +202,16 @@ export function mapPoeReToMapsPreset(
   const good = filterKnownIds(map.goodIds)
   const unknownModIds = [...new Set([...bad.unknown, ...good.unknown])]
 
+  // With the Nightmare toggle off, poe.re strips nightmare mods out of the regex it
+  // generates (getSelectedIds in OptimizedMapOutput.ts) even though they stay selected
+  // in the profile. Scalpel's own nightmare flag only hides them from the picker, so
+  // carrying the ids over verbatim would import a stricter filter than the source.
+  const dropNightmare = map.displayNightmareMods === false
+  const playable = (ids: number[]): number[] => (dropNightmare ? ids.filter((id) => !NIGHTMARE_MOD_IDS.has(id)) : ids)
+  const avoid = playable(bad.kept)
+  const want = playable(good.kept)
+  const nightmareSkipped = bad.kept.length - avoid.length + (good.kept.length - want.length)
+
   const qualifiers: Record<string, number> = {}
   setQualifier(qualifiers, 'quantity', map.quantity)
   setQualifier(qualifiers, 'packsize', map.packsize)
@@ -207,8 +237,8 @@ export function mapPoeReToMapsPreset(
     id: opts?.id ?? `poe-re-${Date.now()}`,
     name,
     generator: 'maps',
-    avoid: bad.kept,
-    want: good.kept,
+    avoid,
+    want,
     wantMode,
     qualifiers,
     nightmare,
@@ -217,6 +247,7 @@ export function mapPoeReToMapsPreset(
   return {
     preset,
     unknownModIds,
+    nightmareSkipped,
     unsupported: collectUnsupported(map),
     profileName,
   }

--- a/src/renderer/src/features/regex/poe-re-import.ts
+++ b/src/renderer/src/features/regex/poe-re-import.ts
@@ -126,10 +126,7 @@ export function extractPoeReMapSettings(decoded: unknown): {
   if (root.profiles && typeof root.profiles === 'object') {
     const profiles = root.profiles as Record<string, Record<string, unknown>>
     const active = typeof root.active === 'string' ? root.active : null
-    const name =
-      (active && profiles[active] ? active : null) ??
-      Object.keys(profiles)[0] ??
-      null
+    const name = (active && profiles[active] ? active : null) ?? Object.keys(profiles)[0] ?? null
     if (!name || !profiles[name]) throw new Error('Export has no profiles to import.')
     const profile = profiles[name]
     if (!profile.map || typeof profile.map !== 'object') {
@@ -204,9 +201,7 @@ export function mapPoeReToMapsPreset(
   const profileName = opts?.profileName ?? null
 
   const name =
-    profileName?.trim() && profileName.trim().toLowerCase() !== 'default'
-      ? profileName.trim()
-      : 'Imported from poe.re'
+    profileName?.trim() && profileName.trim().toLowerCase() !== 'default' ? profileName.trim() : 'Imported from poe.re'
 
   const preset: RegexPreset = {
     id: opts?.id ?? `poe-re-${Date.now()}`,


### PR DESCRIPTION
## Summary
- Add a Maps-only **Import from poe.re** panel under Regex → Load that decodes poe.re profile Export strings (Base64 JSON).
- Map `badIds` / `goodIds` / `allGoodMods` / quantity-quality qualifiers into a Scalpel Maps `RegexPreset` (same mod ID space as vendored MapMods).
- Keep Load enabled on Maps even with no saved presets so import is reachable; skip trade-only poe.re toggles with a clear note.

## Test plan
- [ ] Regex → Maps → Load shows **Import from poe.re** with zero saved presets
- [ ] Paste a poe.re Maps Export string → preview shows avoid/want counts → **Import into Maps** loads mods/qualifiers
- [ ] Unknown mod IDs are skipped; trade-only options listed as not applied
- [ ] `npm test -- src/renderer/src/features/regex/poe-re-import.test.ts` passes

Made with [Cursor](https://cursor.com)