### PR TITLE
fix(trade): Corrupted chip for Abyss Jewels and missing item classes

### DIFF
--- a/src/main/trade/stat-matcher.test.ts
+++ b/src/main/trade/stat-matcher.test.ts
@@ -45,7 +45,15 @@ describe('ITEM_CLASS_TO_CATEGORY', () => {
     expect(ITEM_CLASS_TO_CATEGORY['Body Armours']).toBe('armour.chest')
     expect(ITEM_CLASS_TO_CATEGORY.Wands).toBe('weapon.wand')
     expect(ITEM_CLASS_TO_CATEGORY.Jewels).toBe('jewel')
+    expect(ITEM_CLASS_TO_CATEGORY['Abyss Jewels']).toBe('jewel.abyss')
     expect(ITEM_CLASS_TO_CATEGORY.Flasks).toBe('flask')
+    expect(ITEM_CLASS_TO_CATEGORY['Life Flasks']).toBe('flask')
+    expect(ITEM_CLASS_TO_CATEGORY['Mana Flasks']).toBe('flask')
+    expect(ITEM_CLASS_TO_CATEGORY.Charms).toBe('azmeri.charm')
+    expect(ITEM_CLASS_TO_CATEGORY.Tinctures).toBe('tincture')
+    expect(ITEM_CLASS_TO_CATEGORY.Trinkets).toBe('accessory.trinket')
+    expect(ITEM_CLASS_TO_CATEGORY['Heist Brooches']).toBe('heistequipment.heistreward')
+    expect(ITEM_CLASS_TO_CATEGORY.Contracts).toBe('heistmission.contract')
     // PoE2-specific classes that have live listings -- without these the
     // trade router falls back to searching a single base type instead of the
     // whole class.
@@ -448,6 +456,66 @@ describe('matchItemMods', () => {
         [],
         undefined,
         makeItemInfo({ corrupted: false, itemClass: 'Rings', sockets: '' }),
+      )
+      const corruptedChip = filters.find((f) => f.id === 'misc.corrupted')
+      expect(corruptedChip).toBeDefined()
+      expect(corruptedChip?.chipState).toBe('no')
+    })
+
+    it('generates corrupted chip for uncorrupted Abyss Jewels (Murderous Eye etc.)', () => {
+      const filters = matchItemMods(
+        [],
+        [],
+        undefined,
+        makeItemInfo({
+          corrupted: false,
+          itemClass: 'Abyss Jewels',
+          baseType: 'Murderous Eye Jewel',
+          rarity: 'Rare',
+          sockets: '',
+        }),
+      )
+      const corruptedChip = filters.find((f) => f.id === 'misc.corrupted')
+      expect(corruptedChip).toBeDefined()
+      expect(corruptedChip?.chipState).toBe('no')
+      expect(corruptedChip?.text).toBe('Corrupted')
+    })
+
+    it('generates corrupted chip for uncorrupted Flasks', () => {
+      const filters = matchItemMods(
+        [],
+        [],
+        undefined,
+        makeItemInfo({ corrupted: false, itemClass: 'Flasks', baseType: 'Divine Life Flask', rarity: 'Magic' }),
+      )
+      const corruptedChip = filters.find((f) => f.id === 'misc.corrupted')
+      expect(corruptedChip).toBeDefined()
+      expect(corruptedChip?.chipState).toBe('no')
+    })
+
+    it('generates corrupted chip for uncorrupted Tinctures', () => {
+      const filters = matchItemMods(
+        [],
+        [],
+        undefined,
+        makeItemInfo({ corrupted: false, itemClass: 'Tinctures', baseType: 'Ashbark Tincture', rarity: 'Magic' }),
+      )
+      const corruptedChip = filters.find((f) => f.id === 'misc.corrupted')
+      expect(corruptedChip).toBeDefined()
+      expect(corruptedChip?.chipState).toBe('no')
+    })
+
+    it('generates corrupted chip for PoE2 Life Flasks', () => {
+      const filters = matchItemMods(
+        [],
+        [],
+        undefined,
+        makeItemInfo({
+          corrupted: false,
+          itemClass: 'Life Flasks',
+          baseType: 'Transcendent Life Flask',
+          rarity: 'Magic',
+        }),
       )
       const corruptedChip = filters.find((f) => f.id === 'misc.corrupted')
       expect(corruptedChip).toBeDefined()

--- a/src/main/trade/stat-matcher/item-classes.ts
+++ b/src/main/trade/stat-matcher/item-classes.ts
@@ -27,7 +27,27 @@ export const ITEM_CLASS_TO_CATEGORY: Record<string, string> = {
   Warstaves: 'weapon.warstaff',
   'Rune Daggers': 'weapon.runedagger',
   Jewels: 'jewel',
+  // PoE1 abyss jewels (Murderous/Hypnotic/etc. Eye) — separate clipboard class
+  // from regular Jewels. Without this entry they aren't treated as equipment, so
+  // misc chips like Corrupted never appear on uncorrupted eyes.
+  'Abyss Jewels': 'jewel.abyss',
   Flasks: 'flask',
+  // PoE2 splits flasks by recover type; same trade category as PoE1 Flasks.
+  'Life Flasks': 'flask',
+  'Mana Flasks': 'flask',
+  Charms: 'azmeri.charm',
+  // PoE1 craftables that share the Abyss-Jewel failure mode if omitted: no
+  // Corrupted/Mirrored ternary chips and trade falls back to bare base-type.
+  Tinctures: 'tincture',
+  Trinkets: 'accessory.trinket',
+  'Heist Brooches': 'heistequipment.heistreward',
+  'Heist Cloaks': 'heistequipment.heistutility',
+  'Heist Tools': 'heistequipment.heisttool',
+  // Clipboard emits both "Contracts"/"Blueprints" and the Heist-prefixed forms.
+  Contracts: 'heistmission.contract',
+  Blueprints: 'heistmission.blueprint',
+  'Heist Contracts': 'heistmission.contract',
+  'Heist Blueprints': 'heistmission.blueprint',
   // PoE2-only classes that have live listings. Keeping them in the same map
   // is safe -- no key collides with PoE1, and stat-matcher / trade.ts both
   // look up by the exact class name the clipboard reports. Without these

--- a/src/main/trade/trade.test.ts
+++ b/src/main/trade/trade.test.ts
@@ -1383,6 +1383,63 @@ describe('searchTrade filter-group dispatch', () => {
     expect(body.query.filters.type_filters.filters.category).toEqual({ option: 'jewel' })
   })
 
+  it('Abyss Jewels route to jewel.abyss category', async () => {
+    setPoeVersion(1)
+    const eye = {
+      name: '',
+      baseType: 'Murderous Eye Jewel',
+      itemClass: 'Abyss Jewels',
+      rarity: 'Rare',
+    }
+    await searchTrade('Mirage', eye, [], { tradeStatus: 'any', tradePriceOption: 'chaos_divine' })
+    const req = capturedRequests.find((r) => r.url.includes('/search/'))
+    const body = parseCapturedBody(req)
+    expect(body.query.filters.type_filters.filters.category).toEqual({ option: 'jewel.abyss' })
+    expect(body.query.type).toBeUndefined()
+  })
+
+  it('Flasks route to flask category', async () => {
+    setPoeVersion(1)
+    const flask = {
+      name: '',
+      baseType: 'Divine Life Flask',
+      itemClass: 'Flasks',
+      rarity: 'Magic',
+    }
+    await searchTrade('Mirage', flask, [], { tradeStatus: 'any', tradePriceOption: 'chaos_divine' })
+    const req = capturedRequests.find((r) => r.url.includes('/search/'))
+    const body = parseCapturedBody(req)
+    expect(body.query.filters.type_filters.filters.category).toEqual({ option: 'flask' })
+  })
+
+  it('Tinctures route to tincture category', async () => {
+    setPoeVersion(1)
+    const tincture = {
+      name: '',
+      baseType: 'Ashbark Tincture',
+      itemClass: 'Tinctures',
+      rarity: 'Magic',
+    }
+    await searchTrade('Mirage', tincture, [], { tradeStatus: 'any', tradePriceOption: 'chaos_divine' })
+    const req = capturedRequests.find((r) => r.url.includes('/search/'))
+    const body = parseCapturedBody(req)
+    expect(body.query.filters.type_filters.filters.category).toEqual({ option: 'tincture' })
+  })
+
+  it('PoE2 Life Flasks route to flask category', async () => {
+    setPoeVersion(2)
+    const flask = {
+      name: '',
+      baseType: 'Transcendent Life Flask',
+      itemClass: 'Life Flasks',
+      rarity: 'Magic',
+    }
+    await searchTrade('Fate of the Vaal', flask, [], { tradeStatus: 'any', tradePriceOption: 'exalted_divine' })
+    const req = capturedRequests.find((r) => r.url.includes('/search/'))
+    const body = parseCapturedBody(req)
+    expect(body.query.filters.type_filters.filters.category).toEqual({ option: 'flask' })
+  })
+
   it('PoE2 rune_sockets filter lands under equipment_filters alongside defence stats', async () => {
     setPoeVersion(2)
     const withRunes: StatFilter[] = [


### PR DESCRIPTION
## Summary
- Map `Abyss Jewels` → `jewel.abyss` so Murderous/Hypnotic/etc. Eye jewels get the Corrupted ternary chip (default No) and route to the abyss-jewel trade category
- Same gap for Tinctures, Trinkets, Heist equipment/missions, PoE2 Life/Mana Flasks, and Charms
- Add regression tests for chip generation and trade category routing

## Test plan
- [ ] Price-check an uncorrupted Murderous Eye Jewel — Corrupted chip visible, default No
- [ ] Toggle Corrupted Yes/Any and confirm results change
- [ ] Price-check a PoE1 flask and a tincture — Corrupted chip present
- [ ] `npx vitest run src/main/trade/stat-matcher.test.ts src/main/trade/trade.test.ts -t 'Abyss|corrupted chip for|Flasks route|Tinctures|Life Flasks|ITEM_CLASS_TO_CATEGORY'`

Made with [Cursor](https://cursor.com)