### PR TITLE
fix(hotkeys): harden Use Saved Regex paste like chat commands

### DIFF
--- a/src/main/hotkeys.ts
+++ b/src/main/hotkeys.ts
@@ -748,6 +748,56 @@ export function sendChatCommand(command: string, autoSubmit = true): Promise<voi
   return pasteToPoEChat(command, autoSubmit).finally(() => restoreModifiers(held))
 }
 
+/**
+ * Paste a regex into PoE's stash/inventory search (Ctrl+F, Ctrl+V).
+ * Same hardening as chat paste: release held modifiers, await game focus,
+ * verify the clipboard write, mark injecting so the hook ignores synthetic
+ * keys, and settle briefly so a bare F-key hotkey (flask conflict) finishes
+ * releasing before Ctrl+F is synthesized.
+ */
+let regexPasteLocked = false
+export async function pasteRegexToPoESearch(regex: string): Promise<void> {
+  if (!regex || regexPasteLocked || injecting) return
+  regexPasteLocked = true
+
+  const held: ModSnapshot = { ...heldModifiers }
+  const prevInjecting = injecting
+  injecting = true
+  if (held.ctrl) uIOhook.keyToggle(held.ctrl, 'up')
+  if (held.shift) uIOhook.keyToggle(held.shift, 'up')
+  if (held.alt) uIOhook.keyToggle(held.alt, 'up')
+  injecting = prevInjecting
+
+  const restoreClip = snapshotClipboard()
+  try {
+    // Let the triggering hotkey keyup (and any flask F1–F5 collision) settle.
+    await wait(50)
+    await awaitGameFocus()
+    await writeChatText(regex)
+
+    injecting = true
+    uIOhook.keyToggle(UiohookKey.Ctrl, 'down')
+    uIOhook.keyTap(UiohookKey.F)
+    uIOhook.keyToggle(UiohookKey.Ctrl, 'up')
+    uIOhook.keyToggle(UiohookKey.Ctrl, 'down')
+    uIOhook.keyTap(UiohookKey.V)
+    uIOhook.keyToggle(UiohookKey.Ctrl, 'up')
+  } catch (e) {
+    restoreClip()
+    regexPasteLocked = false
+    injecting = false
+    restoreModifiers(held)
+    recordMainDiagnostic('regex-paste', e)
+    throw e
+  }
+
+  setTimeout(restoreClip, CLIPBOARD_HOLD_MS).unref?.()
+  await wait(PASTE_SETTLE_MS)
+  regexPasteLocked = false
+  injecting = false
+  restoreModifiers(held)
+}
+
 /** Track physically held modifier keys via uiohook (ignores synthetic key events during injection) */
 const heldModifiers = { ctrl: 0 as number, shift: 0 as number, alt: 0 as number }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, clipboard, crashReporter, ipcMain, screen } from 'electron'
+import { app, crashReporter, ipcMain, screen } from 'electron'
 import { installEarlyDiagnostics, recordMainBreadcrumb, recordMainDiagnostic } from './diagnostics'
 
 // Prevent unhandled JS exceptions from crashing the native overlay thread
@@ -30,7 +30,6 @@ installEarlyDiagnostics()
 crashReporter.start({ uploadToServer: false })
 
 import { execSync } from 'node:child_process'
-import { uIOhook, UiohookKey } from 'uiohook-napi'
 import Store from 'electron-store'
 import { OverlayController } from 'electron-overlay-window'
 import { hideOverlay, showOverlay, getOverlayWindow, setCloseOnClickOutside, setWindowInputFocused } from './overlay'
@@ -49,6 +48,7 @@ import {
   resumeHotkeys,
   setStashScrollEnabled,
   setStashScrollModifier,
+  pasteRegexToPoESearch,
 } from './hotkeys'
 import { refreshLeagues } from './trade/leagues'
 import { resolvePresetRegex } from './trade/beast-preset'
@@ -66,7 +66,6 @@ import {
 } from './evaluation'
 import { initLearning } from './learning'
 import { initMainLocale } from './locale'
