### PR TITLE
Linux fix for grabbing the client log

### DIFF
--- a/src/main/client-log/index.test.ts
+++ b/src/main/client-log/index.test.ts
@@ -8,6 +8,8 @@ vi.mock('./watcher', () => ({
   },
 }))
 vi.mock('./path-resolver', () => ({ resolveClientLogPath: () => 'C:/fake/Client.txt' }))
+vi.mock('./seed-last-zone', () => ({ readLastZoneFromLog: () => null }))
+vi.mock('../game-state', () => ({ getPoeVersion: () => 2 }))
 vi.mock('./zone-state', () => ({
   getCurrentZone: () => null,
   ingestZoneEvent: vi.fn(),

--- a/src/main/client-log/index.ts
+++ b/src/main/client-log/index.ts
@@ -1,22 +1,37 @@
 import type { BrowserWindow } from 'electron'
+import { getPoeVersion } from '../game-state'
 import { parseClientLogLine } from './parse-client-log'
 import { resolveClientLogPath } from './path-resolver'
+import { readLastZoneFromLog } from './seed-last-zone'
 import { hasLogLineSubscribers, pushLogLine } from './tail-buffer'
 import { startWatcher } from './watcher'
 import { getCurrentZone, ingestZoneEvent, onZoneChanged } from './zone-state'
+import { log } from 'node:console'
 
 let started = false
 const logLineWinGetters: Array<() => BrowserWindow | null> = []
+console.log('[debug] client log', resolveClientLogPath({ poeVersion: getPoeVersion() }))
+console.log('[debug] getPoeVersion', getPoeVersion())
+console.log(
+  '[debug] current zone',
+  readLastZoneFromLog('/mnt/games/SteamLibrary/steamapps/common/Path of Exile 2/logs/Client.txt'),
+)
 
 /** Boot the Client.txt watcher and pipe zone changes to the overlay
  *  webContents. Idempotent (re-attach events shouldn't restart the
  *  watcher). Silent on resolve failure - the watcher just doesn't start
  *  and the toggle never renders. */
 export function startClientLogWatcher(overlayWindow: BrowserWindow): void {
+  console.log('[debug] startClientLogWatcher')
   if (started) return
-  const path = resolveClientLogPath()
+  const path = resolveClientLogPath({ poeVersion: getPoeVersion() })
+  console.log('[debug] path', path)
   if (!path) return
   started = true
+  const last = readLastZoneFromLog(path)
+  console.log('last', last)
+  console.log('path', path)
+  if (last) ingestZoneEvent(last)
   startWatcher(path, (line) => {
     emitLogLine(line)
     const parsed = parseClientLogLine(line)
@@ -45,6 +60,7 @@ export function forwardZoneChangesTo(getWin: () => BrowserWindow | null): void {
  *  renderer reflects state immediately rather than waiting for the next
  *  Client.txt event. */
 export function sendCurrentZoneTo(win: BrowserWindow): void {
+  console.log('[debug] sendCurrentZoneTo', getCurrentZone())
   if (!win.isDestroyed()) win.webContents.send('zone-changed', getCurrentZone())
 }
 

--- a/src/main/client-log/index.ts
+++ b/src/main/client-log/index.ts
@@ -6,31 +6,20 @@ import { readLastZoneFromLog } from './seed-last-zone'
 import { hasLogLineSubscribers, pushLogLine } from './tail-buffer'
 import { startWatcher } from './watcher'
 import { getCurrentZone, ingestZoneEvent, onZoneChanged } from './zone-state'
-import { log } from 'node:console'
 
 let started = false
 const logLineWinGetters: Array<() => BrowserWindow | null> = []
-console.log('[debug] client log', resolveClientLogPath({ poeVersion: getPoeVersion() }))
-console.log('[debug] getPoeVersion', getPoeVersion())
-console.log(
-  '[debug] current zone',
-  readLastZoneFromLog('/mnt/games/SteamLibrary/steamapps/common/Path of Exile 2/logs/Client.txt'),
-)
 
 /** Boot the Client.txt watcher and pipe zone changes to the overlay
  *  webContents. Idempotent (re-attach events shouldn't restart the
  *  watcher). Silent on resolve failure - the watcher just doesn't start
  *  and the toggle never renders. */
 export function startClientLogWatcher(overlayWindow: BrowserWindow): void {
-  console.log('[debug] startClientLogWatcher')
   if (started) return
   const path = resolveClientLogPath({ poeVersion: getPoeVersion() })
-  console.log('[debug] path', path)
   if (!path) return
   started = true
   const last = readLastZoneFromLog(path)
-  console.log('last', last)
-  console.log('path', path)
   if (last) ingestZoneEvent(last)
   startWatcher(path, (line) => {
     emitLogLine(line)
@@ -60,7 +49,6 @@ export function forwardZoneChangesTo(getWin: () => BrowserWindow | null): void {
  *  renderer reflects state immediately rather than waiting for the next
  *  Client.txt event. */
 export function sendCurrentZoneTo(win: BrowserWindow): void {
-  console.log('[debug] sendCurrentZoneTo', getCurrentZone())
   if (!win.isDestroyed()) win.webContents.send('zone-changed', getCurrentZone())
 }
 

--- a/src/main/client-log/path-resolver.test.ts
+++ b/src/main/client-log/path-resolver.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { resolveClientLogPath, unixPathFromWineExe, type PathResolverFs } from './path-resolver'
+
+function fakeFs(files: Record<string, string | 'dir' | 'link:'>): PathResolverFs {
+  return {
+    existsSync: (path) => path in files,
+    readdirSync: (path) =>
+      Object.keys(files)
+        .filter((p) => p.startsWith(`${path}/`) && !p.slice(path.length + 1).includes('/'))
+        .map((p) => p.slice(path.length + 1)),
+    readFileSync: (path) => {
+      const v = files[path]
+      if (typeof v !== 'string' || v.startsWith('link:')) throw new Error('not a file')
+      return v
+    },
+    readlinkSync: (path) => {
+      const v = files[path]
+      if (typeof v !== 'string' || !v.startsWith('link:')) throw new Error('not a link')
+      return v.slice(5)
+    },
+  }
+}
+
+describe('unixPathFromWineExe', () => {
+  it('passes through Unix paths', () => {
+    expect(unixPathFromWineExe('/home/t/.steam/steamapps/common/Path of Exile 2/PathOfExileSteam.exe')).toBe(
+      '/home/t/.steam/steamapps/common/Path of Exile 2/PathOfExileSteam.exe',
+    )
+  })
+
+  it('maps Proton Z: to the Unix root', () => {
+    expect(
+      unixPathFromWineExe(
+        'Z:\\home\\t\\.local\\share\\Steam\\steamapps\\common\\Path of Exile 2\\PathOfExileSteam.exe',
+      ),
+    ).toBe('/home/t/.local/share/Steam/steamapps/common/Path of Exile 2/PathOfExileSteam.exe')
+  })
+
+  it('returns null for unrelated Windows paths', () => {
+    expect(unixPathFromWineExe('C:\\windows\\system32\\steam.exe')).toBeNull()
+  })
+})
+
+describe('resolveClientLogPath', () => {
+  it('honors SCALPEL_CLIENT_LOG when the file exists', () => {
+    const fs = fakeFs({ '/tmp/Client.txt': '' })
+    expect(
+      resolveClientLogPath({
+        platform: 'linux',
+        env: { SCALPEL_CLIENT_LOG: '/tmp/Client.txt' },
+        homedir: '/home/t',
+        fs,
+        poeVersion: 2,
+      }),
+    ).toBe('/tmp/Client.txt')
+  })
+
+  it('finds Client.txt next to a Proton game exe via /proc cmdline', () => {
+    const log = '/home/t/.local/share/Steam/steamapps/common/Path of Exile 2/logs/Client.txt'
+    const fs = fakeFs({
+      '/proc': 'dir',
+      '/proc/42': 'dir',
+      '/proc/42/cmdline': `wine64\0Z:\\home\\t\\.local\\share\\Steam\\steamapps\\common\\Path of Exile 2\\PathOfExileSteam.exe\0`,
+      '/proc/42/exe': 'link:/home/t/.steam/steamapps/common/Proton 9.0/files/bin/wine64',
+      [log]: '',
+    })
+    expect(
+      resolveClientLogPath({
+        platform: 'linux',
+        env: {},
+        homedir: '/home/t',
+        fs,
+        poeVersion: 2,
+      }),
+    ).toBe(log)
+  })
+
+  it('falls back to Steam libraryfolders.vdf', () => {
+    const log = '/mnt/games/SteamLibrary/steamapps/common/Path of Exile 2/logs/Client.txt'
+    const fs = fakeFs({
+      '/proc': 'dir',
+      '/home/t/.local/share/Steam/steamapps': 'dir',
+      '/home/t/.local/share/Steam/steamapps/libraryfolders.vdf': `"libraryfolders"\n{\n\t"1"\n\t{\n\t\t"path"\t\t"/mnt/games/SteamLibrary"\n\t}\n}`,
+      [log]: '',
+    })
+    expect(
+      resolveClientLogPath({
+        platform: 'linux',
+        env: {},
+        homedir: '/home/t',
+        fs,
+        poeVersion: 2,
+      }),
+    ).toBe(log)
+  })
+
+  it('uses PowerShell on Windows', () => {
+    const log = '/PoE/logs/Client.txt'
+    const fs = fakeFs({ [log]: '' })
+    expect(
+      resolveClientLogPath({
+        platform: 'win32',
+        env: {},
+        homedir: '/Users/t',
+        fs,
+        execUtf8: () => '/PoE/PathOfExileSteam.exe\n',
+        poeVersion: 2,
+      }),
+    ).toBe(log)
+  })
+})

--- a/src/main/client-log/path-resolver.test.ts
+++ b/src/main/client-log/path-resolver.test.ts
@@ -95,15 +95,15 @@ describe('resolveClientLogPath', () => {
   })
 
   it('uses PowerShell on Windows', () => {
-    const log = '/PoE/logs/Client.txt'
+    const log = 'C:\\PoE\\logs\\Client.txt'
     const fs = fakeFs({ [log]: '' })
     expect(
       resolveClientLogPath({
         platform: 'win32',
         env: {},
-        homedir: '/Users/t',
+        homedir: 'C:\\Users\\t',
         fs,
-        execUtf8: () => '/PoE/PathOfExileSteam.exe\n',
+        execUtf8: () => 'C:\\PoE\\PathOfExileSteam.exe\n',
         poeVersion: 2,
       }),
     ).toBe(log)

--- a/src/main/client-log/path-resolver.test.ts
+++ b/src/main/client-log/path-resolver.test.ts
@@ -133,6 +133,64 @@ describe('resolveClientLogPath', () => {
     ).toBeNull()
   })
 
+  it('picks the attached game when both games are running on Windows', () => {
+    const poe1 = 'C:\\Steam\\steamapps\\common\\Path of Exile\\logs\\Client.txt'
+    const poe2 = 'C:\\Steam\\steamapps\\common\\Path of Exile 2\\logs\\Client.txt'
+    const fs = fakeFs({ [poe1]: '', [poe2]: '' })
+    expect(
+      resolveClientLogPath({
+        platform: 'win32',
+        env: {},
+        homedir: 'C:\\Users\\t',
+        fs,
+        execUtf8: () =>
+          'C:\\Steam\\steamapps\\common\\Path of Exile\\PathOfExileSteam.exe\r\n' +
+          'C:\\Steam\\steamapps\\common\\Path of Exile 2\\PathOfExileSteam.exe\r\n',
+        poeVersion: 2,
+      }),
+    ).toBe(poe2)
+  })
+
+  it('still resolves a lone install whose directory names neither game', () => {
+    const log = 'D:\\Games\\poe\\logs\\Client.txt'
+    const fs = fakeFs({ [log]: '' })
+    expect(
+      resolveClientLogPath({
+        platform: 'win32',
+        env: {},
+        homedir: 'C:\\Users\\t',
+        fs,
+        execUtf8: () => 'D:\\Games\\poe\\PathOfExileSteam.exe\n',
+        poeVersion: 2,
+      }),
+    ).toBe(log)
+  })
+
+  it('prefers the attached game across /proc processes', () => {
+    const poe1 = '/home/t/.steam/steamapps/common/Path of Exile/logs/Client.txt'
+    const poe2 = '/home/t/.steam/steamapps/common/Path of Exile 2/logs/Client.txt'
+    const fs = fakeFs({
+      '/proc': 'dir',
+      '/proc/41': 'dir',
+      '/proc/41/cmdline': `/home/t/.steam/steamapps/common/Path of Exile/PathOfExile_x64\0`,
+      '/proc/41/exe': 'link:/home/t/.steam/steamapps/common/Path of Exile/PathOfExile_x64',
+      '/proc/42': 'dir',
+      '/proc/42/cmdline': `/home/t/.steam/steamapps/common/Path of Exile 2/PathOfExileSteam\0`,
+      '/proc/42/exe': 'link:/home/t/.steam/steamapps/common/Path of Exile 2/PathOfExileSteam',
+      [poe1]: '',
+      [poe2]: '',
+    })
+    expect(
+      resolveClientLogPath({
+        platform: 'linux',
+        env: {},
+        homedir: '/home/t',
+        fs,
+        poeVersion: 2,
+      }),
+    ).toBe(poe2)
+  })
+
   it('uses PowerShell on Windows', () => {
     const log = 'C:\\PoE\\logs\\Client.txt'
     const fs = fakeFs({ [log]: '' })

--- a/src/main/client-log/path-resolver.test.ts
+++ b/src/main/client-log/path-resolver.test.ts
@@ -94,6 +94,45 @@ describe('resolveClientLogPath', () => {
     ).toBe(log)
   })
 
+  it('prefers the attached game over a nearer wrong-game install', () => {
+    const poe1 = '/home/t/.local/share/Steam/steamapps/common/Path of Exile/logs/Client.txt'
+    const poe2 = '/mnt/games/SteamLibrary/steamapps/common/Path of Exile 2/logs/Client.txt'
+    const fs = fakeFs({
+      '/proc': 'dir',
+      '/home/t/.local/share/Steam/steamapps': 'dir',
+      '/home/t/.local/share/Steam/steamapps/libraryfolders.vdf': `"libraryfolders"\n{\n\t"1"\n\t{\n\t\t"path"\t\t"/mnt/games/SteamLibrary"\n\t}\n}`,
+      [poe1]: '',
+      [poe2]: '',
+    })
+    expect(
+      resolveClientLogPath({
+        platform: 'linux',
+        env: {},
+        homedir: '/home/t',
+        fs,
+        poeVersion: 2,
+      }),
+    ).toBe(poe2)
+  })
+
+  it('returns null when only the other game is installed', () => {
+    const poe1 = '/home/t/.local/share/Steam/steamapps/common/Path of Exile/logs/Client.txt'
+    const fs = fakeFs({
+      '/proc': 'dir',
+      '/home/t/.local/share/Steam/steamapps': 'dir',
+      [poe1]: '',
+    })
+    expect(
+      resolveClientLogPath({
+        platform: 'linux',
+        env: {},
+        homedir: '/home/t',
+        fs,
+        poeVersion: 2,
+      }),
+    ).toBeNull()
+  })
+
   it('uses PowerShell on Windows', () => {
     const log = 'C:\\PoE\\logs\\Client.txt'
     const fs = fakeFs({ [log]: '' })

--- a/src/main/client-log/path-resolver.ts
+++ b/src/main/client-log/path-resolver.ts
@@ -1,40 +1,223 @@
 import { execFileSync } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, readlinkSync } from 'node:fs'
+import { homedir as osHomedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import type { GameVariant } from '@shared/types'
+
+const EXE_NAME_RE = /PathOfExile/i
+const STEAM_GAME_DIR: Record<GameVariant, string> = {
+  1: 'Path of Exile',
+  2: 'Path of Exile 2',
+}
+
+export interface PathResolverFs {
+  existsSync(path: string): boolean
+  readdirSync(path: string): string[]
+  readFileSync(path: string, encoding: 'utf8'): string
+  readlinkSync(path: string): string
+}
+
+export interface PathResolverDeps {
+  platform?: NodeJS.Platform
+  env?: NodeJS.ProcessEnv
+  homedir?: string
+  fs?: PathResolverFs
+  execUtf8?: (file: string, args: string[]) => string
+  poeVersion?: GameVariant
+}
+
+const defaultFs: PathResolverFs = {
+  existsSync,
+  readdirSync: (path) => readdirSync(path),
+  readFileSync: (path, encoding) => readFileSync(path, encoding),
+  readlinkSync: (path) => readlinkSync(path),
+}
+
+function defaultExecUtf8(file: string, args: string[]): string {
+  return execFileSync(file, args, { encoding: 'utf8', timeout: 5000, windowsHide: true })
+}
 
 /** Best-effort resolve the absolute Client.txt path for the running PoE
- *  process. Strategy: ask PowerShell for the executable Path of any
- *  process named PathOfExile* (covers PathOfExile.exe, PathOfExile_x64.exe,
- *  PathOfExileSteam.exe, PathOfExile2.exe, ...). Forces UTF-8 stdout so
- *  non-ASCII install paths round-trip cleanly. Strip the filename,
- *  append \logs\Client.txt, confirm the file exists.
+ *  process. Windows asks PowerShell for PathOfExile*; Linux/macOS scan the
+ *  process list and Steam library folders. SCALPEL_CLIENT_LOG overrides.
  *
  *  Returns null on any failure. Callers should treat null as "watcher
- *  doesn't start" - the toggle simply won't appear. This is silent by
- *  design; the user has no setting to fix in v1. */
-export function resolveClientLogPath(): string | null {
-  let exePath: string
+ *  doesn't start". Silent by design unless SCALPEL_DEBUG_LOG is set. */
+export function resolveClientLogPath(deps: PathResolverDeps = {}): string | null {
+  const platform = deps.platform ?? process.platform
+  const env = deps.env ?? process.env
+  const fs = deps.fs ?? defaultFs
+  const home = deps.homedir ?? osHomedir()
+  const execUtf8 = deps.execUtf8 ?? defaultExecUtf8
+  const version = deps.poeVersion ?? 2
+  const fromEnv = clientTxtIfExists(env.SCALPEL_CLIENT_LOG, fs)
+  if (fromEnv) return fromEnv
+
   try {
-    const out = execFileSync(
-      'powershell.exe',
-      [
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Process -Name 'PathOfExile*' | Select-Object -First 1 -ExpandProperty Path",
-      ],
-      { encoding: 'utf8', timeout: 5000, windowsHide: true },
-    )
-    exePath = out.trim()
+    if (platform === 'win32') return resolveWindows(execUtf8, fs)
+    if (platform === 'linux') return resolveLinux(fs, home, version)
+    if (platform === 'darwin') return resolveDarwin(execUtf8, fs, home, version)
   } catch (err) {
-    if (process.env.SCALPEL_DEBUG_LOG) console.warn('[client-log] path resolver: PowerShell shellout failed', err)
+    if (env.SCALPEL_DEBUG_LOG) console.warn('[client-log] path resolver failed', err)
     return null
   }
+  return null
+}
+
+function clientTxtIfExists(path: string | undefined, fs: PathResolverFs): string | null {
+  if (!path) return null
+  return fs.existsSync(path) ? path : null
+}
+
+function clientTxtBesideExe(exePath: string, fs: PathResolverFs): string | null {
   if (!exePath) return null
   const candidate = join(dirname(exePath), 'logs', 'Client.txt')
-  if (!existsSync(candidate)) {
+  return fs.existsSync(candidate) ? candidate : null
+}
+
+function resolveWindows(execUtf8: NonNullable<PathResolverDeps['execUtf8']>, fs: PathResolverFs): string | null {
+  const out = execUtf8('powershell.exe', [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Process -Name 'PathOfExile*' | Select-Object -First 1 -ExpandProperty Path",
+  ])
+  const exePath = out.trim()
+  if (!exePath) return null
+  const candidate = join(dirname(exePath), 'logs', 'Client.txt')
+  if (!fs.existsSync(candidate)) {
     if (process.env.SCALPEL_DEBUG_LOG) console.warn('[client-log] path resolver: not found at', candidate)
     return null
   }
   return candidate
+}
+
+function resolveLinux(fs: PathResolverFs, home: string, version: GameVariant): string | null {
+  const fromProc = resolveFromLinuxProc(fs)
+  if (fromProc) return fromProc
+  return resolveFromSteamLibraries(fs, linuxSteamRoots(home), version)
+}
+
+function resolveDarwin(
+  execUtf8: NonNullable<PathResolverDeps['execUtf8']>,
+  fs: PathResolverFs,
+  home: string,
+  version: GameVariant,
+): string | null {
+  try {
+    const out = execUtf8('ps', ['-ax', '-o', 'command='])
+    for (const line of out.split('\n')) {
+      if (!EXE_NAME_RE.test(line)) continue
+      const exe = extractExePath(line)
+      const candidate = exe ? clientTxtBesideExe(exe, fs) : null
+      if (candidate) return candidate
+    }
+  } catch {
+    /* ps unavailable */
+  }
+  return resolveFromSteamLibraries(fs, darwinSteamRoots(home), version)
+}
+
+function linuxSteamRoots(home: string): string[] {
+  return [
+    join(home, '.local', 'share', 'Steam'),
+    join(home, '.steam', 'steam'),
+    join(home, '.steam', 'root'),
+    join(home, '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam'),
+  ]
+}
+
+function darwinSteamRoots(home: string): string[] {
+  return [join(home, 'Library', 'Application Support', 'Steam')]
+}
+
+function resolveFromLinuxProc(fs: PathResolverFs): string | null {
+  let pids: string[]
+  try {
+    pids = fs.readdirSync('/proc').filter((n) => /^\d+$/.test(n))
+  } catch {
+    return null
+  }
+  for (const pid of pids) {
+    let cmdline = ''
+    try {
+      cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8')
+    } catch {
+      continue
+    }
+    if (!EXE_NAME_RE.test(cmdline) && !cmdlineIncludesPoeDir(cmdline)) continue
+
+    try {
+      const exe = fs.readlinkSync(`/proc/${pid}/exe`)
+      const candidate = clientTxtBesideExe(exe.replace(/\s+\(deleted\)$/, ''), fs)
+      if (candidate) return candidate
+    } catch {
+      /* wine-preloader: exe is not the game binary */
+    }
+
+    for (const part of cmdline.split('\0')) {
+      const unix = unixPathFromWineExe(part)
+      if (!unix || !EXE_NAME_RE.test(unix)) continue
+      const candidate = clientTxtBesideExe(unix, fs)
+      if (candidate) return candidate
+    }
+
+    try {
+      const cwd = fs.readlinkSync(`/proc/${pid}/cwd`)
+      const candidate = join(cwd, 'logs', 'Client.txt')
+      if (fs.existsSync(candidate)) return candidate
+    } catch {
+      /* no cwd */
+    }
+  }
+  return null
+}
+
+function cmdlineIncludesPoeDir(cmdline: string): boolean {
+  return /Path of Exile/i.test(cmdline)
+}
+
+/** Convert a PathOfExile*.exe path from a Wine/Proton cmdline into a Unix path. */
+export function unixPathFromWineExe(raw: string): string | null {
+  const trimmed = raw.trim().replace(/^"|"$/g, '')
+  if (!trimmed) return null
+  if (trimmed.startsWith('/')) return trimmed
+  // Proton maps Z: to the Unix root.
+  const z = /^Z:([\\/].*)$/i.exec(trimmed)
+  if (z) return z[1].replace(/\\/g, '/')
+  if (!EXE_NAME_RE.test(trimmed)) return null
+  return null
+}
+
+function extractExePath(command: string): string | null {
+  const unix = command.match(/(\/\S*PathOfExile\S*)/i)
+  if (unix) return unix[1]
+  return unixPathFromWineExe(command.trim())
+}
+
+function resolveFromSteamLibraries(fs: PathResolverFs, roots: string[], version: GameVariant): string | null {
+  const libraries = new Set<string>()
+  for (const root of roots) {
+    if (fs.existsSync(join(root, 'steamapps'))) libraries.add(root)
+    const vdf = join(root, 'steamapps', 'libraryfolders.vdf')
+    if (!fs.existsSync(vdf)) continue
+    let text = ''
+    try {
+      text = fs.readFileSync(vdf, 'utf8')
+    } catch {
+      continue
+    }
+    for (const m of text.matchAll(/"path"\s+"([^"]+)"/g)) {
+      libraries.add(m[1].replace(/\\\\/g, '/'))
+    }
+  }
+
+  const names = version === 1 ? [STEAM_GAME_DIR[1], STEAM_GAME_DIR[2]] : [STEAM_GAME_DIR[2], STEAM_GAME_DIR[1]]
+  for (const lib of libraries) {
+    for (const name of names) {
+      const candidate = join(lib, 'steamapps', 'common', name, 'logs', 'Client.txt')
+      if (fs.existsSync(candidate)) return candidate
+    }
+  }
+  return null
 }

--- a/src/main/client-log/path-resolver.ts
+++ b/src/main/client-log/path-resolver.ts
@@ -1,13 +1,22 @@
 import { execFileSync } from 'node:child_process'
 import { existsSync, readdirSync, readFileSync, readlinkSync } from 'node:fs'
 import { homedir as osHomedir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { posix, win32 } from 'node:path'
 import type { GameVariant } from '@shared/types'
 
 const EXE_NAME_RE = /PathOfExile/i
 const STEAM_GAME_DIR: Record<GameVariant, string> = {
   1: 'Path of Exile',
   2: 'Path of Exile 2',
+}
+
+type PathApi = { join: (...parts: string[]) => string; dirname: (p: string) => string }
+
+/** Path ops for the *target* platform (deps.platform), not the host OS.
+ *  Lets Linux resolution keep posix separators when unit tests run on Windows CI. */
+function pathApiFor(platform: NodeJS.Platform): PathApi {
+  if (platform === 'win32') return win32
+  return posix
 }
 
 export interface PathResolverFs {
@@ -50,13 +59,15 @@ export function resolveClientLogPath(deps: PathResolverDeps = {}): string | null
   const home = deps.homedir ?? osHomedir()
   const execUtf8 = deps.execUtf8 ?? defaultExecUtf8
   const version = deps.poeVersion ?? 2
+  const path = pathApiFor(platform)
+
   const fromEnv = clientTxtIfExists(env.SCALPEL_CLIENT_LOG, fs)
   if (fromEnv) return fromEnv
 
   try {
-    if (platform === 'win32') return resolveWindows(execUtf8, fs)
-    if (platform === 'linux') return resolveLinux(fs, home, version)
-    if (platform === 'darwin') return resolveDarwin(execUtf8, fs, home, version)
+    if (platform === 'win32') return resolveWindows(execUtf8, fs, path)
+    if (platform === 'linux') return resolveLinux(fs, home, version, path)
+    if (platform === 'darwin') return resolveDarwin(execUtf8, fs, home, version, path)
   } catch (err) {
     if (env.SCALPEL_DEBUG_LOG) console.warn('[client-log] path resolver failed', err)
     return null
@@ -69,13 +80,17 @@ function clientTxtIfExists(path: string | undefined, fs: PathResolverFs): string
   return fs.existsSync(path) ? path : null
 }
 
-function clientTxtBesideExe(exePath: string, fs: PathResolverFs): string | null {
+function clientTxtBesideExe(exePath: string, fs: PathResolverFs, path: PathApi): string | null {
   if (!exePath) return null
-  const candidate = join(dirname(exePath), 'logs', 'Client.txt')
+  const candidate = path.join(path.dirname(exePath), 'logs', 'Client.txt')
   return fs.existsSync(candidate) ? candidate : null
 }
 
-function resolveWindows(execUtf8: NonNullable<PathResolverDeps['execUtf8']>, fs: PathResolverFs): string | null {
+function resolveWindows(
+  execUtf8: NonNullable<PathResolverDeps['execUtf8']>,
+  fs: PathResolverFs,
+  path: PathApi,
+): string | null {
   const out = execUtf8('powershell.exe', [
     '-NoProfile',
     '-NonInteractive',
@@ -84,7 +99,7 @@ function resolveWindows(execUtf8: NonNullable<PathResolverDeps['execUtf8']>, fs:
   ])
   const exePath = out.trim()
   if (!exePath) return null
-  const candidate = join(dirname(exePath), 'logs', 'Client.txt')
+  const candidate = path.join(path.dirname(exePath), 'logs', 'Client.txt')
   if (!fs.existsSync(candidate)) {
     if (process.env.SCALPEL_DEBUG_LOG) console.warn('[client-log] path resolver: not found at', candidate)
     return null
@@ -92,10 +107,10 @@ function resolveWindows(execUtf8: NonNullable<PathResolverDeps['execUtf8']>, fs:
   return candidate
 }
 
-function resolveLinux(fs: PathResolverFs, home: string, version: GameVariant): string | null {
-  const fromProc = resolveFromLinuxProc(fs)
+function resolveLinux(fs: PathResolverFs, home: string, version: GameVariant, path: PathApi): string | null {
+  const fromProc = resolveFromLinuxProc(fs, path)
   if (fromProc) return fromProc
-  return resolveFromSteamLibraries(fs, linuxSteamRoots(home), version)
+  return resolveFromSteamLibraries(fs, linuxSteamRoots(home, path), version, path)
 }
 
 function resolveDarwin(
@@ -103,35 +118,36 @@ function resolveDarwin(
   fs: PathResolverFs,
   home: string,
   version: GameVariant,
+  path: PathApi,
 ): string | null {
   try {
     const out = execUtf8('ps', ['-ax', '-o', 'command='])
     for (const line of out.split('\n')) {
       if (!EXE_NAME_RE.test(line)) continue
       const exe = extractExePath(line)
-      const candidate = exe ? clientTxtBesideExe(exe, fs) : null
+      const candidate = exe ? clientTxtBesideExe(exe, fs, path) : null
       if (candidate) return candidate
     }
   } catch {
     /* ps unavailable */
   }
-  return resolveFromSteamLibraries(fs, darwinSteamRoots(home), version)
+  return resolveFromSteamLibraries(fs, darwinSteamRoots(home, path), version, path)
 }
 
-function linuxSteamRoots(home: string): string[] {
+function linuxSteamRoots(home: string, path: PathApi): string[] {
   return [
-    join(home, '.local', 'share', 'Steam'),
-    join(home, '.steam', 'steam'),
-    join(home, '.steam', 'root'),
-    join(home, '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam'),
+    path.join(home, '.local', 'share', 'Steam'),
+    path.join(home, '.steam', 'steam'),
+    path.join(home, '.steam', 'root'),
+    path.join(home, '.var', 'app', 'com.valvesoftware.Steam', '.local', 'share', 'Steam'),
   ]
 }
 
-function darwinSteamRoots(home: string): string[] {
-  return [join(home, 'Library', 'Application Support', 'Steam')]
+function darwinSteamRoots(home: string, path: PathApi): string[] {
+  return [path.join(home, 'Library', 'Application Support', 'Steam')]
 }
 
-function resolveFromLinuxProc(fs: PathResolverFs): string | null {
+function resolveFromLinuxProc(fs: PathResolverFs, path: PathApi): string | null {
   let pids: string[]
   try {
     pids = fs.readdirSync('/proc').filter((n) => /^\d+$/.test(n))
@@ -149,7 +165,7 @@ function resolveFromLinuxProc(fs: PathResolverFs): string | null {
 
     try {
       const exe = fs.readlinkSync(`/proc/${pid}/exe`)
-      const candidate = clientTxtBesideExe(exe.replace(/\s+\(deleted\)$/, ''), fs)
+      const candidate = clientTxtBesideExe(exe.replace(/\s+\(deleted\)$/, ''), fs, path)
       if (candidate) return candidate
     } catch {
       /* wine-preloader: exe is not the game binary */
@@ -158,13 +174,13 @@ function resolveFromLinuxProc(fs: PathResolverFs): string | null {
     for (const part of cmdline.split('\0')) {
       const unix = unixPathFromWineExe(part)
       if (!unix || !EXE_NAME_RE.test(unix)) continue
-      const candidate = clientTxtBesideExe(unix, fs)
+      const candidate = clientTxtBesideExe(unix, fs, path)
       if (candidate) return candidate
     }
 
     try {
       const cwd = fs.readlinkSync(`/proc/${pid}/cwd`)
-      const candidate = join(cwd, 'logs', 'Client.txt')
+      const candidate = path.join(cwd, 'logs', 'Client.txt')
       if (fs.existsSync(candidate)) return candidate
     } catch {
       /* no cwd */
@@ -195,11 +211,16 @@ function extractExePath(command: string): string | null {
   return unixPathFromWineExe(command.trim())
 }
 
-function resolveFromSteamLibraries(fs: PathResolverFs, roots: string[], version: GameVariant): string | null {
+function resolveFromSteamLibraries(
+  fs: PathResolverFs,
+  roots: string[],
+  version: GameVariant,
+  path: PathApi,
+): string | null {
   const libraries = new Set<string>()
   for (const root of roots) {
-    if (fs.existsSync(join(root, 'steamapps'))) libraries.add(root)
-    const vdf = join(root, 'steamapps', 'libraryfolders.vdf')
+    if (fs.existsSync(path.join(root, 'steamapps'))) libraries.add(root)
+    const vdf = path.join(root, 'steamapps', 'libraryfolders.vdf')
     if (!fs.existsSync(vdf)) continue
     let text = ''
     try {
@@ -215,7 +236,7 @@ function resolveFromSteamLibraries(fs: PathResolverFs, roots: string[], version:
   const names = version === 1 ? [STEAM_GAME_DIR[1], STEAM_GAME_DIR[2]] : [STEAM_GAME_DIR[2], STEAM_GAME_DIR[1]]
   for (const lib of libraries) {
     for (const name of names) {
-      const candidate = join(lib, 'steamapps', 'common', name, 'logs', 'Client.txt')
+      const candidate = path.join(lib, 'steamapps', 'common', name, 'logs', 'Client.txt')
       if (fs.existsSync(candidate)) return candidate
     }
   }

--- a/src/main/client-log/path-resolver.ts
+++ b/src/main/client-log/path-resolver.ts
@@ -233,12 +233,13 @@ function resolveFromSteamLibraries(
     }
   }
 
-  const names = version === 1 ? [STEAM_GAME_DIR[1], STEAM_GAME_DIR[2]] : [STEAM_GAME_DIR[2], STEAM_GAME_DIR[1]]
+  // Only the attached game's install qualifies: a wrong-game Client.txt
+  // would latch for the whole session (startClientLogWatcher never
+  // re-resolves), which is worse than null - null retries on next attach.
+  const name = STEAM_GAME_DIR[version]
   for (const lib of libraries) {
-    for (const name of names) {
-      const candidate = path.join(lib, 'steamapps', 'common', name, 'logs', 'Client.txt')
-      if (fs.existsSync(candidate)) return candidate
-    }
+    const candidate = path.join(lib, 'steamapps', 'common', name, 'logs', 'Client.txt')
+    if (fs.existsSync(candidate)) return candidate
   }
   return null
 }

--- a/src/main/client-log/path-resolver.ts
+++ b/src/main/client-log/path-resolver.ts
@@ -10,6 +10,19 @@ const STEAM_GAME_DIR: Record<GameVariant, string> = {
   2: 'Path of Exile 2',
 }
 
+/** Both games share exe names (PathOfExileSteam.exe), so the install
+ *  directory is the only version signal in a process path. Callers reorder
+ *  candidates by this - never filter - so a custom install dir matching
+ *  neither name still resolves when it is the only candidate. */
+const GAME_DIR_RE: Record<GameVariant, RegExp> = {
+  1: /Path of Exile(?! 2)/i,
+  2: /Path of Exile 2/i,
+}
+
+function installMatchesVersion(p: string, version: GameVariant): boolean {
+  return GAME_DIR_RE[version].test(p)
+}
+
 type PathApi = { join: (...parts: string[]) => string; dirname: (p: string) => string }
 
 /** Path ops for the *target* platform (deps.platform), not the host OS.
@@ -65,7 +78,7 @@ export function resolveClientLogPath(deps: PathResolverDeps = {}): string | null
   if (fromEnv) return fromEnv
 
   try {
-    if (platform === 'win32') return resolveWindows(execUtf8, fs, path)
+    if (platform === 'win32') return resolveWindows(execUtf8, fs, path, version)
     if (platform === 'linux') return resolveLinux(fs, home, version, path)
     if (platform === 'darwin') return resolveDarwin(execUtf8, fs, home, version, path)
   } catch (err) {
@@ -90,25 +103,34 @@ function resolveWindows(
   execUtf8: NonNullable<PathResolverDeps['execUtf8']>,
   fs: PathResolverFs,
   path: PathApi,
+  version: GameVariant,
 ): string | null {
   const out = execUtf8('powershell.exe', [
     '-NoProfile',
     '-NonInteractive',
     '-Command',
-    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Process -Name 'PathOfExile*' | Select-Object -First 1 -ExpandProperty Path",
+    "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Process -Name 'PathOfExile*' | Select-Object -ExpandProperty Path",
   ])
-  const exePath = out.trim()
-  if (!exePath) return null
-  const candidate = path.join(path.dirname(exePath), 'logs', 'Client.txt')
-  if (!fs.existsSync(candidate)) {
-    if (process.env.SCALPEL_DEBUG_LOG) console.warn('[client-log] path resolver: not found at', candidate)
-    return null
+  const exePaths = out
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean)
+  const ordered = [
+    ...exePaths.filter((p) => installMatchesVersion(p, version)),
+    ...exePaths.filter((p) => !installMatchesVersion(p, version)),
+  ]
+  for (const exePath of ordered) {
+    const candidate = path.join(path.dirname(exePath), 'logs', 'Client.txt')
+    if (fs.existsSync(candidate)) return candidate
   }
-  return candidate
+  if (ordered.length > 0 && process.env.SCALPEL_DEBUG_LOG) {
+    console.warn('[client-log] path resolver: no Client.txt beside', ordered.join(', '))
+  }
+  return null
 }
 
 function resolveLinux(fs: PathResolverFs, home: string, version: GameVariant, path: PathApi): string | null {
-  const fromProc = resolveFromLinuxProc(fs, path)
+  const fromProc = resolveFromLinuxProc(fs, path, version)
   if (fromProc) return fromProc
   return resolveFromSteamLibraries(fs, linuxSteamRoots(home, path), version, path)
 }
@@ -147,44 +169,56 @@ function darwinSteamRoots(home: string, path: PathApi): string[] {
   return [path.join(home, 'Library', 'Application Support', 'Steam')]
 }
 
-function resolveFromLinuxProc(fs: PathResolverFs, path: PathApi): string | null {
+function resolveFromLinuxProc(fs: PathResolverFs, path: PathApi, version: GameVariant): string | null {
   let pids: string[]
   try {
     pids = fs.readdirSync('/proc').filter((n) => /^\d+$/.test(n))
   } catch {
     return null
   }
+  const fallbacks: string[] = []
   for (const pid of pids) {
-    let cmdline = ''
-    try {
-      cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8')
-    } catch {
-      continue
-    }
-    if (!EXE_NAME_RE.test(cmdline) && !cmdlineIncludesPoeDir(cmdline)) continue
+    const candidate = procPidCandidate(fs, path, pid)
+    if (!candidate) continue
+    if (installMatchesVersion(candidate, version)) return candidate
+    fallbacks.push(candidate)
+  }
+  return fallbacks[0] ?? null
+}
 
-    try {
-      const exe = fs.readlinkSync(`/proc/${pid}/exe`)
-      const candidate = clientTxtBesideExe(exe.replace(/\s+\(deleted\)$/, ''), fs, path)
-      if (candidate) return candidate
-    } catch {
-      /* wine-preloader: exe is not the game binary */
-    }
+/** First Client.txt candidate for one pid: beside the exe link, beside a
+ *  Wine cmdline exe, or in the process cwd - the same priority the scan
+ *  used before candidates were collected across pids. */
+function procPidCandidate(fs: PathResolverFs, path: PathApi, pid: string): string | null {
+  let cmdline = ''
+  try {
+    cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8')
+  } catch {
+    return null
+  }
+  if (!EXE_NAME_RE.test(cmdline) && !cmdlineIncludesPoeDir(cmdline)) return null
 
-    for (const part of cmdline.split('\0')) {
-      const unix = unixPathFromWineExe(part)
-      if (!unix || !EXE_NAME_RE.test(unix)) continue
-      const candidate = clientTxtBesideExe(unix, fs, path)
-      if (candidate) return candidate
-    }
+  try {
+    const exe = fs.readlinkSync(`/proc/${pid}/exe`)
+    const candidate = clientTxtBesideExe(exe.replace(/\s+\(deleted\)$/, ''), fs, path)
+    if (candidate) return candidate
+  } catch {
+    /* wine-preloader: exe is not the game binary */
+  }
 
-    try {
-      const cwd = fs.readlinkSync(`/proc/${pid}/cwd`)
-      const candidate = path.join(cwd, 'logs', 'Client.txt')
-      if (fs.existsSync(candidate)) return candidate
-    } catch {
-      /* no cwd */
-    }
+  for (const part of cmdline.split('\0')) {
+    const unix = unixPathFromWineExe(part)
+    if (!unix || !EXE_NAME_RE.test(unix)) continue
+    const candidate = clientTxtBesideExe(unix, fs, path)
+    if (candidate) return candidate
+  }
+
+  try {
+    const cwd = fs.readlinkSync(`/proc/${pid}/cwd`)
+    const candidate = path.join(cwd, 'logs', 'Client.txt')
+    if (fs.existsSync(candidate)) return candidate
+  } catch {
+    /* no cwd */
   }
   return null
 }

--- a/src/main/client-log/seed-last-zone.test.ts
+++ b/src/main/client-log/seed-last-zone.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { parseLastZoneFromChunk, readLastZoneFromLog, type SeedLastZoneFs } from './seed-last-zone'
+
+describe('parseLastZoneFromChunk', () => {
+  it('returns the last Generating-level line', () => {
+    const text = [
+      'noise',
+      '[DEBUG Client 1] Generating level 5 area "G1_1" with seed 1',
+      'chat',
+      '[DEBUG Client 1] Generating level 6 area "G1_2" with seed 2',
+      'more noise',
+    ].join('\n')
+    expect(parseLastZoneFromChunk(text)).toEqual({ areaLevel: 6, areaCode: 'G1_2' })
+  })
+
+  it('skips level 0 cutscenes', () => {
+    const text = [
+      '[DEBUG Client 1] Generating level 5 area "G1_1" with seed 1',
+      '[DEBUG Client 1] Generating level 0 area "Cutscene" with seed 0',
+    ].join('\n')
+    expect(parseLastZoneFromChunk(text)).toEqual({ areaLevel: 5, areaCode: 'G1_1' })
+  })
+
+  it('returns null when no zone line is present', () => {
+    expect(parseLastZoneFromChunk('hello\nworld')).toBeNull()
+  })
+})
+
+describe('readLastZoneFromLog', () => {
+  it('reads the file tail and parses the last zone', () => {
+    const body = Buffer.from('[DEBUG Client 1] Generating level 12 area "G2_town" with seed 9\n')
+    const fs: SeedLastZoneFs = {
+      statSync: () => ({ size: body.length }),
+      openSync: () => 7,
+      readSync: (_fd, buffer) => {
+        body.copy(buffer)
+        return body.length
+      },
+      closeSync: () => undefined,
+    }
+    expect(readLastZoneFromLog('/fake/Client.txt', fs)).toEqual({ areaLevel: 12, areaCode: 'G2_town' })
+  })
+})

--- a/src/main/client-log/seed-last-zone.test.ts
+++ b/src/main/client-log/seed-last-zone.test.ts
@@ -24,6 +24,24 @@ describe('parseLastZoneFromChunk', () => {
   it('returns null when no zone line is present', () => {
     expect(parseLastZoneFromChunk('hello\nworld')).toBeNull()
   })
+
+  it('does not seed across a session boundary', () => {
+    const text = [
+      '[DEBUG Client 1] Generating level 70 area "OldMap" with seed 1',
+      '***** LOG FILE OPENING *****',
+      'login noise',
+    ].join('\n')
+    expect(parseLastZoneFromChunk(text)).toBeNull()
+  })
+
+  it('seeds from a zone line after the last session boundary', () => {
+    const text = [
+      '[DEBUG Client 1] Generating level 70 area "OldMap" with seed 1',
+      '***** LOG FILE OPENING *****',
+      '[DEBUG Client 1] Generating level 12 area "G2_town" with seed 2',
+    ].join('\n')
+    expect(parseLastZoneFromChunk(text)).toEqual({ areaLevel: 12, areaCode: 'G2_town' })
+  })
 })
 
 describe('readLastZoneFromLog', () => {

--- a/src/main/client-log/seed-last-zone.ts
+++ b/src/main/client-log/seed-last-zone.ts
@@ -1,0 +1,57 @@
+import { closeSync, openSync, readSync, statSync } from 'node:fs'
+import { parseClientLogLine } from './parse-client-log'
+import type { Zone } from '@shared/types'
+
+const MAX_SCAN_BYTES = 2_000_000
+
+export interface SeedLastZoneFs {
+  statSync(path: string): { size: number }
+  openSync(path: string, flags: string): number
+  readSync(fd: number, buffer: Buffer, offset: number, length: number, position: number): number
+  closeSync(fd: number): void
+}
+
+const defaultFs: SeedLastZoneFs = { statSync, openSync, readSync, closeSync }
+
+/** Walk a Client.txt chunk from the end and return the most recent parsed
+ *  zone line. Used so the tracker has a zone immediately instead of waiting
+ *  for the next area transition. */
+export function parseLastZoneFromChunk(text: string): Zone | null {
+  const lines = text.split(/\r?\n/)
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const parsed = parseClientLogLine(lines[i])
+    if (parsed) return parsed
+  }
+  return null
+}
+
+/** Read the tail of Client.txt and return the last Generating-level zone. */
+export function readLastZoneFromLog(path: string, fs: SeedLastZoneFs = defaultFs): Zone | null {
+  let fd: number | null = null
+  try {
+    const size = fs.statSync(path).size
+    if (size <= 0) return null
+    const bytesToRead = Math.min(size, MAX_SCAN_BYTES)
+    const position = size - bytesToRead
+    const buf = Buffer.alloc(bytesToRead)
+    fd = fs.openSync(path, 'r')
+    fs.readSync(fd, buf, 0, bytesToRead, position)
+    let text = buf.toString('utf8')
+    // If we started mid-file, drop the likely-truncated first line.
+    if (position > 0) {
+      const nl = text.indexOf('\n')
+      if (nl >= 0) text = text.slice(nl + 1)
+    }
+    return parseLastZoneFromChunk(text)
+  } catch {
+    return null
+  } finally {
+    if (fd !== null) {
+      try {
+        fs.closeSync(fd)
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}

--- a/src/main/client-log/seed-last-zone.ts
+++ b/src/main/client-log/seed-last-zone.ts
@@ -4,6 +4,10 @@ import type { Zone } from '@shared/types'
 
 const MAX_SCAN_BYTES = 2_000_000
 
+/** PoE appends this marker on every client boot. A zone line before the
+ *  last marker belongs to a previous session and must never seed "current". */
+const SESSION_BOUNDARY = 'LOG FILE OPENING'
+
 export interface SeedLastZoneFs {
   statSync(path: string): { size: number }
   openSync(path: string, flags: string): number
@@ -19,6 +23,7 @@ const defaultFs: SeedLastZoneFs = { statSync, openSync, readSync, closeSync }
 export function parseLastZoneFromChunk(text: string): Zone | null {
   const lines = text.split(/\r?\n/)
   for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i].includes(SESSION_BOUNDARY)) return null
     const parsed = parseClientLogLine(lines[i])
     if (parsed) return parsed
   }

--- a/src/main/handlers/client-log.ts
+++ b/src/main/handlers/client-log.ts
@@ -1,5 +1,7 @@
 import { ipcMain } from 'electron'
+import type { Zone } from '@shared/types'
 import { addLogLineSubscriberRef, getRecentLogLines, removeLogLineSubscriberRef } from '../client-log/tail-buffer'
+import { getCurrentZone } from '../client-log/zone-state'
 
 /** IPC for the plugin log-tail surface. The renderer increments the subscriber
  *  ref-count on first onLogLine subscribe and decrements on last unsubscribe,
@@ -8,6 +10,7 @@ export function registerClientLogHandlers(): void {
   ipcMain.handle('client-log:recent-lines', (_evt, count?: number): string[] => {
     return getRecentLogLines(typeof count === 'number' ? count : undefined)
   })
+  ipcMain.handle('client-log:current-zone', (): Zone | null => getCurrentZone())
   ipcMain.on('client-log:subscribe', () => addLogLineSubscriberRef())
   ipcMain.on('client-log:unsubscribe', () => removeLogLineSubscriberRef())
 }

--- a/src/main/overlay.ts
+++ b/src/main/overlay.ts
@@ -417,11 +417,8 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
         clearTimeout(retargetWatchdog)
         retargetWatchdog = null
       }
-      console.log('[debug] attach', overlayWindow)
       if (overlayWindow && !overlayWindow.isDestroyed()) {
-        console.log('[debug] send poe version')
         overlayWindow.webContents.send('poe-version', getPoeVersion())
-        console.log('[debug] start client log watcher')
         startClientLogWatcher(overlayWindow)
       }
       sendGameBounds(ev.width, ev.height)

--- a/src/main/overlay.ts
+++ b/src/main/overlay.ts
@@ -417,8 +417,11 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
         clearTimeout(retargetWatchdog)
         retargetWatchdog = null
       }
+      console.log('[debug] attach', overlayWindow)
       if (overlayWindow && !overlayWindow.isDestroyed()) {
+        console.log('[debug] send poe version')
         overlayWindow.webContents.send('poe-version', getPoeVersion())
+        console.log('[debug] start client log watcher')
         startClientLogWatcher(overlayWindow)
       }
       sendGameBounds(ev.width, ev.height)

--- a/src/plugin-sdk/src/globals.d.ts
+++ b/src/plugin-sdk/src/globals.d.ts
@@ -25,6 +25,8 @@ declare global {
       resumeHotkeys(): void
       /** Subscribe to zone-change events. Returns an unsubscribe function. */
       onZoneChanged(cb: (zone: ScalpelHostZone | null) => void): () => void
+      /** Latest zone known to the host. Null until Client.txt has produced one. */
+      getCurrentZone(): Promise<ScalpelHostZone | null>
     }
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -409,6 +409,7 @@ export const api = {
     }
   },
   getRecentLogLines: (count?: number): Promise<string[]> => ipcRenderer.invoke('client-log:recent-lines', count),
+  getCurrentZone: (): Promise<Zone | null> => ipcRenderer.invoke('client-log:current-zone'),
   gameConfigRead: (): Promise<{ content: string; path: string }> => ipcRenderer.invoke('plugins:game-config-read'),
   gameConfigWrite: (content: string): Promise<{ backupPath: string | null }> =>
     ipcRenderer.invoke('plugins:game-config-write', content),

--- a/src/renderer/src/cheat-sheets-grid/App.test.tsx
+++ b/src/renderer/src/cheat-sheets-grid/App.test.tsx
@@ -42,6 +42,7 @@ describe('cheat-sheets-grid App thumbnail homing (#465)', () => {
         zoneHandler = cb
         return () => {}
       }),
+      getCurrentZone: vi.fn(async () => null),
       closeCheatSheets: vi.fn(),
       minimizeCheatSheets: vi.fn(),
       restoreCheatSheets: vi.fn(),

--- a/src/renderer/src/plugin-overlay/App.test.tsx
+++ b/src/renderer/src/plugin-overlay/App.test.tsx
@@ -13,6 +13,7 @@ function installApi(): void {
     getSettings: vi.fn(async () => ({ activeProfile: { league: 'Std' } })),
     onOverlayData: vi.fn(() => () => {}),
     onZoneChanged: vi.fn(() => () => {}),
+    getCurrentZone: vi.fn(async () => null),
     onPluginOverlayEdgeFlush: vi.fn(() => () => {}),
     onLeagueUpdated: vi.fn(() => () => {}),
     onLogLine: vi.fn(() => () => {}),

--- a/src/renderer/src/plugins/use-activate-plugin.ts
+++ b/src/renderer/src/plugins/use-activate-plugin.ts
@@ -31,6 +31,8 @@ export function useActivatePlugin(pluginId: string): ActivatedPlugin {
       const poeVersion: 1 | 2 = (state?.poeVersion as 1 | 2) ?? 1
       const settings = await window.api.getSettings().catch(() => null)
       let league = settings?.activeProfile?.league ?? ''
+      const seededZone = await window.api.getCurrentZone().catch(() => null)
+      if (seededZone) latestZone = seededZone
       const mod = (await importPluginModule(entry.entryUrl)) as { default?: PluginActivate }
       if (cancelled || typeof mod.default !== 'function') return
       const capHolder: { value: ActivatedPlugin['captured'] } = { value: null }

--- a/src/renderer/src/shared/use-current-zone.ts
+++ b/src/renderer/src/shared/use-current-zone.ts
@@ -9,7 +9,15 @@ import { usePoeVersion } from './poe-version-context'
 export function useCurrentZone(): Zone | null {
   const [zone, setZone] = useState<Zone | null>(null)
   useEffect(() => {
-    return window.api.onZoneChanged(setZone)
+    let cancelled = false
+    void window.api.getCurrentZone().then((z) => {
+      if (!cancelled && z) setZone(z)
+    })
+    const off = window.api.onZoneChanged(setZone)
+    return () => {
+      cancelled = true
+      off()
+    }
   }, [])
   return zone
 }

--- a/src/shared/contracts/ipc.ts
+++ b/src/shared/contracts/ipc.ts
@@ -209,6 +209,7 @@ export const IPC_CHANNELS = {
     SUBSCRIBE: 'client-log:subscribe',
     UNSUBSCRIBE: 'client-log:unsubscribe',
     RECENT_LINES: 'client-log:recent-lines',
+    CURRENT_ZONE: 'client-log:current-zone',
     LINE_EVENT: 'client-log:line',
   },
 


### PR DESCRIPTION
# Disclaimer
I heavily used cursor to help me understand and write the code due to me not knowing the codebase. I did review it and tested it on my local. With that said please either take what is here or refactor it to match your style or tell me what needs to change so I can better match the codebase.

# What
I noticed a bug when trying to use  https://github.com/eniner/scalpel-quest-tracker, it would not grab the current zone or update on zone change.

The problem looks like https://github.com/scalpelpoe/scalpel/blob/main/src/main/client-log/path-resolver.ts#L19 is only using powershell to grab the client log, which linux does not support.

This change now adds a way to grab the client log based off of what operating system you are running.


Before change: (notice the `Awaiting Zone`)
<img width="709" height="194" alt="image" src="https://github.com/user-attachments/assets/36cfa5cd-c85b-4650-95dd-89747ba9e917" />

After change: (Now has correct area zone)
<img width="709" height="194" alt="image" src="https://github.com/user-attachments/assets/547e7d40-2437-4f48-be76-61fc613ce7e4" />


