### PR TITLE
fix(price-check): exclude enchanted comps for unenchanted Blueprints

### DIFF
--- a/src/main/evaluation.ts
+++ b/src/main/evaluation.ts
@@ -283,6 +283,7 @@ export async function preloadPriceCheck(item: PoeItem, store: Store<AppSettings>
       attacksPerSecond: item.attacksPerSecond,
       critChance: item.critChance,
       heistJob: item.heistJob,
+      heistTarget: item.heistTarget,
       monsterLevel: item.monsterLevel,
       wingsRevealed: item.wingsRevealed,
       wingsTotal: item.wingsTotal,

--- a/src/main/trade/clipboard.test.ts
+++ b/src/main/trade/clipboard.test.ts
@@ -2135,6 +2135,39 @@ describe('parseItemText', () => {
       expect(item.wingsRevealed).toBe(1)
       expect(item.wingsTotal).toBe(3)
     })
+
+    it('parses Heist Target property from a blueprint', () => {
+      const text = [
+        'Item Class: Blueprints',
+        'Rarity: Normal',
+        'Blueprint: Bunker',
+        '--------',
+        'Heist Target: Currency',
+        'Area Level: 83',
+        'Wings Revealed: 3/3',
+        '--------',
+        'Item Level: 83',
+      ].join('\n')
+      const item = parseItemText(text)!
+      expect(item.heistTarget).toBe('Currency')
+    })
+
+    it('parses Heist Targets are always line as heistTarget', () => {
+      const text = [
+        'Item Class: Blueprints',
+        'Rarity: Normal',
+        'Blueprint: Bunker',
+        '--------',
+        'Area Level: 83',
+        'Wings Revealed: 1/3',
+        '--------',
+        'Heist Targets are always Enchanted Armaments',
+        '--------',
+        'Item Level: 83',
+      ].join('\n')
+      const item = parseItemText(text)!
+      expect(item.heistTarget).toBe('Enchanted Armaments')
+    })
   })
 
   // ---------------------------------------------------------------------------