-import { snapshotClipboard } from './clipboard-preserve'
 import { flushAll as flushPluginStorage } from './plugins/storage'
 import { registerCheatSheetProtocol } from './cheat-sheet-protocol'
 import { registerScalpelInternalProtocol, registerScalpelInternalSchemePrivileges } from './plugins/protocol'
@@ -337,23 +336,6 @@ app.whenReady().then(() => {
     openDivCards: 'divcards',
     openRegex: 'regex',
   }
-  const pasteRegexToSearch = (regex: string): void => {
-    const restoreClip = snapshotClipboard()
-    try {
-      clipboard.writeText(regex)
-      uIOhook.keyToggle(UiohookKey.Ctrl, 'down')
-      uIOhook.keyTap(UiohookKey.F)
-      uIOhook.keyToggle(UiohookKey.Ctrl, 'up')
-      uIOhook.keyToggle(UiohookKey.Ctrl, 'down')
-      uIOhook.keyTap(UiohookKey.V)
-      uIOhook.keyToggle(UiohookKey.Ctrl, 'up')
-    } catch (e) {
-      // A leaked borrow holds the user's clipboard until the watchdog fires.
-      restoreClip()
-      throw e
-    }
-    setTimeout(restoreClip, 100)
-  }
 
   // Beasts presets re-derive against cached poe.ninja prices so a hotkey bound
   // weeks ago still pastes today's valuable beasts. A cold cache pastes the
@@ -388,7 +370,9 @@ app.whenReady().then(() => {
           OverlayController.focusTarget()
         } catch {}
       },
-      paste: pasteRegexToSearch,
+      paste: (regex) => {
+        void pasteRegexToPoESearch(regex)
+      },
       defer: (fn) => setTimeout(fn, 50),
       resolveRegex: presetRegex,
     })
@@ -402,7 +386,7 @@ app.whenReady().then(() => {
 
   setAppMacroHandler((action, tag, presetId) => {
     if (action === 'pasteRegex') {
-      if (currentRegex) pasteRegexToSearch(currentRegex)
+      if (currentRegex) void pasteRegexToPoESearch(currentRegex)
       return
     }
     if (action === 'useSavedRegex') {
@@ -413,7 +397,7 @@ app.whenReady().then(() => {
         ? presets.find((p) => p.id === presetId)
         : presets.find((p) => p.tags?.some((t) => t.text === tag && (!t.source || t.source === 'custom')))
       const regex = preset ? presetRegex(preset) : undefined
-      if (regex) pasteRegexToSearch(regex)
+      if (regex) void pasteRegexToPoESearch(regex)
       return
     }
     if (action === 'closeOverlay') {

--- a/src/main/regex-remote.ts
+++ b/src/main/regex-remote.ts
@@ -8,7 +8,7 @@ export interface RegexRemoteApplyDeps {
   getPresets: () => RegexPreset[]
   /** Hand OS focus back to the PoE window before keystrokes are synthesized. */
   focusGame: () => void
-  /** Paste the regex into PoE's search (the existing pasteRegexToSearch flow). */
+  /** Paste the regex into PoE's search (hardened Ctrl+F / Ctrl+V injector). */
   paste: (regex: string) => void
   /** Defer the paste until after focus settles. Real wiring uses setTimeout;
    *  tests pass a synchronous implementation. */


### PR DESCRIPTION
## Summary
- Bare F-key macros for **Use Saved Regex** / **Paste Current Regex** injected Ctrl+F then Ctrl+V without the chat-command hardening (release held modifiers, await PoE focus, verified clipboard write, `injecting` guard).
- That left PoE seeing mangled input (failed search open, junk like `c`/`cc`, flask conflicts on F1–F5).
- Move paste into `pasteRegexToPoESearch()` next to chat paste and wire macros + Regex Remote through it.

## Test plan
- [ ] Bind **Use Saved Regex** to a bare F-key (e.g. F4); with stash/inventory focused, confirm regex pastes into search
- [ ] Confirm Ctrl+Shift chord still works
- [ ] Confirm Regex Remote pad still applies presets
- [ ] Confirm chat commands (`/hideout` etc.) still work
- [ ] `vitest run src/main/regex-remote.test.ts`
