### PR TITLE
add in linux support for window popout

### DIFF
--- a/src/main/screen-capture/cursor.test.ts
+++ b/src/main/screen-capture/cursor.test.ts
@@ -65,8 +65,9 @@ describe('toGameCursor', () => {
   })
 })
 
-describe('getGameCursorPosition', () => {
+describe('getGameCursorPosition (Windows)', () => {
   beforeEach(() => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
     mock.state.targetHasFocus = true
     mock.state.targetBounds = { x: 100, y: 50, width: 1920, height: 1080 }
     // Identity conversion by default: physical == DIP (scale 1.0).
@@ -82,10 +83,11 @@ describe('getGameCursorPosition', () => {
   })
 
   afterEach(() => {
+    vi.unstubAllGlobals()
     vi.clearAllMocks()
   })
 
-  it('returns the cursor position at scale 1.0', () => {
+  it('returns the cursor position at scale 1.0 via screenToDipRect', () => {
     expect(getGameCursorPosition()).toEqual({ x: 600, y: 350 })
     expect(mock.screenToDipRect).toHaveBeenCalledWith(null, { x: 100, y: 50, width: 1920, height: 1080 })
   })
@@ -157,10 +159,39 @@ describe('getGameCursorPosition', () => {
     expect(getGameCursorPosition()).toBeNull()
   })
 
-  it('returns null instead of throwing when the underlying electron call throws', () => {
+  it('returns null instead of throwing when screenToDipRect throws', () => {
     mock.screenToDipRect.mockImplementation(() => {
       throw new Error('boom')
     })
     expect(getGameCursorPosition()).toBeNull()
+  })
+})
+
+describe('getGameCursorPosition (Linux)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    mock.state.targetHasFocus = true
+    mock.state.targetBounds = { x: 100, y: 50, width: 1920, height: 1080 }
+    mock.getCursorScreenPoint.mockReturnValue({ x: 700, y: 400 })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('uses targetBounds as-is and does not call screenToDipRect', () => {
+    // electron-overlay-window already reports logical coords on Linux;
+    // screenToDipRect is Windows-only and must not be touched.
+    expect(getGameCursorPosition()).toEqual({ x: 600, y: 350 })
+    expect(mock.screenToDipRect).not.toHaveBeenCalled()
+  })
+
+  it('still works if screenToDipRect is missing (Electron Linux)', () => {
+    // Regression: calling a missing screenToDipRect used to throw and blank Pop out.
+    mock.screenToDipRect.mockImplementation(() => {
+      throw new TypeError('screen.screenToDipRect is not a function')
+    })
+    expect(getGameCursorPosition()).toEqual({ x: 600, y: 350 })
   })
 })

--- a/src/main/screen-capture/cursor.ts
+++ b/src/main/screen-capture/cursor.ts
@@ -1,5 +1,6 @@
 import { screen } from 'electron'
 import { OverlayController } from 'electron-overlay-window'
+import { toDipRect } from '../windowing/dip-rect'
 
 export interface CursorPoint {
   x: number
@@ -22,23 +23,19 @@ export function toGameCursor(
 
 /** Read the live cursor position in game CSS px. Null when the game has no
  *  bounds yet, or the cursor is outside the game window.
- *  getCursorScreenPoint returns DIP; targetBounds is physical. screenToDipRect
- *  converts the whole rect (origin and size) to DIP in a single native call, so
- *  there's no separate scale-factor lookup to get wrong on a mixed-DPI, multi-
- *  monitor setup (unlike the getDisplayNearestPoint-based math in capture.ts,
- *  which has the same class of bug tracked separately). Win32-only API.
- *  Deliberately does not gate on targetHasFocus: captureGameWindow needs that
- *  gate because it grabs pixels off the screen and must not do so while the
- *  game isn't the focused window, but a cursor read only needs the game
- *  window's bounds, and the bounds-containment check below already covers the
- *  cursor-is-elsewhere case. The focus flag flickers around overlay window
- *  show/hide, so gating on it here caused reads to intermittently and
- *  spuriously return null. */
+ *  getCursorScreenPoint returns DIP; targetBounds may be physical on Windows
+ *  (converted via toDipRect). Deliberately does not gate on targetHasFocus:
+ *  captureGameWindow needs that gate because it grabs pixels off the screen
+ *  and must not do so while the game isn't the focused window, but a cursor
+ *  read only needs the game window's bounds, and the bounds-containment check
+ *  below already covers the cursor-is-elsewhere case. The focus flag flickers
+ *  around overlay window show/hide, so gating on it here caused reads to
+ *  intermittently and spuriously return null. */
 export function getGameCursorPosition(): CursorPoint | null {
   const tb = OverlayController.targetBounds
   if (!tb?.width || !tb.height) return null
   try {
-    const windowDip = screen.screenToDipRect(null, tb)
+    const windowDip = toDipRect(null, tb)
     const gameSize = { width: windowDip.width, height: windowDip.height }
     return toGameCursor(screen.getCursorScreenPoint(), windowDip, gameSize)
   } catch (err) {

--- a/src/main/windowing/dip-rect.test.ts
+++ b/src/main/windowing/dip-rect.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const screenToDipRect = vi.fn((_win: unknown, rect: { x: number; y: number; width: number; height: number }) => ({
+  x: Math.round(rect.x / 2),
+  y: Math.round(rect.y / 2),
+  width: Math.round(rect.width / 2),
+  height: Math.round(rect.height / 2),
+}))
+
+vi.mock('electron', () => ({
+  screen: { screenToDipRect },
+}))
+
+describe('toDipRect', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses screenToDipRect on Windows', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' })
+    const { toDipRect } = await import('./dip-rect')
+    expect(toDipRect(null, { x: 100, y: 200, width: 800, height: 600 })).toEqual({
+      x: 50,
+      y: 100,
+      width: 400,
+      height: 300,
+    })
+    expect(screenToDipRect).toHaveBeenCalled()
+  })
+
+  it('returns the rect unchanged on Linux (no screenToDipRect call)', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    vi.resetModules()
+    const { toDipRect } = await import('./dip-rect')
+    const rect = { x: 100, y: 200, width: 800, height: 600 }
+    expect(toDipRect(null, rect)).toEqual(rect)
+    expect(screenToDipRect).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/windowing/dip-rect.ts
+++ b/src/main/windowing/dip-rect.ts
@@ -1,0 +1,24 @@
+import { type BrowserWindow, screen } from 'electron'
+
+export interface DipRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+/** Convert OverlayController target bounds to DIP for BrowserWindow.setBounds.
+ *
+ *  `screen.screenToDipRect` is Windows-only in Electron. Calling it on Linux
+ *  throws (`is not a function`) and aborts secondary-overlay show — that was
+ *  why plugin Pop out did nothing on Linux. On non-Windows, electron-overlay-
+ *  window already reports logical coordinates (same assumption as
+ *  cheat-sheets `setBoundsToGame`).
+ *  https://www.electronjs.org/docs/latest/api/screen#screenscreentodiprectwindow-rect-windows
+ */
+export function toDipRect(win: BrowserWindow | null, rect: DipRect): DipRect {
+  if (process.platform === 'win32' && typeof screen.screenToDipRect === 'function') {
+    return screen.screenToDipRect(win, rect)
+  }
+  return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+}

--- a/src/main/windowing/index.ts
+++ b/src/main/windowing/index.ts
@@ -8,6 +8,7 @@ import { prewarmSnapCanvas, type Rect, setSnapGhost } from './snap-canvas'
 import { type FlushEdges, nearestMountTarget } from './snap-mounts'
 import { fireOnLeaveScalpel, type OverlayState, overlays } from './state'
 import { createOverlayWindow } from './window'
+import { toDipRect } from './dip-rect'
 
 export type { OverlayAnchor } from '@shared/types'
 export {
@@ -106,25 +107,24 @@ function anchorTimes(anchor: OverlayAnchor, base: Rect): Rect {
 }
 
 /** Compute the DIP (logical) bounds an overlay window should occupy for the
- *  given anchor. Uses `screen.screenToDipRect(win, physRect)` - the same path
- *  the electron-overlay-window library uses for the main overlay - so behavior
- *  matches across all DPI / multi-monitor configurations.
+ *  given anchor. Uses `toDipRect` so Windows gets native DPI conversion and
+ *  Linux/macOS keep working without screenToDipRect.
  *
  *  Returns null when PoE bounds aren't available yet. */
 function anchorToDipBounds(win: BrowserWindow, anchor: OverlayAnchor): Rect | null {
   const tb = OverlayController.targetBounds
   if (!tb || tb.width <= 0 || tb.height <= 0) return null
   const phys = anchorTimes(anchor, { x: tb.x, y: tb.y, width: tb.width, height: tb.height })
-  return screen.screenToDipRect(win, phys)
+  return toDipRect(win, phys)
 }
 
 /** Compute an anchor from a window's current DIP bounds. Converts PoE's
- *  physical bounds to DIP using the same `screenToDipRect` path so the
- *  numerator and denominator are in the same coordinate space. */
+ *  bounds to DIP with the same path as anchorToDipBounds so the numerator
+ *  and denominator are in the same coordinate space. */
 function boundsToAnchor(win: BrowserWindow): OverlayAnchor | null {
   const tb = OverlayController.targetBounds
   if (!tb || tb.width <= 0 || tb.height <= 0) return null
-  const poeDip = screen.screenToDipRect(win, { x: tb.x, y: tb.y, width: tb.width, height: tb.height })
+  const poeDip = toDipRect(win, { x: tb.x, y: tb.y, width: tb.width, height: tb.height })
   if (poeDip.width <= 0 || poeDip.height <= 0) return null
   const cur = win.getBounds()
   return {
@@ -428,8 +428,7 @@ function makeOverlayApi(state: OverlayState): SecondaryOverlay {
 
 function ensureWin(state: OverlayState): BrowserWindow {
   if (state.win && !state.win.isDestroyed()) return state.win
-  // Window must exist before we can call `screen.screenToDipRect(win, ...)`
-  // (the same path the library uses for the main overlay), so create at a
+  // Window must exist before we can call toDipRect / setBounds, so create at a
   // sensible placeholder - the display PoE is on if known, otherwise primary
   // workArea - then immediately overwrite with the anchor-derived DIP bounds.
   const placeholder = pickPlaceholderBounds()


### PR DESCRIPTION
# What
Electron does not support screenToDip: https://www.electronjs.org/docs/latest/api/screen#screenscreentodiprectwindow-rect-windows

`screen.screenToDipRect` is Windows-only in Electron. Calling it on Linux throws (`is not a function`) and aborts secondary-overlay show — that was why plugin Pop out did nothing on Linux. On non-Windows, electron-overlay- window already reports logical coordinates (same assumption as cheat-sheets `setBoundsToGame`).