--- a/src/main/trade/clipboard.ts
+++ b/src/main/trade/clipboard.ts
@@ -385,6 +385,13 @@ export function parseItemText(text: string): PoeItem | null {
   const wingsParts = wingsLine?.split(':')[1]?.trim().split('/')
   const wingsRevealed = wingsParts ? parseInt(wingsParts[0], 10) : undefined
   const wingsTotal = wingsParts?.[1] ? parseInt(wingsParts[1], 10) : undefined
+  // Heist target: property line "Heist Target: Currency" or enchant/implicit
+  // "Heist Targets are always Enchanted Armaments".
+  const heistTargetProp = extractStr(allLines, 'Heist Target:')
+  const heistTargetsAlways = allLines
+    .map((l) => l.match(/^Heist Targets are always (.+)$/i)?.[1]?.trim())
+    .find((v): v is string => !!v)
+  const heistTarget = heistTargetProp ?? heistTargetsAlways
   // Facetor's Lens: "Stored Experience: 999,627,082" (or "750 000 000" on a
   // space-grouping client -- see parseGroupedInt)
   const storedExpLine = allLines.find((l) => l.startsWith('Stored Experience:'))
@@ -768,6 +775,7 @@ export function parseItemText(text: string): PoeItem | null {
     ...(critChance != null ? { critChance } : {}),
     ...(itemSize ? { width: itemSize[0], height: itemSize[1] } : {}),
     ...(heistJob ? { heistJob } : {}),
+    ...(heistTarget ? { heistTarget } : {}),
     ...(monsterLevel != null ? { monsterLevel } : {}),
     ...(wingsRevealed != null ? { wingsRevealed, wingsTotal } : {}),
     ...(storedExperience != null ? { storedExperience } : {}),

--- a/src/main/trade/stat-matcher.test.ts
+++ b/src/main/trade/stat-matcher.test.ts
@@ -1674,6 +1674,52 @@ describe('matchItemMods', () => {
       )
       expect(jobFilter).toBeUndefined()
     })
+
+    it('adds Exclude Enchanted misc chip enabled by default for unenchanted blueprints', () => {
+      const filters = matchItemMods(
+        [],
+        [],
+        undefined,
+        makeItemInfo({ itemClass: 'Blueprints', wingsRevealed: 3, wingsTotal: 3, heistTarget: 'Currency' }),
+      )
+      const chip = filters.find((f) => f.id === 'misc.exclude_enchanted')
+      expect(chip).toBeDefined()
+      expect(chip?.type).toBe('misc')
+      expect(chip?.enabled).toBe(true)
+      expect(chip?.text).toBe('Exclude Enchanted')
+    })
+
+    it('defaults Exclude Enchanted off for Enchanted Armaments blueprints', () => {
+      const filters = matchItemMods(
+        [],
+        [],
+        undefined,
+        makeItemInfo({
+          itemClass: 'Blueprints',
+          wingsRevealed: 1,
+          wingsTotal: 3,
+          heistTarget: 'Enchanted Armaments',
+        }),
+      )
+      const chip = filters.find((f) => f.id === 'misc.exclude_enchanted')
+      expect(chip?.enabled).toBe(false)
+    })
+
+    it('defaults Exclude Enchanted off when blueprint has enchants', () => {
+      const filters = matchItemMods(
+        [],
+        [],
+        undefined,
+        makeItemInfo({
+          itemClass: 'Blueprints',
+          wingsRevealed: 1,
+          wingsTotal: 3,
+          enchants: ['Heist Targets are always Enchanted Armaments'],
+        }),
+      )
+      const chip = filters.find((f) => f.id === 'misc.exclude_enchanted')
+      expect(chip?.enabled).toBe(false)
+    })
   })
 
   describe('trial key area level pinning', () => {

--- a/src/main/trade/stat-matcher/context.ts
+++ b/src/main/trade/stat-matcher/context.ts
@@ -42,6 +42,7 @@ export interface ItemInfo {
   attacksPerSecond?: number
   critChance?: number
   heistJob?: { skill: string; level: number }
+  heistTarget?: string
   monsterLevel?: number
   wingsRevealed?: number
   wingsTotal?: number

--- a/src/main/trade/stat-matcher/producers/heist.ts
+++ b/src/main/trade/stat-matcher/producers/heist.ts
@@ -3,16 +3,32 @@ import type { StatFilter } from '../../trade'
 
 type HeistItemInfo = {
   heistJob?: { skill: string; level: number }
+  heistTarget?: string
   monsterLevel?: number
   wingsRevealed?: number
   wingsTotal?: number
   itemClass?: string
   baseType?: string
+  enchants?: string[]
+  implicits?: string[]
+}
+
+const ENCHANTED_ARMAMENTS = /Enchanted Armaments/i
+const HEIST_TARGETS_ALWAYS = /Heist Targets are always Enchanted Armaments/i
+
+/** True when a Blueprint looks enchanted (has enchant mods or Enchanted Armaments target). */
+export function isEnchantedBlueprint(itemInfo: HeistItemInfo | undefined): boolean {
+  if (!itemInfo || itemInfo.itemClass !== 'Blueprints') return false
+  if ((itemInfo.enchants?.length ?? 0) > 0) return true
+  if (itemInfo.heistTarget && ENCHANTED_ARMAMENTS.test(itemInfo.heistTarget)) return true
+  const lines = [...(itemInfo.implicits ?? []), ...(itemInfo.enchants ?? [])]
+  return lines.some((l) => HEIST_TARGETS_ALWAYS.test(l))
 }
 
 // Heist job skill requirement (contracts only; blueprints have multiple jobs that don't filter search)
 // Area level chip (for heist contracts/blueprints)
 // Heist blueprint wings revealed
+// Exclude Enchanted chip (blueprints only)
 export function buildHeistFilters(itemInfo: HeistItemInfo | undefined): StatFilter[] {
   const out: StatFilter[] = []
 
@@ -71,6 +87,23 @@ export function buildHeistFilters(itemInfo: HeistItemInfo | undefined): StatFilt
         type: 'heist',
       })
     }
+  }
+
+  // Unenchanted blueprints: exclude listings that have enchant modifiers (e.g.
+  // Enchanted Armaments). Emitted as a misc chip (above the filter rows) so it
+  // toggles like Unidentified / influence — not a heist numeric row.
+  // Defaults off when the clipboard BP itself is enchanted.
+  if (itemInfo?.itemClass === 'Blueprints') {
+    const enchanted = isEnchantedBlueprint(itemInfo)
+    out.push({
+      id: 'misc.exclude_enchanted',
+      text: 'Exclude Enchanted',
+      value: null,
+      min: null,
+      max: null,
+      enabled: !enchanted,
+      type: 'misc',
+    })
   }
 
   return out

--- a/src/main/trade/trade.test.ts
+++ b/src/main/trade/trade.test.ts
@@ -3032,3 +3032,94 @@ describe('searchTrade mercenary warrant handling', () => {
     expect(isBulkExchangeItem('Map Fragments', 'Mercenary Warrant', 'Mercenary Warrant', 'Normal')).toBe(false)
   })
 })
