### PR TITLE
fix(linux): relaunch the outer AppImage, not the mounted binary

### DIFF
--- a/src/main/experimental/stable.ts
+++ b/src/main/experimental/stable.ts
@@ -5,6 +5,7 @@ import { createOverlayWindow, getOverlayAttachedVersion } from '../overlay'
 import { requestGameSwitch } from '../game-switch'
 import { getEffectiveSettings, getProfileById, persistProfileSwitchForRestart } from '../profiles/profile-settings'
 import { applySetting } from '../settings-write'
+import { relaunchApp } from '../relaunch'
 
 export const stableGameSwitchCoordinator: GameSwitchCoordinator = {
   requestGameSwitch,
@@ -25,7 +26,7 @@ export const stableGameSwitchCoordinator: GameSwitchCoordinator = {
       }
 
       persistProfileSwitchForRestart(store, profile)
-      app.relaunch()
+      relaunchApp()
       app.quit()
       return { ok: true as const, restarting: true as const }
     }

--- a/src/main/game-switch.ts
+++ b/src/main/game-switch.ts
@@ -3,6 +3,7 @@ import type Store from 'electron-store'
 import type { AppSettings, GameVariant } from '@shared/types'
 import { getAppWindow, showAppWindow } from './app-window'
 import { applySetting } from './settings-write'
+import { relaunchApp } from './relaunch'
 
 // Only one prompt may be in-flight. Extra calls while a prompt is open are
 // ignored (requestGameSwitch returns immediately) so we never stack modals.
@@ -55,6 +56,6 @@ export async function requestGameSwitch(store: Store<AppSettings>, target: GameV
     console.warn(`[game-switch] target=${target}; restart dev to re-attach`)
     return
   }
-  app.relaunch()
+  relaunchApp()
   app.quit()
 }

--- a/src/main/handlers/settings.ts
+++ b/src/main/handlers/settings.ts
@@ -28,6 +28,7 @@ import {
 import { getOverlayAttachedVersion } from '../overlay'
 import { shouldRelaunchAfterOnboarding } from '../onboarding-relaunch'
 import { getGameSwitchCoordinator } from '../experimental'
+import { relaunchApp } from '../relaunch'
 
 export function register(store: Store<AppSettings>): void {
   ipcMain.handle('get-settings', () => getEffectiveSettings(store))
@@ -65,7 +66,7 @@ export function register(store: Store<AppSettings>): void {
       return { ok: true as const, devRestartRequired: true as const }
     }
     if (action === 'relaunch') {
-      app.relaunch()
+      relaunchApp()
       app.quit()
       return { ok: true as const, restarting: true as const }
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -123,6 +123,7 @@ import { registerAllIpc } from './app/register-ipc'
 import { createTray, refreshTrayMenu } from './app/tray'
 import { startLiveServices } from './app/lifecycle'
 import { getOverlayAttachStrategy } from './experimental'
+import { relaunchApp } from './relaunch'
 
 // ---- Linux display-server setup --------------------------------------------
 
@@ -131,7 +132,7 @@ if (
   process.env.WAYLAND_DISPLAY &&
   !process.argv.some((a) => a.startsWith('--ozone-platform='))
 ) {
-  app.relaunch({ args: [...process.argv.slice(1), '--ozone-platform=x11'] })
+  relaunchApp([...process.argv.slice(1), '--ozone-platform=x11'])
   app.exit(0)
 }
 
@@ -571,7 +572,7 @@ app.whenReady().then(() => {
       console.warn('[app-restart] dev build — close and `npm run dev` to re-attach')
       return
     }
-    app.relaunch()
+    relaunchApp()
     app.quit()
   })
 

--- a/src/main/relaunch.test.ts
+++ b/src/main/relaunch.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const electron = vi.hoisted(() => ({ app: { isPackaged: true, relaunch: vi.fn() } }))
+vi.mock('electron', () => electron)
+import { relaunchApp } from './relaunch'
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+  electron.app.relaunch.mockClear()
+  electron.app.isPackaged = true
+})
+
+describe('relaunchApp', () => {
+  it('restarts the outer AppImage with the X11 arguments intact', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    vi.stubEnv('APPIMAGE', '/opt/Scalpel With Spaces.AppImage')
+    relaunchApp(['--ozone-platform=x11'])
+    expect(electron.app.relaunch).toHaveBeenCalledWith({
+      execPath: '/opt/Scalpel With Spaces.AppImage',
+      args: ['--ozone-platform=x11'],
+    })
+  })
+
+  it('keeps the normal executable for unpacked installations', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    vi.stubEnv('APPIMAGE', '')
+    relaunchApp(['--ozone-platform=x11'])
+    expect(electron.app.relaunch).toHaveBeenCalledWith({ args: ['--ozone-platform=x11'] })
+  })
+
+  it('does not use inherited AppImage variables in development', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+    vi.stubEnv('APPIMAGE', '/another-app.AppImage')
+    electron.app.isPackaged = false
+    relaunchApp(['.'])
+    expect(electron.app.relaunch).toHaveBeenCalledWith({ args: ['.'] })
+  })
+})

--- a/src/main/relaunch.ts
+++ b/src/main/relaunch.ts
@@ -1,0 +1,8 @@
+import { app } from 'electron'
+
+// The executable inside an AppImage lives on a temporary FUSE mount. Restart
+// the outer AppImage so the new process gets its own mount and ICU/resources.
+export function relaunchApp(args = process.argv.slice(1)): void {
+  const appImage = process.platform === 'linux' && app.isPackaged && process.env.APPIMAGE
+  app.relaunch(appImage ? { execPath: appImage, args } : { args })
+}

--- a/src/main/update/updater.ts
+++ b/src/main/update/updater.ts
@@ -18,6 +18,7 @@ import { findBrickedMatch } from '@shared/version-match'
 import { selectListRelease } from './select-release'
 import { recordMainBreadcrumb, registerDiagnosticProvider } from '../diagnostics'
 import { stopHotkeyListener } from '../hotkeys'
+import { relaunchApp } from '../relaunch'
 
 const CHECK_DELAY = 5000
 const CHECK_INTERVAL = 60_000
@@ -510,7 +511,7 @@ ipcMain.handle('install-update', () => {
     // during env cleanup with events in flight (tsfn-proxy abort risk).
     recordMainBreadcrumb('updater: relaunch (no pending update)')
     stopHotkeyListener()
-    app.relaunch()
+    relaunchApp()
     app.exit(0)
     return
   }


### PR DESCRIPTION
## Issue

`app.relaunch()` restarts `process.execPath`. Inside an AppImage that path points into the temporary FUSE mount, which is unmounted as soon as the old process exits — so the replacement process starts with its resources gone and dies loading ICU data. The app never comes back.

I see it on Wayland, where `src/main/index.ts` re-execs itself with `--ozone-platform=x11` at startup, but it affects every relaunch path: game and profile switches, the settings restart, and the updater.

## Solution

Restart `$APPIMAGE` so the new process gets a mount of its own.

Guarded on `app.isPackaged` so a dev run started from some other AppImage can't inherit a stray `$APPIMAGE`.

## Testing

Crash observed on Omarchy 4 / Hyprland with an RTX 5080, nvidia-smi 610.57.04, where the startup Wayland → X11 re-exec restarted from the AppImage's already-unmounted FUSE path.

`npm run typecheck` and `npm test` clean. Unit tests cover the AppImage, unpacked and dev cases.