### PR TITLE
fix(overlay): clear stuck snap-dock ghost after drag

### DIFF
--- a/src/main/windowing/focus.test.ts
+++ b/src/main/windowing/focus.test.ts
@@ -1,12 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-const { focusHolder } = vi.hoisted(() => ({ focusHolder: { current: null as unknown } }))
+const { focusHolder, snapGhostCalls } = vi.hoisted(() => ({
+  focusHolder: { current: null as unknown },
+  snapGhostCalls: [] as unknown[],
+}))
 vi.mock('electron', () => ({
   BrowserWindow: { getFocusedWindow: () => focusHolder.current },
   screen: { getDisplayNearestPoint: () => ({ scaleFactor: 1 }) },
 }))
+vi.mock('./snap-canvas', () => ({
+  getSnapCanvasWindow: () => null,
+  setSnapGhost: (rect: unknown) => {
+    snapGhostCalls.push(rect)
+  },
+}))
 import {
   aroundNativeDialog,
   closeAllOverlaysOnPoeExit,
+  hideAllOnPoeBlur,
   hideFocusedOrAnyVisibleSecondaryOverlay,
   isAnyScalpelBrowserWindowFocused,
   isAnyScalpelWindowFocused,
@@ -40,6 +50,7 @@ function fakeState(opts: {
   persist?: boolean
   gateShow?: () => boolean
   userPinned?: boolean
+  snapGhostActive?: boolean
 }): OverlayState {
   return {
     spec: { gateShow: opts.gateShow } as unknown as OverlayState['spec'],
@@ -50,7 +61,7 @@ function fakeState(opts: {
       show: vi.fn(),
       moveTop: vi.fn(),
     } as unknown as OverlayState['win'],
-    snapGhostActive: false,
+    snapGhostActive: opts.snapGhostActive ?? false,
     inProgrammaticMove: false,
     programmaticSettleTimer: null,
     isResizing: false,
@@ -59,6 +70,54 @@ function fakeState(opts: {
     userPinned: opts.userPinned ?? false,
   }
 }
+
+// A snap-dock ghost is painted by a shared always-shown canvas window that is
+// never hidden - only its rect is cleared. Every path that takes overlays off
+// screen therefore has to clear the ghost too, or a dashed box is left painted
+// over the game (or the bare desktop) with nothing alive to remove it.
+describe('snap-ghost teardown', () => {
+  beforeEach(() => {
+    overlays.clear()
+    snapGhostCalls.length = 0
+    focusHolder.current = null
+  })
+
+  it('hideAllOnPoeBlur clears the ghost flag on every overlay and the canvas', () => {
+    const dragging = fakeState({ visible: true, snapGhostActive: true })
+    const other = fakeState({ visible: true })
+    overlays.set('dragging', dragging)
+    overlays.set('other', other)
+
+    hideAllOnPoeBlur()
+
+    expect(dragging.snapGhostActive).toBe(false)
+    expect(other.snapGhostActive).toBe(false)
+    expect(snapGhostCalls).toEqual([null])
+  })
+
+  it('hideAllOnPoeBlur leaves the ghost alone when focus stayed inside Scalpel', () => {
+    const dragging = fakeState({ visible: true, snapGhostActive: true })
+    focusHolder.current = dragging.win
+    overlays.set('dragging', dragging)
+
+    hideAllOnPoeBlur()
+
+    // Focus moving PoE -> our own window is not "leaving the app", so the drag
+    // is still live and its pending snap must survive.
+    expect(dragging.snapGhostActive).toBe(true)
+    expect(snapGhostCalls).toEqual([])
+  })
+
+  it('closeAllOverlaysOnPoeExit clears the ghost flag and the canvas', () => {
+    const dragging = fakeState({ visible: true, snapGhostActive: true })
+    overlays.set('dragging', dragging)
+
+    closeAllOverlaysOnPoeExit()
+
+    expect(dragging.snapGhostActive).toBe(false)
+    expect(snapGhostCalls).toEqual([null])
+  })
+})
 
 describe('closeAllOverlaysOnPoeExit', () => {
   beforeEach(() => {

--- a/src/main/windowing/focus.ts
+++ b/src/main/windowing/focus.ts
@@ -119,6 +119,7 @@ export function hideAllOnPoeBlur(): void {
     if (!state.win || state.win.isDestroyed()) continue
     state.wasVisibleBeforeFocusLoss = state.win.isVisible()
     if (state.wasVisibleBeforeFocusLoss) state.win.hide()
+    state.snapGhostActive = false
   }
   setSnapGhost(null)
   // Let auxiliary windows (cheat-sheet hover preview) clear themselves so

--- a/src/main/windowing/focus.ts
+++ b/src/main/windowing/focus.ts
@@ -119,6 +119,9 @@ export function hideAllOnPoeBlur(): void {
     if (!state.win || state.win.isDestroyed()) continue
     state.wasVisibleBeforeFocusLoss = state.win.isVisible()
     if (state.wasVisibleBeforeFocusLoss) state.win.hide()
+    // Drop any pending snap along with the window. A drag still waiting on
+    // 'moved' loses its snap here (the raw drop position persists instead) -
+    // accepted, because a ghost with no owner on screen is the worse outcome.
     state.snapGhostActive = false
   }
   setSnapGhost(null)
@@ -188,8 +191,13 @@ function hideOverlayState(state: import('./state').OverlayState): void {
  *  is no PoE focus event coming back to restore from. */
 export function closeAllOverlaysOnPoeExit(): void {
   for (const state of overlays.values()) {
+    state.snapGhostActive = false
     hideOverlayState(state)
   }
+  // The snap canvas is never hidden, only its rect cleared, so a ghost left up
+  // when PoE exits keeps painting on the bare desktop with nothing alive to
+  // clear it - every other path that hides overlays clears it too.
+  setSnapGhost(null)
   // Auxiliary windows (preview) need to clear too - they're not in the
   // overlays map but the user shouldn't see leftover content after PoE exits.
   firePoeLeaveHooks()

--- a/src/main/windowing/index.ts
+++ b/src/main/windowing/index.ts
@@ -272,21 +272,36 @@ function cancelSnapGhostSafetyClear(): void {
   snapGhostSafetyTimer = null
 }
 
+/** Commit a pending snap: clear the ghost, move the window onto its snap
+ *  target, persist. Persisting explicitly (rather than letting the next 'moved'
+ *  do it) is required because the synthetic 'moved' Windows fires from a
+ *  setBounds-inside-a-moved-handler doesn't reliably arrive. Shared by the
+ *  'moved' handler and the mouseup safety-clear so the two can't diverge. */
+function commitSnap(state: OverlayState): void {
+  state.snapGhostActive = false
+  setSnapGhost(null)
+  if (!state.win || state.win.isDestroyed()) return
+  const target = snapTargetFor(state, state.win.getBounds())
+  if (!target) return
+  setBoundsProgrammatic(state, target)
+  persistBounds(state)
+}
+
 /** If 'moved' never arrived after mouseup, commit any pending snap (same as
  *  the moved handler) or just clear the visual ghost. */
 function runSnapGhostSafetyClear(): void {
   snapGhostSafetyTimer = null
-  if (leftMouseHeld) return
+  // mousedown cancels this timer, so a button still held at fire time means a
+  // native event went missing - which is the exact failure this fallback
+  // exists for. Re-arm instead of bailing, or the ghost stays stuck forever.
+  // The next real mouseup replaces the timer, so this can't outlive the drag.
+  if (leftMouseHeld) {
+    scheduleSnapGhostSafetyClear()
+    return
+  }
   for (const state of overlays.values()) {
     if (!state.snapGhostActive) continue
-    state.snapGhostActive = false
-    setSnapGhost(null)
-    if (!state.win || state.win.isDestroyed()) continue
-    const target = snapTargetFor(state, state.win.getBounds())
-    if (target) {
-      setBoundsProgrammatic(state, target)
-      persistBounds(state)
-    }
+    commitSnap(state)
   }
 }
 
@@ -473,17 +488,9 @@ function wireWindowEvents(state: OverlayState, win: BrowserWindow): void {
     if (state.inProgrammaticMove) return
     cancelSnapGhostSafetyClear()
     if (state.snapGhostActive) {
-      // Snap will commit: skip persisting the user's pre-snap drop position
-      // and persist the snapped position once after setBounds. The synthetic
-      // 'moved' Windows fires from setBounds-inside-a-moved-handler doesn't
-      // reliably arrive on Windows, so we have to persist explicitly.
-      state.snapGhostActive = false
-      setSnapGhost(null)
-      const target = snapTargetFor(state, win.getBounds())
-      if (target) {
-        setBoundsProgrammatic(state, target)
-        persistBounds(state)
-      }
+      // Snap will commit: skip persisting the user's pre-snap drop position,
+      // commitSnap persists the snapped one instead.
+      commitSnap(state)
     } else {
       persistBounds(state)
       setSnapGhost(null)

--- a/src/main/windowing/index.ts
+++ b/src/main/windowing/index.ts
@@ -261,19 +261,60 @@ function applyAnchorBounds(state: OverlayState): void {
 // within snap range of the default. Mirrors how the main overlay only updates
 // snap state inside its drag-bound mousemove handler.
 let leftMouseHeld = false
+/** Safety clear for the shared snap-ghost canvas. Windows sometimes never
+ *  fires 'moved' after a title-bar drag release; without this the dashed ghost
+ *  can stick over the game until restart. */
+let snapGhostSafetyTimer: ReturnType<typeof setTimeout> | null = null
+
+function cancelSnapGhostSafetyClear(): void {
+  if (snapGhostSafetyTimer == null) return
+  clearTimeout(snapGhostSafetyTimer)
+  snapGhostSafetyTimer = null
+}
+
+/** If 'moved' never arrived after mouseup, commit any pending snap (same as
+ *  the moved handler) or just clear the visual ghost. */
+function runSnapGhostSafetyClear(): void {
+  snapGhostSafetyTimer = null
+  if (leftMouseHeld) return
+  for (const state of overlays.values()) {
+    if (!state.snapGhostActive) continue
+    state.snapGhostActive = false
+    setSnapGhost(null)
+    if (!state.win || state.win.isDestroyed()) continue
+    const target = snapTargetFor(state, state.win.getBounds())
+    if (target) {
+      setBoundsProgrammatic(state, target)
+      persistBounds(state)
+    }
+  }
+}
+
+function scheduleSnapGhostSafetyClear(): void {
+  cancelSnapGhostSafetyClear()
+  snapGhostSafetyTimer = setTimeout(runSnapGhostSafetyClear, 300)
+}
+
 uIOhook.on(
   'mousedown',
   guardNativeListener('mousedown-snap', (e) => {
-    if (e.button === 1) leftMouseHeld = true
+    if (e.button === 1) {
+      leftMouseHeld = true
+      cancelSnapGhostSafetyClear()
+    }
   }),
 )
 uIOhook.on(
   'mouseup',
   guardNativeListener('mouseup-snap', (e) => {
-    if (e.button === 1) leftMouseHeld = false
-    // Don't clear snapGhostActive here - the gridWin 'moved' event fires
-    // *after* this mouseup and needs the flag set to know whether to commit
-    // the snap. Clearing it here would silently break the snap.
+    if (e.button === 1) {
+      leftMouseHeld = false
+      // Don't clear snapGhostActive here - the gridWin 'moved' event fires
+      // *after* this mouseup and needs the flag set to know whether to commit
+      // the snap. Clearing it here would silently break the snap. Schedule a
+      // fallback in case 'moved' never arrives.
+      scheduleSnapGhostSafetyClear()
+    }
   }),
 )
 
@@ -430,6 +471,7 @@ function wireWindowEvents(state: OverlayState, win: BrowserWindow): void {
   })
   win.on('moved', () => {
     if (state.inProgrammaticMove) return
+    cancelSnapGhostSafetyClear()
     if (state.snapGhostActive) {
       // Snap will commit: skip persisting the user's pre-snap drop position
       // and persist the snapped position once after setBounds. The synthetic

--- a/src/main/windowing/snap-canvas.ts
+++ b/src/main/windowing/snap-canvas.ts
@@ -94,18 +94,25 @@ export function getSnapCanvasWindow(): BrowserWindow | null {
 
 /** Show the snap ghost at the given rect. Pass null to clear it. */
 export function setSnapGhost(rect: Rect | null): void {
+  // Clearing must never create the canvas. There is nothing to clear if it
+  // doesn't exist, and the hide/blur/exit paths clear defensively on every
+  // call - going through ensureCanvasWindow would spawn a whole renderer
+  // process the first time the user alt-tabs out of PoE, for a window no
+  // secondary overlay ever asked for.
+  if (!rect) {
+    getSnapCanvasWindow()?.webContents.send('secondary-overlay-canvas:snap-ghost', null)
+    return
+  }
   const win = ensureCanvasWindow()
-  if (rect) {
-    // Re-apply bounds on every show: PoE may have moved to a different display
-    // since the canvas was last sized, and the canvas needs to land on PoE's
-    // current display to inherit that monitor's scale factor. Also covers the
-    // Windows quirk where the first show after creation re-clamps the window
-    // into the work area, chopping the bottom off.
-    applyCanvasBounds(win)
-    if (!canvasShown) {
-      win.show()
-      canvasShown = true
-    }
+  // Re-apply bounds on every show: PoE may have moved to a different display
+  // since the canvas was last sized, and the canvas needs to land on PoE's
+  // current display to inherit that monitor's scale factor. Also covers the
+  // Windows quirk where the first show after creation re-clamps the window
+  // into the work area, chopping the bottom off.
+  applyCanvasBounds(win)
+  if (!canvasShown) {
+    win.show()
+    canvasShown = true
   }
   win.webContents.send('secondary-overlay-canvas:snap-ghost', rect)
 }

--- a/src/renderer/src/overlay/App.tsx
+++ b/src/renderer/src/overlay/App.tsx
@@ -517,6 +517,9 @@ export default function App(): JSX.Element {
   useEffect(() => {
     if (isHidden) {
       window.api.reportPanelRect([])
+      // Dock ghost is a sibling of the panel, so it survives panel hide. Clear it
+      // so a stuck snapTarget can't leave a faded dashed box over the game.
+      setSnapTarget(null)
       return
     }
     const tick = (): void => {
@@ -645,8 +648,12 @@ export default function App(): JSX.Element {
           sEl.style.transition = 'transform 0.2s ease-out'
           setTranslate(sEl, targetDx, 0)
         }
-        const onEnd = (): void => {
+        let settled = false
+        const settle = (): void => {
+          if (settled) return
+          settled = true
           el.removeEventListener('transitionend', onEnd)
+          window.clearTimeout(settleTimer)
           // Set final position directly on the DOM - React may skip the
           // transform update if the value matches what it last rendered
           el.style.left = `${targetMountX}px`
@@ -658,13 +665,26 @@ export default function App(): JSX.Element {
           if (snap !== cursorSide) {
             setCursorSide(snap)
           }
+          // Always clear the dock ghost — transitionend can miss when the view
+          // remounts mid-snap (e.g. price-check opening), which left a faded
+          // dashed box stuck over the game.
           setSnapTarget(null)
           skipAnimRef.current = true
         }
+        const onEnd = (ev: TransitionEvent): void => {
+          // Ignore child transitions (sisters); only the wrapper transform settles the snap.
+          if (ev.target !== el || ev.propertyName !== 'transform') return
+          settle()
+        }
         el.addEventListener('transitionend', onEnd)
+        // Fallback if transitionend never fires (0-distance snap, remount, etc.).
+        const settleTimer = window.setTimeout(settle, 250)
       } else {
         panelRef.current?.classList.remove('panel-unmounted')
         setDragOffset({ ...dragOffsetRef.current })
+        // Clear even when not snapping / wrapper missing — otherwise a prior
+        // in-range hover leaves the ghost visible after mouseup.
+        setSnapTarget(null)
       }
     }
     window.addEventListener('mousemove', onMove)
@@ -807,8 +827,8 @@ export default function App(): JSX.Element {
           rightMountX={rightMountX}
           panelTop={PANEL_TOP}
           panelWidth={PANEL_WIDTH}
-          panelHeight={panelRef.current?.offsetHeight ?? 0}
-          snapTarget={snapTarget}
+          panelHeight={isHidden ? 0 : (panelRef.current?.offsetHeight ?? 0)}
+          snapTarget={isHidden ? null : snapTarget}
           overlayScale={settings?.overlayScale}
         />
         <div

--- a/src/renderer/src/overlay/App.tsx
+++ b/src/renderer/src/overlay/App.tsx
@@ -672,13 +672,19 @@ export default function App(): JSX.Element {
           skipAnimRef.current = true
         }
         const onEnd = (ev: TransitionEvent): void => {
-          // Ignore child transitions (sisters); only the wrapper transform settles the snap.
+          // Only the wrapper's own transform settles the snap. transitionend
+          // bubbles, so any transition-* inside the panel (hover colors flip as
+          // the panel slides under a stationary cursor) would otherwise settle
+          // us mid-slide and cut the animation short.
           if (ev.target !== el || ev.propertyName !== 'transform') return
           settle()
         }
         el.addEventListener('transitionend', onEnd)
         // Fallback if transitionend never fires (0-distance snap, remount, etc.).
-        const settleTimer = window.setTimeout(settle, 250)
+        // Comfortably longer than the 200ms transition: firing this early would
+        // clear the transition mid-slide and visibly jump the panel, and being
+        // late costs nothing since it only runs when the event was already lost.
+        const settleTimer = window.setTimeout(settle, 400)
       } else {
         panelRef.current?.classList.remove('panel-unmounted')
         setDragOffset({ ...dragOffsetRef.current })


### PR DESCRIPTION
## Summary
- The faded dashed box over the game is Scalpel’s snap-dock ghost getting stuck after a title-bar drag (or plugin overlay drag)
- Main overlay: always clear `snapTarget` on mouse-up (250ms fallback if `transitionend` misses) and when the panel hides
- Secondary overlays: schedule a 300ms safety clear if Windows never fires `moved`; reset `snapGhostActive` on PoE blur hide

## Test plan
- [ ] Drag the main overlay near a dock edge until the dashed ghost appears, release — ghost clears after snap
- [ ] Drag near the edge, release, then immediately price-check — no leftover faded box
- [ ] Hide/close the overlay with Esc while a ghost was visible — ghost gone
- [ ] Drag a plugin overlay (e.g. Lab) near a snap edge and release — ghost clears even if Windows skips `moved`