+
+describe('searchTrade unenchanted Blueprint NOT Enchant Modifiers', () => {
+  const blueprintItem = {
+    name: 'Blueprint: Bunker',
+    baseType: 'Blueprint: Bunker',
+    itemClass: 'Blueprints',
+    rarity: 'Normal',
+  }
+
+  const wingsChips: StatFilter[] = [
+    {
+      id: 'heist.heist_wings',
+      text: 'Wings Revealed: 3',
+      value: 3,
+      min: 3,
+      max: null,
+      enabled: true,
+      type: 'heist',
+    },
+    {
+      id: 'heist.heist_max_wings',
+      text: 'Total Wings: 3',
+      value: 3,
+      min: 3,
+      max: null,
+      enabled: true,
+      type: 'heist',
+    },
+  ]
+
+  const excludeOn: StatFilter = {
+    id: 'misc.exclude_enchanted',
+    text: 'Exclude Enchanted',
+    value: null,
+    min: null,
+    max: null,
+    enabled: true,
+    type: 'misc',
+  }
+
+  const excludeOff: StatFilter = { ...excludeOn, enabled: false }
+
+  beforeEach(() => {
+    capturedRequests.length = 0
+    _resetRateLimitsForTests()
+    setPoeVersion(1)
+    _setStatEntriesForTests([
+      { id: 'pseudo.pseudo_number_of_enchant_mods', text: '# Enchant Modifiers', type: 'pseudo' },
+    ])
+  })
+
+  it('injects a not group with Enchant Modifiers when Exclude Enchanted is on', async () => {
+    await searchTrade('Mirage', blueprintItem, [...wingsChips, excludeOn], {
+      tradeStatus: 'any',
+      tradePriceOption: 'chaos_divine',
+    })
+    const req = capturedRequests.find((r) => r.url.includes('/search/'))
+    const body = parseCapturedBody(req)
+    const notGroup = body.query.stats.find((g) => g.type === 'not')
+    expect(notGroup).toBeDefined()
+    expect(notGroup?.filters).toEqual([
+      { id: 'pseudo.pseudo_number_of_enchant_mods', value: {} },
+    ])
+    // Chip must not leak into heist_filters or misc_filters
+    const heist = (body.query.filters as { heist_filters?: CapturedTradeFilterGroup }).heist_filters
+    expect(heist?.filters.heist_wings).toEqual({ min: 3 })
+    expect(heist?.filters.exclude_enchanted).toBeUndefined()
+    const misc = (body.query.filters as { misc_filters?: CapturedTradeFilterGroup }).misc_filters
+    expect(misc?.filters.exclude_enchanted).toBeUndefined()
+  })
+
+  it('omits the not group when Exclude Enchanted is off', async () => {
+    await searchTrade('Mirage', blueprintItem, [...wingsChips, excludeOff], {
+      tradeStatus: 'any',
+      tradePriceOption: 'chaos_divine',
+    })
+    const req = capturedRequests.find((r) => r.url.includes('/search/'))
+    const body = parseCapturedBody(req)
+    expect(body.query.stats.find((g) => g.type === 'not')).toBeUndefined()
+  })
+
+  it('omits the not group when the chip is absent (enchanted default)', async () => {
+    await searchTrade('Mirage', blueprintItem, wingsChips, {
+      tradeStatus: 'any',
+      tradePriceOption: 'chaos_divine',
+    })
+    const req = capturedRequests.find((r) => r.url.includes('/search/'))
+    const body = parseCapturedBody(req)
+    expect(body.query.stats.find((g) => g.type === 'not')).toBeUndefined()
+  })
+})

--- a/src/main/trade/trade.test.ts
+++ b/src/main/trade/trade.test.ts
@@ -3092,9 +3092,7 @@ describe('searchTrade unenchanted Blueprint NOT Enchant Modifiers', () => {
     const body = parseCapturedBody(req)
     const notGroup = body.query.stats.find((g) => g.type === 'not')
     expect(notGroup).toBeDefined()
-    expect(notGroup?.filters).toEqual([
-      { id: 'pseudo.pseudo_number_of_enchant_mods', value: {} },
-    ])
+    expect(notGroup?.filters).toEqual([{ id: 'pseudo.pseudo_number_of_enchant_mods', value: {} }])
     // Chip must not leak into heist_filters or misc_filters
     const heist = (body.query.filters as { heist_filters?: CapturedTradeFilterGroup }).heist_filters
     expect(heist?.filters.heist_wings).toEqual({ min: 3 })

--- a/src/main/trade/trade.ts
+++ b/src/main/trade/trade.ts
@@ -16,7 +16,16 @@ import { getOverlayWindow } from '../overlay'
 import { harvestIcons } from './icon-cache'
 import { getUniquesByBase } from './prices'
 import { adjustRateLimits, RateLimiter } from './rate-limiter'
+import { getStatEntries } from './stat-matcher/stats-cache'
 import { normalizeTabletModKey, stripTabletMapScoping } from './stat-matcher/producers/tablets'
+
+/** Trade pseudo id for "# Enchant Modifiers" — used to NOT-filter enchanted BPs. */
+export function resolveEnchantModsPseudoId(): string | null {
+  const hit = getStatEntries().find(
+    (e) => e.id.startsWith('pseudo.') && /Enchant Modifiers/i.test(e.text),
+  )
+  return hit?.id ?? null
+}
 
 /** Forward any newly-harvested name->icon pairs to the overlay so it can merge
  *  them into the in-session iconMap. Without this the renderer would only pick
@@ -905,7 +914,7 @@ export async function searchTrade(
     }
   }
 
-  // Add heist filters (wings revealed)
+  // Add heist filters (wings revealed / job levels)
   const heistFilters = statFilters.filter((f) => f.type === 'heist' && f.enabled)
   if (heistFilters.length > 0) {
     const heistQuery: Record<string, { min?: number; max?: number }> = {}
@@ -1270,6 +1279,23 @@ export async function searchTrade(
         ...((query.filters as Record<string, unknown>) ?? {}),
         ultimatum_filters: { disabled: false, filters: ultimatumFilters },
       }
+    }
+  }
+
+  // Unenchanted Heist Blueprints: NOT `# Enchant Modifiers` so comps exclude
+  // Enchanted Armaments / other enchanted listings. Honors the Exclude Enchanted chip.
+  const excludeEnchantChip = statFilters.find((f) => f.id === 'misc.exclude_enchanted')
+  if (excludeEnchantChip?.enabled) {
+    const enchantModsPseudoId = resolveEnchantModsPseudoId()
+    if (enchantModsPseudoId) {
+      statGroups.push({
+        type: 'not',
+        filters: [{ id: enchantModsPseudoId, value: {} }],
+      })
+    } else {
+      recordMainBreadcrumb(
+        'trade: Exclude Enchanted enabled but Enchant Modifiers pseudo id not in stats catalog',
+      )
     }
   }
 

--- a/src/main/trade/trade.ts
+++ b/src/main/trade/trade.ts
@@ -21,9 +21,7 @@ import { normalizeTabletModKey, stripTabletMapScoping } from './stat-matcher/pro
 
 /** Trade pseudo id for "# Enchant Modifiers" — used to NOT-filter enchanted BPs. */
 export function resolveEnchantModsPseudoId(): string | null {
-  const hit = getStatEntries().find(
-    (e) => e.id.startsWith('pseudo.') && /Enchant Modifiers/i.test(e.text),
-  )
+  const hit = getStatEntries().find((e) => e.id.startsWith('pseudo.') && /Enchant Modifiers/i.test(e.text))
   return hit?.id ?? null
 }
 
@@ -1293,9 +1291,7 @@ export async function searchTrade(
         filters: [{ id: enchantModsPseudoId, value: {} }],
       })
     } else {
-      recordMainBreadcrumb(
-        'trade: Exclude Enchanted enabled but Enchant Modifiers pseudo id not in stats catalog',
-      )
+      recordMainBreadcrumb('trade: Exclude Enchanted enabled but Enchant Modifiers pseudo id not in stats catalog')
     }
   }
 

--- a/src/renderer/src/features/price-check/constants.ts
+++ b/src/renderer/src/features/price-check/constants.ts
@@ -32,6 +32,7 @@ export const CHIP_COLORS: Record<string, string> = {
   'misc.corrupted': '#ef5350',
   'misc.mirrored': '#8787FE',
   'misc.identified': '#ffb74d',
+  'misc.exclude_enchanted': '#81c784',
 }
 
 export const TERNARY_CHIP_IDS = new Set([

--- a/src/shared/contracts/items.ts
+++ b/src/shared/contracts/items.ts
@@ -139,6 +139,8 @@ export interface PoeItem {
   width?: number
   height?: number
   heistJob?: { skill: string; level: number }
+  /** Heist blueprint target, e.g. "Currency" or "Enchanted Armaments". */
+  heistTarget?: string
   monsterLevel?: number
   wingsRevealed?: number
   wingsTotal?: number


### PR DESCRIPTION
## Summary
- Unenchanted Heist Blueprint price-checks no longer mix in Enchanted Armaments / other enchanted listings
- Adds an **Exclude Enchanted** chip in the misc chip row (on by default for unenchanted BPs; off when the clipboard BP is enchanted)
- When enabled, `searchTrade` / Open in Trade inject a `not` stats group for `# Enchant Modifiers` (`pseudo.pseudo_number_of_enchant_mods`)

## Test plan
- [ ] Ctrl+D an unenchanted 3/3 or 4/4 Blueprint → **Exclude Enchanted** chip is on in the chip row above the filters
- [ ] Match count drops vs without the chip; Open in Trade shows NOT Enchant Modifiers; Enchanted Armaments listings gone
- [ ] Toggle the chip off → enchanted comps return
- [ ] Ctrl+D an Enchanted Armaments Blueprint → chip defaults off