### PR TITLE
feat(linux): drive the overlay through Hyprland instead of X11

### DIFF
--- a/src/main/hotkeys.test.ts
+++ b/src/main/hotkeys.test.ts
@@ -53,6 +53,10 @@ const focusMockState: { scalpelBrowserWindowFocused: boolean } = {
   scalpelBrowserWindowFocused: false,
 }
 
+// Whether the compositor-driven overlay path is in charge. Mocked rather than
+// derived from the environment so no test shells out to hyprctl.
+const hyprlandMockState = { overlayActive: false }
+
 vi.mock('electron', () => ({
   globalShortcut: globalShortcutMock,
   clipboard: {
@@ -96,6 +100,11 @@ vi.mock('./windowing', () => ({
   isAnyScalpelBrowserWindowFocused: () => focusMockState.scalpelBrowserWindowFocused,
 }))
 
+vi.mock('./hyprland', () => ({
+  hyprlandOverlayActive: () => hyprlandMockState.overlayActive,
+  hyprlandInputAllowed: () => true,
+}))
+
 vi.mock('./diagnostics', () => ({
   guardNativeListener:
     (_label: string, fn: (...args: unknown[]) => void) =>
@@ -127,6 +136,7 @@ async function loadHotkeys(onEscape: () => void) {
   windowingMockState.hideFocusedOrAnyVisibleSecondaryOverlay.mockReset()
   windowingMockState.hideFocusedOrAnyVisibleSecondaryOverlay.mockReturnValue(false)
   focusMockState.scalpelBrowserWindowFocused = false
+  hyprlandMockState.overlayActive = false
 
   const hotkeys = await import('./hotkeys')
   hotkeys.startHotkeyListener(() => {})
@@ -141,6 +151,19 @@ function lastEscapeCallback(): () => void {
   if (!cb) throw new Error('Escape shortcut was never registered')
   return cb
 }
+
+describe('Hyprland dialog shortcut dismissal', () => {
+  it('uses the close handler instead of starting another filter lookup', async () => {
+    const close = vi.fn()
+    const hotkeys = await loadHotkeys(close)
+    hyprlandMockState.overlayActive = true
+    overlayControllerState.targetHasFocus = true
+    overlayMockState.visibilityListener?.(true)
+    hotkeys.setHotkey('Ctrl+C')
+    activeGlobalShortcuts.get('Ctrl+C')?.()
+    expect(close).toHaveBeenCalledOnce()
+  })
+})
 
 describe('Escape globalShortcut sync', () => {
   afterEach(() => {

--- a/src/main/hotkeys.test.ts
+++ b/src/main/hotkeys.test.ts
@@ -185,6 +185,34 @@ describe('Escape globalShortcut sync', () => {
     expect(globalShortcutMock.register).toHaveBeenCalledTimes(1)
   })
 
+  it('stays registered through the initial Hyprland dialog focus handoff', async () => {
+    const onEscape = vi.fn()
+    await loadHotkeys(onEscape)
+    hyprlandMockState.overlayActive = true
+    overlayControllerState.targetHasFocus = true
+    overlayMockState.visibilityListener?.(true)
+
+    overlayControllerState.targetHasFocus = false
+    overlayControllerState.events.emit('blur')
+
+    expect(globalShortcutMock.unregister).not.toHaveBeenCalled()
+    lastEscapeCallback()()
+    expect(onEscape).toHaveBeenCalledOnce()
+  })
+
+  it('closes from the uiohook path during the initial Hyprland dialog focus handoff', async () => {
+    const onEscape = vi.fn()
+    await loadHotkeys(onEscape)
+    hyprlandMockState.overlayActive = true
+    overlayControllerState.targetHasFocus = false
+    focusMockState.scalpelBrowserWindowFocused = false
+    overlayMockState.visibilityListener?.(true)
+
+    emitKeydown(ESCAPE_KEYDOWN)
+
+    expect(onEscape).toHaveBeenCalledOnce()
+  })
+
   it('unregisters on overlay hide and on game blur; re-registers on refocus while still visible', async () => {
     const onEscape = vi.fn()
     await loadHotkeys(onEscape)

--- a/src/main/hotkeys.ts
+++ b/src/main/hotkeys.ts
@@ -13,6 +13,7 @@ import {
 } from './diagnostics'
 import { getPoeVersion } from './game-state'
 import { focusGameWindow, isTypingInOverlay, setOverlayVisibilityListener } from './overlay'
+import { hyprlandInputAllowed, hyprlandOverlayActive } from './hyprland'
 import { advancedCopyTracker } from './trade/advanced-copy'
 import { hideFocusedOrAnyVisibleSecondaryOverlay, isAnyScalpelBrowserWindowFocused } from './windowing'
 
@@ -97,6 +98,10 @@ function fireTrigger(): void {
   if (now - lastTriggerFireAt < DEDUPE_MS) return
   lastTriggerFireAt = now
   releaseHotkeyKey(triggerCombo)
+  if (hyprlandOverlayActive() && overlayVisibleForEscape && onEscape) {
+    onEscape()
+    return
+  }
   if (onTrigger) onTrigger()
 }
 
@@ -106,6 +111,10 @@ function firePriceCheck(): void {
   if (now - lastPriceCheckFireAt < DEDUPE_MS) return
   lastPriceCheckFireAt = now
   releaseHotkeyKey(priceCheckCombo)
+  if (hyprlandOverlayActive() && overlayVisibleForEscape && onEscape) {
+    onEscape()
+    return
+  }
   if (onPriceCheck) onPriceCheck()
 }
 
@@ -275,7 +284,7 @@ export function startHotkeyListener(handler: () => void): void {
     guardNativeListener('wheel', (e) => {
       const modHeld =
         stashScrollModifier === 'Ctrl' ? e.ctrlKey : stashScrollModifier === 'Shift' ? e.shiftKey : e.altKey
-      if (!stashScrollEnabled || !modHeld || !OverlayController.targetHasFocus) return
+      if (!stashScrollEnabled || !modHeld || !OverlayController.targetHasFocus || !hyprlandInputAllowed()) return
       const tb = OverlayController.targetBounds
       if (!tb?.width) return
       // Only act when cursor is inside the PoE window but outside the stash grid area
@@ -400,7 +409,11 @@ function applySuspendTransition(wasSuspended: boolean, rearmReason: string): voi
  *  or one of Scalpel's gameplay overlays. Registration follows the same focus
  *  lifecycle, and this dispatch-time check closes uIOhook and transition races. */
 function hotkeyContextIsActive(): boolean {
-  return !hotkeysAreSuspended() && (OverlayController.targetHasFocus || isAnyScalpelBrowserWindowFocused())
+  return (
+    hyprlandInputAllowed() &&
+    !hotkeysAreSuspended() &&
+    (OverlayController.targetHasFocus || isAnyScalpelBrowserWindowFocused())
+  )
 }
 
 /** Idempotent: gameplay focus left PoE/Scalpel (PoE blur, overlay leave, boot).
@@ -662,10 +675,12 @@ const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms)
  *  the paste. targetHasFocus is the same signal that authorizes every gameplay
  *  hotkey (see hotkeyContextIsActive). */
 async function awaitGameFocus(): Promise<void> {
+  if (!hyprlandInputAllowed()) throw new Error('Game workspace is inactive - input not sent')
   if (OverlayController.targetHasFocus) return
   focusGameWindow()
   for (let waited = 0; waited < FOCUS_WAIT_MS; waited += FOCUS_POLL_MS) {
     await wait(FOCUS_POLL_MS)
+    if (!hyprlandInputAllowed()) throw new Error('Game workspace is inactive - input not sent')
     if (OverlayController.targetHasFocus) return
   }
   throw new Error('PoE did not take focus - chat command not sent')
@@ -1021,6 +1036,7 @@ function releaseCKeyedRegistrationsForInjection(): (() => void) | null {
  * releaseCKeyedRegistrationsForInjection (#601).
  */
 export async function sendCtrlCToPoE(opts?: { withAlt?: boolean }): Promise<void> {
+  if (!hyprlandInputAllowed()) return
   injecting = true
   const restoreCKeyedRegistrations = releaseCKeyedRegistrationsForInjection()
 

--- a/src/main/hotkeys.ts
+++ b/src/main/hotkeys.ts
@@ -122,7 +122,7 @@ function firePriceCheck(): void {
  *  registered by syncEscapeShortcut, and the uiohook fallback keydown branch
  *  below). Both can deliver for the same physical press - see DEDUPE_MS. */
 function fireEscape(): void {
-  if (injecting || isTypingInOverlay() || !hotkeyContextIsActive()) return
+  if (injecting || isTypingInOverlay() || !escapeContextIsActive()) return
   const now = Date.now()
   if (now - lastEscapeFireAt < DEDUPE_MS) return
   lastEscapeFireAt = now
@@ -138,7 +138,17 @@ function fireEscape(): void {
  *  Safe to call from anywhere - it's a no-op when the desired state already
  *  matches the registered state. */
 function syncEscapeShortcut(): void {
-  const desired = !!onEscape && overlayVisibleForEscape && OverlayController.targetHasFocus && !hotkeysAreSuspended()
+  // On Hyprland, activating the XWayland overlay takes focus away from PoE
+  // before Electron reliably reports the overlay BrowserWindow as focused.
+  // Keep Escape registered across that handoff; hyprlandInputAllowed() in
+  // escapeContextIsActive() still rejects delivery after leaving the gameplay
+  // context or switching workspace.
+  const ownsHyprlandDialog = hyprlandOverlayActive() && overlayVisibleForEscape
+  const desired =
+    !!onEscape &&
+    overlayVisibleForEscape &&
+    (OverlayController.targetHasFocus || ownsHyprlandDialog) &&
+    !hotkeysAreSuspended()
   if (desired === escapeShortcutRegistered) return
   if (desired) {
     try {
@@ -413,6 +423,20 @@ function hotkeyContextIsActive(): boolean {
     hyprlandInputAllowed() &&
     !hotkeysAreSuspended() &&
     (OverlayController.targetHasFocus || isAnyScalpelBrowserWindowFocused())
+  )
+}
+
+/** Escape must remain usable during Hyprland's PoE -> XWayland overlay focus
+ * handoff. Electron can report neither window focused until the first pointer
+ * interaction, while Hyprland already considers the visible overlay part of
+ * the active game context. Other hotkeys retain the stricter focus gate. */
+function escapeContextIsActive(): boolean {
+  return (
+    hyprlandInputAllowed() &&
+    !hotkeysAreSuspended() &&
+    (OverlayController.targetHasFocus ||
+      isAnyScalpelBrowserWindowFocused() ||
+      (hyprlandOverlayActive() && overlayVisibleForEscape))
   )
 }
 

--- a/src/main/hyprland-focus.test.ts
+++ b/src/main/hyprland-focus.test.ts
@@ -1,0 +1,48 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+import { hyprlandFocusScript } from './hyprland-focus'
+
+describe('Hyprland focus script', () => {
+  it('rejects invalid selectors before constructing Lua', () => {
+    expect(() => hyprlandFocusScript('bad"selector', '0x2', 1)).toThrow()
+    expect(() => hyprlandFocusScript('0x1', '0x2', 0)).toThrow()
+  })
+  // Exercise the actual generated callback when a Lua interpreter is available.
+  describe.skipIf(spawnSync('lua', ['-v']).status !== 0)('Lua handoff', () => {
+    for (const fail of [false, true]) {
+      it(`transfers pointer and keyboard focus and restores policies (failure=${fail})`, () => {
+        const script = `
+local config = { ["cursor.no_warps"] = false, ["input.follow_mouse"] = 1 }
+local target = { address = "0x1", workspace = { id = 2 } }
+local game = { address = "0x2", workspace = { id = 2 } }
+local dispatched = false
+hl = {
+  get_window = function(s) return s == "address:0x1" and target or game end,
+  get_active_window = function() return game end,
+  get_config = function(k) return config[k] end,
+  config = function(c)
+    config["cursor.no_warps"] = c.cursor.no_warps
+    config["input.follow_mouse"] = c.input.follow_mouse
+  end,
+  dsp = { focus = function(args) return args end },
+  dispatch = function(args)
+    assert(args.window == "address:0x1")
+    assert(config["cursor.no_warps"] == true)
+    assert(config["input.follow_mouse"] == 0)
+    dispatched = true
+    ${fail ? 'error("simulated failure")' : ''}
+  end,
+}
+local ok = pcall(function()
+${hyprlandFocusScript('0x1', '0x2', 10)}
+end)
+assert(ok == ${!fail})
+assert(dispatched)
+assert(config["cursor.no_warps"] == false)
+assert(config["input.follow_mouse"] == 1)
+`
+        expect(() => execFileSync('lua', ['-'], { input: script })).not.toThrow()
+      })
+    }
+  })
+})

--- a/src/main/hyprland-focus.ts
+++ b/src/main/hyprland-focus.ts
@@ -1,0 +1,34 @@
+/** Run the focus handoff and restore the user's cursor policy in one compositor
+ * callback. Separate IPC calls would leave a window for cursor warps or a stuck
+ * setting if Scalpel exits between them. */
+export function hyprlandFocusScript(targetAddress: string, gameAddress: string, pid: number): string {
+  if (
+    ![targetAddress, gameAddress].every((address) => /^0x[0-9a-f]+$/i.test(address)) ||
+    !Number.isSafeInteger(pid) ||
+    pid <= 0
+  ) {
+    throw new Error('Invalid Hyprland focus target')
+  }
+  return `
+local target = hl.get_window("address:${targetAddress}")
+local game = hl.get_window("address:${gameAddress}")
+local active = hl.get_active_window()
+if not target or not game or not active then return end
+if active.workspace.id ~= game.workspace.id or target.workspace.id ~= game.workspace.id then return end
+if active.address ~= game.address and not (active.pid == ${pid} and active.title:match("^Scalpel Overlay")) then return end
+if active.address == target.address then return end
+local original = hl.get_config("cursor.no_warps")
+local followMouse = hl.get_config("input.follow_mouse")
+if type(original) ~= "boolean" then error("Cannot read cursor warp policy") end
+if type(followMouse) ~= "number" then error("Cannot read pointer focus policy") end
+-- In Hyprland 0.56, rawWindowFocus only sends pointer enter to the new
+-- surface when follow_mouse is 0. Otherwise keyboard focus changes but
+-- pointer focus waits for physical movement (Alt-Tab uses a different path).
+hl.config({ cursor = { no_warps = true }, input = { follow_mouse = 0 } })
+local ok, err = pcall(function()
+  hl.dispatch(hl.dsp.focus({ window = "address:${targetAddress}" }))
+end)
+hl.config({ cursor = { no_warps = original }, input = { follow_mouse = followMouse } })
+if not ok then error(err) end
+`
+}

--- a/src/main/hyprland-policy.test.ts
+++ b/src/main/hyprland-policy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type HyprClient,
+  hyprlandOverlayBounds,
+  hyprlandVersionAtLeast,
+  isHyprlandGameContext,
+} from './hyprland-policy'
+
+const game: HyprClient = {
+  address: '0x1',
+  pid: 10,
+  title: 'Path of Exile 2',
+  workspace: { id: 2 },
+  at: [0, 0],
+  size: [2400, 1350],
+  floating: true,
+}
+describe('Hyprland input ownership', () => {
+  it('converts fractional Hyprland scaling to Electron DIP without clipping', () => {
+    expect(hyprlandOverlayBounds(game, { x: 0, y: 0, scale: 1.6 }, { bounds: { x: 0, y: 0 }, scaleFactor: 2 })).toEqual(
+      {
+        dip: { x: 0, y: 0, width: 1920, height: 1080 },
+        physical: { x: 0, y: 0, width: 3840, height: 2160 },
+      },
+    )
+  })
+  it('allows the focused game', () => expect(isHyprlandGameContext(game, game, 20)).toBe(true))
+  it('allows our overlay on the game workspace', () => {
+    expect(isHyprlandGameContext({ ...game, address: '0x2', pid: 20, title: 'Scalpel Overlay' }, game, 20)).toBe(true)
+  })
+  it('rejects our overlay on another workspace', () => {
+    expect(
+      isHyprlandGameContext(
+        { ...game, address: '0x2', pid: 20, title: 'Scalpel Overlay', workspace: { id: 1 } },
+        game,
+        20,
+      ),
+    ).toBe(false)
+  })
+  it('rejects other applications, settings, and missing compositor state', () => {
+    expect(isHyprlandGameContext({ ...game, address: '0x3', pid: 30 }, game, 20)).toBe(false)
+    expect(isHyprlandGameContext({ ...game, address: '0x3', pid: 20, title: 'Scalpel' }, game, 20)).toBe(false)
+    expect(isHyprlandGameContext(null, game, 20)).toBe(false)
+    expect(isHyprlandGameContext(game, null, 20)).toBe(false)
+  })
+})
+
+describe('Hyprland version gate', () => {
+  const version = (tag: string) => JSON.stringify({ branch: 'main', tag })
+  it('accepts the minimum release and newer', () => {
+    expect(hyprlandVersionAtLeast(version('v0.56.0'))).toBe(true)
+    expect(hyprlandVersionAtLeast(version('v0.57.1'))).toBe(true)
+    expect(hyprlandVersionAtLeast(version('v1.0.0'))).toBe(true)
+  })
+  it('accepts -git builds of the minimum release', () => {
+    expect(hyprlandVersionAtLeast(version('v0.56.0-13-gdeadbee'))).toBe(true)
+  })
+  it('rejects older releases', () => {
+    expect(hyprlandVersionAtLeast(version('v0.55.9'))).toBe(false)
+    expect(hyprlandVersionAtLeast(version('v0.9.0'))).toBe(false)
+  })
+  it('fails closed on output it cannot read', () => {
+    expect(hyprlandVersionAtLeast('not json')).toBe(false)
+    expect(hyprlandVersionAtLeast(version('unknown'))).toBe(false)
+    expect(hyprlandVersionAtLeast('{}')).toBe(false)
+  })
+})

--- a/src/main/hyprland-policy.ts
+++ b/src/main/hyprland-policy.ts
@@ -1,0 +1,62 @@
+export interface HyprClient {
+  address: string
+  pid: number
+  title: string
+  workspace: { id: number }
+  at: [number, number]
+  size: [number, number]
+  floating: boolean
+  monitor?: number
+}
+
+/** Oldest Hyprland this overlay path is exercised against. Earlier releases
+ *  lack the `hyprctl eval` Lua API it drives (hl.get_config, hl.dsp.*) and keep
+ *  using the X11 tracker, which is what they run today. */
+export const MIN_HYPRLAND: readonly [number, number, number] = [0, 56, 0]
+
+/** `hyprctl -j version` reports tags like "v0.56.0", or "v0.56.0-13-gdeadbee"
+ *  for -git builds. Unreadable output fails closed: keep the X11 tracker rather
+ *  than drive a compositor whose capabilities we couldn't confirm. */
+export function hyprlandVersionAtLeast(versionJson: string, min = MIN_HYPRLAND): boolean {
+  let tag: unknown
+  try {
+    tag = (JSON.parse(versionJson) as { tag?: unknown }).tag
+  } catch {
+    return false
+  }
+  const parsed = typeof tag === 'string' ? /^v?(\d+)\.(\d+)\.(\d+)/.exec(tag) : null
+  if (!parsed) return false
+  for (const [index, bound] of min.entries()) {
+    const part = Number(parsed[index + 1])
+    if (part !== bound) return part > bound
+  }
+  return true
+}
+
+export function hyprlandOverlayBounds(
+  client: HyprClient,
+  monitor: { x: number; y: number; scale: number },
+  display: { bounds: { x: number; y: number }; scaleFactor: number },
+) {
+  const ratio = monitor.scale / display.scaleFactor
+  const dip = {
+    x: Math.round(display.bounds.x + (client.at[0] - monitor.x) * ratio),
+    y: Math.round(display.bounds.y + (client.at[1] - monitor.y) * ratio),
+    width: Math.round(client.size[0] * ratio),
+    height: Math.round(client.size[1] * ratio),
+  }
+  return {
+    dip,
+    physical: {
+      x: Math.round(dip.x * display.scaleFactor),
+      y: Math.round(dip.y * display.scaleFactor),
+      width: Math.round(client.size[0] * monitor.scale),
+      height: Math.round(client.size[1] * monitor.scale),
+    },
+  }
+}
+
+export function isHyprlandGameContext(active: HyprClient | null, game: HyprClient | null, pid: number): boolean {
+  if (!active?.address || !game?.address || active.workspace?.id !== game.workspace.id) return false
+  return active.address === game.address || (active.pid === pid && active.title.startsWith('Scalpel Overlay'))
+}

--- a/src/main/hyprland.ts
+++ b/src/main/hyprland.ts
@@ -1,0 +1,250 @@
+import { execFile, execFileSync } from 'node:child_process'
+import { promisify } from 'node:util'
+import { createConnection } from 'node:net'
+import { join } from 'node:path'
+import { app, type BrowserWindow, screen } from 'electron'
+import { OverlayController } from 'electron-overlay-window'
+import {
+  type HyprClient,
+  MIN_HYPRLAND,
+  hyprlandOverlayBounds,
+  hyprlandVersionAtLeast,
+  isHyprlandGameContext,
+} from './hyprland-policy'
+import { hyprlandFocusScript } from './hyprland-focus'
+
+const isHyprland = process.platform === 'linux' && !!process.env.HYPRLAND_INSTANCE_SIGNATURE
+const exec = promisify(execFile)
+let game: HyprClient | null = null
+let tracking = false
+let overlayActive: boolean | null = null
+
+/** Whether to drive the compositor instead of the native X11 tracker. Resolved
+ *  once, on first use: the version query costs a subprocess, and Hyprland can't
+ *  be swapped underneath a running process. */
+export function hyprlandOverlayActive(): boolean {
+  if (!isHyprland) return false
+  if (overlayActive === null) {
+    try {
+      overlayActive = hyprlandVersionAtLeast(
+        execFileSync('hyprctl', ['-j', 'version'], { encoding: 'utf8', timeout: 1000 }),
+      )
+      if (!overlayActive) console.warn(`[hyprland] older than ${MIN_HYPRLAND.join('.')}; using the X11 overlay tracker`)
+    } catch (error) {
+      overlayActive = false
+      console.warn('[hyprland] version query failed; using the X11 overlay tracker:', String(error))
+    }
+  }
+  return overlayActive
+}
+
+// Native X11 focus can remain stale when focus moves to a Wayland client.
+// Recheck with the compositor at the point of input/focus dispatch; fail closed.
+// Off the Hyprland path `tracking` is never set, so this stays a no-op.
+export function hyprlandInputAllowed(): boolean {
+  if (!tracking) return true
+  try {
+    const active = JSON.parse(execFileSync('hyprctl', ['-j', 'activewindow'], { encoding: 'utf8', timeout: 500 }))
+    return isHyprlandGameContext(active, game, process.pid)
+  } catch {
+    return false
+  }
+}
+
+export function nameHyprlandOverlay(win: BrowserWindow): void {
+  if (!hyprlandOverlayActive()) return
+  win.setTitle('Scalpel Overlay')
+  win.on('page-title-updated', (event, title) => {
+    event.preventDefault()
+    win.setTitle(`Scalpel Overlay: ${title}`)
+  })
+}
+
+/** Hyprland owns workspace, focus and logical geometry. Avoid the native X11
+ * override-redirect window and direct xcb_set_input_focus entirely here. */
+export function attachHyprlandOverlay(win: BrowserWindow, initialTitles: string[]): void {
+  tracking = true
+  let titles = initialTitles
+  let lastAddress = ''
+  let overlayAddress = ''
+  let focusRequestedUntil = 0
+  let focusConfirmedSince = 0
+  let lastGeometry = ''
+  let lastFocused = false
+  let lastContextActive = false
+  let stopped = false
+  let busy = false
+  let dirty = false
+  let eventsConnected = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const dispatch = async (expression: string) => {
+    const result = await exec('hyprctl', ['dispatch', expression], { timeout: 1000 })
+    if (result.stdout.startsWith('error:')) throw new Error(result.stdout)
+  }
+  OverlayController.activateOverlay = () => {
+    if (!hyprlandInputAllowed() || win.isDestroyed()) return
+    focusRequestedUntil = Date.now() + 1500
+    focusConfirmedSince = 0
+    win.setIgnoreMouseEvents(false)
+    if (timer) clearTimeout(timer)
+    if (busy) dirty = true
+    else timer = setTimeout(poll, 0)
+  }
+  OverlayController.focusTarget = () => {
+    focusRequestedUntil = 0
+    focusConfirmedSince = 0
+    if (!hyprlandInputAllowed() || !game) return
+    if (!/^0x[0-9a-f]+$/i.test(game.address)) return
+    try {
+      execFileSync('hyprctl', ['eval', hyprlandFocusScript(game.address, game.address, process.pid)], {
+        timeout: 1000,
+      })
+      win.setIgnoreMouseEvents(true)
+    } catch (error) {
+      console.warn('[hyprland] game focus handoff failed:', String(error))
+    }
+  }
+  OverlayController.setTargetTitles = (next) => {
+    titles = next
+  }
+  OverlayController.clearTarget = () => {
+    titles = []
+  }
+
+  const poll = async () => {
+    if (stopped || busy || win.isDestroyed()) return
+    busy = true
+    try {
+      const [clientResult, activeResult, monitorResult] = await Promise.all([
+        exec('hyprctl', ['-j', 'clients'], { timeout: 1000 }),
+        exec('hyprctl', ['-j', 'activewindow'], { timeout: 1000 }),
+        exec('hyprctl', ['-j', 'monitors'], { timeout: 1000 }),
+      ])
+      if (stopped || win.isDestroyed()) return
+      const clients: HyprClient[] = JSON.parse(clientResult.stdout)
+      overlayAddress = clients.find((c) => c.pid === process.pid && c.title === win.getTitle())?.address ?? ''
+      const active: HyprClient = JSON.parse(activeResult.stdout)
+      game =
+        clients.find((c) => c.address === active.address && titles.includes(c.title)) ??
+        clients.find((c) => c.address === lastAddress && titles.includes(c.title)) ??
+        clients.find((c) => titles.includes(c.title)) ??
+        null
+      if (!game) {
+        if (lastAddress) OverlayController.events.emit('detach')
+        lastAddress = ''
+        lastGeometry = ''
+      } else {
+        const monitors: Array<{ id: number; name: string; x: number; y: number; scale: number }> = JSON.parse(
+          monitorResult.stdout,
+        )
+        const monitor = monitors.find((m) => m.id === game?.monitor)
+        if (!monitor) throw new Error('Game monitor is unavailable')
+        const display =
+          screen.getAllDisplays().find((d) => d.label === monitor.name) ??
+          screen.getDisplayNearestPoint({ x: monitor.x, y: monitor.y })
+        const { dip: bounds, physical } = hyprlandOverlayBounds(game, monitor, display)
+        const geometry = JSON.stringify(bounds)
+        if (game.address !== lastAddress) {
+          OverlayController.events.emit('attach', { ...physical, titleIndex: titles.indexOf(game.title) })
+        } else if (geometry !== lastGeometry) {
+          OverlayController.events.emit('moveresize', physical)
+        }
+        lastAddress = game.address
+
+        // Move only our gameplay overlays, never Scalpel's settings window or
+        // the game itself. Silent moves must not switch the user's workspace.
+        for (const overlay of clients.filter((c) => c.pid === process.pid && c.title.startsWith('Scalpel Overlay'))) {
+          if (!/^0x[0-9a-f]+$/i.test(overlay.address)) continue
+          if (!overlay.floating)
+            await dispatch(`hl.dsp.window.float({ window = "address:${overlay.address}", action = "set" })`)
+          if (overlay.workspace.id !== game.workspace.id) {
+            if (!Number.isInteger(game.workspace.id)) continue
+            await dispatch(
+              `hl.dsp.window.move({ window = "address:${overlay.address}", workspace = "${game.workspace.id}", follow = false })`,
+            )
+          }
+        }
+        if (!win.isDestroyed() && geometry !== lastGeometry) win.setBounds(bounds)
+        lastGeometry = geometry
+      }
+      const contextActive = isHyprlandGameContext(active, game, process.pid)
+      const focused = !!game && active.address === game.address
+      if (focused !== lastFocused || OverlayController.targetHasFocus !== focused) {
+        OverlayController.events.emit(focused ? 'focus' : 'blur')
+      } else if (lastContextActive && !contextActive) {
+        // Leaving a focused overlay must hide it too, even though the game
+        // had already lost focus when the pointer entered that overlay.
+        OverlayController.events.emit('blur')
+      }
+      lastFocused = focused
+      lastContextActive = contextActive
+      if (!contextActive) focusRequestedUntil = 0
+      if (active.address === overlayAddress && win.isFocused()) {
+        focusConfirmedSince ||= Date.now()
+        if (Date.now() - focusConfirmedSince >= 100) focusRequestedUntil = 0
+      } else focusConfirmedSince = 0
+      if (focusRequestedUntil > Date.now() && overlayAddress && game && win.isVisible()) {
+        // Never trust Electron's cached X11 focus. Resolve the compositor window
+        // after mapping/workspace placement and check context again inside Lua.
+        execFileSync('hyprctl', ['eval', hyprlandFocusScript(overlayAddress, game.address, process.pid)], {
+          timeout: 1000,
+        })
+      }
+    } catch (error) {
+      game = null
+      if (lastContextActive || lastFocused || OverlayController.targetHasFocus) OverlayController.events.emit('blur')
+      lastFocused = false
+      lastContextActive = false
+      console.warn('[hyprland] overlay tracking failed:', String(error))
+    } finally {
+      busy = false
+      if (!stopped)
+        timer = setTimeout(poll, dirty || focusRequestedUntil > Date.now() ? 25 : eventsConnected ? 2000 : 250)
+      dirty = false
+    }
+  }
+  const stop = () => {
+    stopped = true
+    if (timer) clearTimeout(timer)
+    socket.destroy()
+    game = null
+  }
+  win.once('closed', stop)
+  app.once('before-quit', stop)
+  // React promptly to workspace/focus changes without spawning compositor
+  // queries continuously during gameplay. Periodic refresh covers geometry
+  // changes for which the event socket doesn't provide coordinates.
+  const socket = createConnection(
+    join(
+      process.env.XDG_RUNTIME_DIR ?? `/run/user/${process.getuid?.()}`,
+      'hypr',
+      process.env.HYPRLAND_INSTANCE_SIGNATURE!,
+      '.socket2.sock',
+    ),
+  )
+  socket.on('connect', () => {
+    eventsConnected = true
+  })
+  socket.on('error', () => {
+    eventsConnected = false
+  })
+  socket.on('close', () => {
+    eventsConnected = false
+  })
+  socket.on('data', (data) => {
+    if (
+      !/(activewindow|workspace|movewindow|openwindow|closewindow|monitor|fullscreen|windowtitle|changefloatingmode|configreloaded)/.test(
+        data.toString(),
+      )
+    )
+      return
+    if (busy) {
+      dirty = true
+      return
+    }
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(poll, 25)
+  })
+  void poll()
+}

--- a/src/main/overlay-manual-focus.test.ts
+++ b/src/main/overlay-manual-focus.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mock = vi.hoisted(() => ({
+  mouse: {} as Record<string, (event: { x: number; y: number }) => void>,
+  ipc: {} as Record<string, (...args: any[]) => void>,
+  ignore: vi.fn(),
+  activate: vi.fn(),
+  focus: vi.fn(),
+  unmap: vi.fn(),
+  allowed: true,
+}))
+vi.mock('electron', () => ({
+  BrowserWindow: class {
+    static fromWebContents() {
+      return window
+    }
+    setIgnoreMouseEvents = mock.ignore
+    webContents = { send: vi.fn(), id: 1 }
+    on = vi.fn()
+    loadFile = vi.fn()
+    setAlwaysOnTop = vi.fn()
+    setOpacity = vi.fn()
+    setSkipTaskbar = vi.fn()
+    hide = mock.unmap
+    showInactive = vi.fn()
+    isVisible = () => true
+    isDestroyed = () => false
+  },
+  ipcMain: {
+    on: (name: string, cb: any) => {
+      mock.ipc[name] = cb
+    },
+    handle: vi.fn(),
+  },
+  screen: { getDisplayNearestPoint: () => ({ scaleFactor: 1 }), getPrimaryDisplay: () => ({ scaleFactor: 1 }) },
+  webContents: {},
+}))
+vi.mock('electron-overlay-window', () => ({
+  OVERLAY_WINDOW_OPTS: {},
+  OverlayController: {
+    targetHasFocus: true,
+    targetBounds: { x: 0, y: 0, width: 1000, height: 800 },
+    events: { on: vi.fn() },
+    activateOverlay: mock.activate,
+    focusTarget: mock.focus,
+  },
+}))
+vi.mock('uiohook-napi', () => ({
+  uIOhook: {
+    on: (name: string, cb: any) => {
+      mock.mouse[name] = cb
+    },
+  },
+}))
+vi.mock('./hyprland', () => ({
+  hyprlandOverlayActive: () => true,
+  hyprlandInputAllowed: () => mock.allowed,
+  nameHyprlandOverlay: vi.fn(),
+  attachHyprlandOverlay: vi.fn(),
+}))
+vi.mock('./diagnostics', () => ({
+  guardNativeListener: (_: string, cb: any) => cb,
+  registerDiagnosticProvider: vi.fn(),
+}))
+vi.mock('./client-log', () => ({ startClientLogWatcher: vi.fn() }))
+vi.mock('./game-state', () => ({ getPoeVersion: () => 2, setPoeVersion: vi.fn() }))
+vi.mock('./tier-data', () => ({ loadTierData: async () => {}, refreshTierData: async () => {} }))
+vi.mock('./premium-mods', () => ({ loadPremiumMods: async () => {}, refreshPremiumMods: async () => {} }))
+vi.mock('./trade/endgame-filter-support', () => ({
+  loadEndgameFilterSupport: async () => {},
+  refreshEndgameFilterSupport: async () => {},
+}))
+vi.mock('./windowing', () => ({
+  closeAllOverlaysOnPoeExit: vi.fn(),
+  isAnyScalpelWindowFocused: () => false,
+  isInsideAnySecondaryOverlay: () => false,
+}))
+vi.mock('./whiteboard', () => ({ getWhiteboardOverlay: () => null }))
+
+import { createOverlayWindow, hideOverlay, showOverlay, setCloseOnClickOutside } from './overlay'
+let window: ReturnType<typeof createOverlayWindow>
+
+describe('Hyprland manual dialog focus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mock.allowed = true
+    window = createOverlayWindow(2)
+    setCloseOnClickOutside(false)
+    showOverlay()
+    mock.ipc['report-panel-rect']({ sender: { id: 1 } }, { left: 100, top: 100, width: 200, height: 200 })
+  })
+  afterEach(() => {
+    hideOverlay()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+  it('explicitly requests focus on open without waiting for mouse movement', () => {
+    expect(mock.activate).toHaveBeenCalledOnce()
+    expect(mock.ignore).toHaveBeenLastCalledWith(false)
+  })
+  it('does not release focus when moving outside or dragging past stale panel bounds', async () => {
+    mock.mouse.mousemove({ x: 150, y: 150 })
+    mock.mouse.mousedown({ x: 150, y: 150 })
+    mock.mouse.mousemove({ x: 900, y: 700 })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(mock.focus).not.toHaveBeenCalled()
+    expect(mock.ignore).toHaveBeenLastCalledWith(false)
+  })
+  it('dismisses on outside click even when the legacy preference is disabled', () => {
+    mock.mouse.mousedown({ x: 900, y: 700 })
+    expect(mock.focus).toHaveBeenCalledOnce()
+    expect(mock.focus.mock.invocationCallOrder[0]).toBeLessThan(mock.ignore.mock.invocationCallOrder.at(-1)!)
+    expect(mock.ignore).toHaveBeenLastCalledWith(true)
+  })
+  it('keeps input while dropdowns unlock and panel reports are refreshed', () => {
+    mock.ipc['unlock-interactive']()
+    mock.ipc['clear-panel-rect']({ sender: { id: 1 } })
+    expect(mock.ignore).toHaveBeenLastCalledWith(false)
+    expect(mock.focus).not.toHaveBeenCalled()
+  })
+  it('does not react to clicks in an unrelated workspace', () => {
+    mock.allowed = false
+    mock.mouse.mousedown({ x: 900, y: 700 })
+    expect(mock.focus).not.toHaveBeenCalled()
+  })
+  it('does not reactivate a dismissed panel before its renderer clears the old rects', () => {
+    hideOverlay()
+    expect(mock.unmap).toHaveBeenCalledOnce()
+    expect(window.isVisible()).toBe(false)
+    mock.activate.mockClear()
+    mock.mouse.mousemove({ x: 150, y: 150 })
+    expect(mock.activate).not.toHaveBeenCalled()
+    expect(mock.ignore).toHaveBeenLastCalledWith(true)
+  })
+  it('maps the dialog again after a deliberate dismissal', () => {
+    hideOverlay()
+    showOverlay()
+    expect(window.isVisible()).toBe(true)
+    expect(mock.activate).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/overlay.ts
+++ b/src/main/overlay.ts
@@ -13,8 +13,10 @@ import { getWhiteboardOverlay } from './whiteboard'
 import { POE_SIDEBAR_RATIO } from '@shared/poe-geometry'
 import { GAME_TITLES } from '@shared/contracts/game-variant'
 import { IPC_CHANNELS } from '@shared/contracts/ipc'
+import { attachHyprlandOverlay, hyprlandInputAllowed, hyprlandOverlayActive, nameHyprlandOverlay } from './hyprland'
 
 let overlayWindow: BrowserWindow | null = null
+let unmapHyprlandDialog: (() => void) | null = null
 let overlayVisible = false
 let mouseOverPanel = false
 let closeOnClickOutside = false
@@ -76,9 +78,13 @@ function flatPanelRects(): PhysRect[] {
 /** Return the window that owns the topmost rect containing (x, y), or null. */
 function windowAtPoint(x: number, y: number): BrowserWindow | null {
   for (const entry of panelRectsBySender.values()) {
+    // A hidden window keeps its last reported rects until its renderer clears
+    // them, and must not be made interactive on the strength of stale geometry.
+    if (entry.win.isDestroyed() || !entry.win.isVisible()) continue
+    if (hyprlandOverlayActive() && entry.win === overlayWindow && !overlayVisible) continue
     for (const r of entry.rects) {
       if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
-        return entry.win.isDestroyed() ? null : entry.win
+        return entry.win
       }
     }
   }
@@ -124,7 +130,7 @@ ipcMain.on('clear-panel-rect', (event) => {
   // unmount time).
   if (entry && !entry.win.isDestroyed()) {
     try {
-      entry.win.setIgnoreMouseEvents(true)
+      entry.win.setIgnoreMouseEvents(!(hyprlandOverlayActive() && overlayVisible && entry.win === overlayWindow))
     } catch {}
   }
   if (currentInteractiveWindow === entry?.win) currentInteractiveWindow = null
@@ -154,6 +160,7 @@ ipcMain.on('lock-interactive', () => {
 })
 ipcMain.on('unlock-interactive', () => {
   interactiveLocked = false
+  if (hyprlandOverlayActive() && overlayVisible) return
   // Re-evaluate based on current mouse position
   if (!mouseOverPanel) setInteractive(false)
 })
@@ -173,6 +180,8 @@ let currentInteractiveWindow: BrowserWindow | null = null
  *  Setting a different window to interactive automatically reverts the prior
  *  one to click-through, so we never end up with two windows competing. */
 function setInteractiveWindow(win: BrowserWindow | null): void {
+  if (hyprlandOverlayActive() && overlayVisible && win !== overlayWindow) return
+  if (!hyprlandInputAllowed()) return
   if (currentInteractiveWindow === win) return
   // Revert prior window to click-through.
   const prev = currentInteractiveWindow
@@ -226,6 +235,9 @@ let exitTimer: ReturnType<typeof setTimeout> | null = null
 uIOhook.on(
   'mousemove',
   guardNativeListener('mousemove', (e) => {
+    // A dialog owns input until explicitly dismissed. Hit-test updates can lag
+    // behind dragging; neither leaving a rect nor stale geometry may release it.
+    if (hyprlandOverlayActive() && overlayVisible) return
     // No rects reported yet -- skip hit testing. (Whiteboard registers its own
     // rects independently of the main overlay's `overlayVisible` flag.)
     if (panelRectsBySender.size === 0) return
@@ -256,6 +268,7 @@ uIOhook.on(
   'mousedown',
   guardNativeListener('mousedown-overlay', (e) => {
     if (!overlayVisible) return
+    if (!hyprlandInputAllowed()) return
     // Only process clicks if the overlay window is actually visible on screen
     if (!overlayWindow || overlayWindow.isDestroyed() || !overlayWindow.isVisible()) return
     if (!isInsidePanel(e.x, e.y)) {
@@ -266,6 +279,10 @@ uIOhook.on(
       // panel rect, so every click on it looks like a click "outside". Bail so we don't
       // disable interactivity (click-through to PoE) or close the overlay.
       if (interactiveLocked) return
+      if (hyprlandOverlayActive()) {
+        hideOverlay()
+        return
+      }
       // Ensure click-through is enabled so the click reaches the game
       if (mouseOverPanel) {
         mouseOverPanel = false
@@ -325,6 +342,7 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
       contextIsolation: true,
     },
   })
+  nameHyprlandOverlay(overlayWindow)
 
   if (process.env.ELECTRON_RENDERER_URL) {
     overlayWindow.loadURL(process.env.ELECTRON_RENDERER_URL)
@@ -337,25 +355,37 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
 
   overlayWindow.on('closed', () => {
     overlayWindow = null
+    unmapHyprlandDialog = null
   })
 
   // Prevent Windows show/hide animation by using opacity instead of hide/show.
   // electron-overlay-window calls hide()/showInactive() on focus changes, which
   // triggers the OS zoom animation. We intercept to use opacity instead.
   const origShowInactive = overlayWindow.showInactive.bind(overlayWindow)
+  const origHide = overlayWindow.hide.bind(overlayWindow)
   let opacityHidden = false
+  unmapHyprlandDialog = () => {
+    origHide()
+    opacityHidden = true
+  }
 
   overlayWindow.hide = () => {
-    if (Date.now() - lastShowTime < 100) return
+    if (!hyprlandOverlayActive() && Date.now() - lastShowTime < 100) return
 
     // electron-overlay-window's native code calls .hide() on PoE blur. Skip
     // the hide when focus actually moved to another Scalpel window (cheat
     // sheets etc.) - that's an in-app interaction, not "user left the app".
-    if (isAnyScalpelWindowFocused()) return
+    if (hyprlandOverlayActive() ? hyprlandInputAllowed() : isAnyScalpelWindowFocused()) return
 
     // Make it invisible and click-through - don't actually hide from OS to avoid animation
-    overlayWindow?.setOpacity(0)
+    if (hyprlandOverlayActive()) origHide()
+    else overlayWindow?.setOpacity(0)
     overlayWindow?.setIgnoreMouseEvents(true)
+    currentInteractiveWindow = null
+    interactiveLocked = false
+    mouseOverPanel = false
+    if (exitTimer) clearTimeout(exitTimer)
+    exitTimer = null
 
     opacityHidden = true
     if (onGameBlur) setImmediate(onGameBlur)
@@ -363,7 +393,7 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
 
   overlayWindow.showInactive = () => {
     // Only show the overlay if POE actually has focus (alt-tab fix)
-    if (!OverlayController.targetHasFocus) return
+    if (hyprlandOverlayActive() ? !hyprlandInputAllowed() : !OverlayController.targetHasFocus) return
 
     // Restore opacity before showing so it's visible immediately
     overlayWindow?.setOpacity(1)
@@ -385,7 +415,12 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
   // In multi-title mode (experimental), pass both titles so the native tracker
   // can find either PoE1 or PoE2 without a restart. In single-title mode
   // (stable), attach to the specific game version only.
-  if (multiTitleMode) {
+  if (hyprlandOverlayActive()) {
+    overlayWindow.setAlwaysOnTop(true, 'screen-saver')
+    OverlayController.events.on('blur', () => overlayWindow?.hide())
+    OverlayController.events.on('detach', () => overlayWindow?.hide())
+    attachHyprlandOverlay(overlayWindow, multiTitleMode ? [GAME_TITLES[1], GAME_TITLES[2]] : [GAME_TITLES[version]])
+  } else if (multiTitleMode) {
     OverlayController.attachByTitles(overlayWindow, [GAME_TITLES[1], GAME_TITLES[2]])
   } else {
     OverlayController.attachByTitle(overlayWindow, GAME_TITLES[version])
@@ -427,7 +462,7 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
       getWhiteboardOverlay()?.send(IPC_CHANNELS.SCREEN.SOURCE_INVALIDATED_EVENT)
       mouseOverPanel = false
       if (overlayVisible && overlayWindow && !overlayWindow.isDestroyed()) {
-        overlayWindow.setIgnoreMouseEvents(true)
+        overlayWindow.setIgnoreMouseEvents(!hyprlandOverlayActive())
         if (currentInteractiveWindow === overlayWindow) currentInteractiveWindow = null
         overlayWindow.webContents.send('skip-animation')
       }
@@ -478,7 +513,7 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
         // hotkeys and restores any hidden secondary overlays.
         overlayWindow.showInactive()
         mouseOverPanel = false
-        overlayWindow.setIgnoreMouseEvents(true)
+        overlayWindow.setIgnoreMouseEvents(!hyprlandOverlayActive())
         if (currentInteractiveWindow === overlayWindow) currentInteractiveWindow = null
       } else if (onGameFocus) {
         // Main overlay is closed but PoE just refocused -- still need to resume
@@ -557,6 +592,7 @@ export function showOverlay(): void {
   // Direct setOpacity(1) alone doesn't reset the closure flag, so the next hide/show cycle
   // from electron-overlay-window can re-zero the opacity.
   try {
+    if (hyprlandOverlayActive()) setInteractive(true)
     overlayWindow.showInactive()
   } catch {}
   // If a persisting whiteboard is visible, raise the eval above it so the
@@ -576,19 +612,37 @@ export function showOverlay(): void {
     console.error('[overlay] Error in showOverlay:', err)
   }
   overlayVisibilityListener?.(true)
+  if (hyprlandOverlayActive()) {
+    if (exitTimer) clearTimeout(exitTimer)
+    exitTimer = null
+    setInteractive(true)
+    OverlayController.activateOverlay()
+  }
 }
 
 export function hideOverlay(): void {
   if (!overlayWindow || overlayWindow.isDestroyed() || !overlayVisible) return
   overlayVisible = false
   mouseOverPanel = false
+  if (hyprlandOverlayActive()) {
+    interactiveLocked = false
+    currentInteractiveWindow = null
+    if (exitTimer) clearTimeout(exitTimer)
+    exitTimer = null
+    // Focus before removing the input region: otherwise pointer-follow-focus
+    // can activate the game outside our no-warp handoff.
+    OverlayController.focusTarget()
+    // X11 input-shape click-through is not enough: Hyprland can still
+    // hit-test the mapped full-screen window on the next physical click.
+    unmapHyprlandDialog?.()
+  }
   try {
     overlayWindow.setIgnoreMouseEvents(true)
   } catch {}
   // Tell renderer to hide its content (don't call overlayWindow.hide() -
   // OverlayController manages window visibility and would re-show it, causing flicker)
   overlayWindow.webContents.send('overlay-hide')
-  OverlayController.focusTarget()
+  if (!hyprlandOverlayActive()) OverlayController.focusTarget()
   overlayVisibilityListener?.(false)
 }
 

--- a/src/main/windowing/focus.test.ts
+++ b/src/main/windowing/focus.test.ts
@@ -13,6 +13,9 @@ vi.mock('./snap-canvas', () => ({
     snapGhostCalls.push(rect)
   },
 }))
+// These cases cover focus bookkeeping off the compositor-driven path, where the
+// Hyprland gate is a no-op. Mocked so the suite never loads the native tracker.
+vi.mock('../hyprland', () => ({ hyprlandInputAllowed: () => true }))
 import {
   aroundNativeDialog,
   closeAllOverlaysOnPoeExit,

--- a/src/main/windowing/focus.ts
+++ b/src/main/windowing/focus.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, screen } from 'electron'
+import { hyprlandInputAllowed } from '../hyprland'
 import { getSnapCanvasWindow, setSnapGhost } from './snap-canvas'
 import { firePoeLeaveHooks, getAuxiliaryScalpelWindows, getMainOverlay, overlays } from './state'
 
@@ -69,6 +70,7 @@ function collectScalpelWindows(): BrowserWindow[] {
  *  dialogs are intentionally excluded: callers that authorize keyboard input
  *  must not treat a file picker as an injection target. */
 export function isAnyScalpelBrowserWindowFocused(): boolean {
+  if (!hyprlandInputAllowed()) return false
   const focused = BrowserWindow.getFocusedWindow()
   if (!focused || focused.isDestroyed()) return false
   if (focused === getMainOverlay()) return true

--- a/src/main/windowing/window.ts
+++ b/src/main/windowing/window.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { BrowserWindow } from 'electron'
 import { OVERLAY_WINDOW_OPTS } from 'electron-overlay-window'
 import type { Rect } from './snap-canvas'
+import { hyprlandOverlayActive, nameHyprlandOverlay } from '../hyprland'
 
 interface CreateOptions {
   htmlEntry: string
@@ -27,6 +28,7 @@ export function createOverlayWindow({ htmlEntry, bounds }: CreateOptions): Brows
       nodeIntegration: false,
     },
   })
+  nameHyprlandOverlay(win)
   // 'screen-saver' is the level the main overlay uses (set by electron-overlay-
   // window on attach). It sits above PoE, the taskbar, and other floating
   // windows, and lets the window's full bounds render including the taskbar
@@ -56,10 +58,12 @@ export function createOverlayWindow({ htmlEntry, bounds }: CreateOptions): Brows
  *  for interaction; we just don't take focus on our own. */
 function installOpacityHideShow(win: BrowserWindow): void {
   const origShowInactive = win.showInactive.bind(win)
+  const origHide = win.hide.bind(win)
   const origIsVisible = win.isVisible.bind(win)
   let opacityHidden = false
   win.hide = (): void => {
-    win.setOpacity(0)
+    if (hyprlandOverlayActive()) origHide()
+    else win.setOpacity(0)
     win.setIgnoreMouseEvents(true)
     opacityHidden = true
   }


### PR DESCRIPTION
## Issue

Under Hyprland the compositor owns workspace placement, focus and logical geometry, so `electron-overlay-window`'s X11 path is advisory at best. On Omarchy/Hyprland the overlay could appear on a different workspace than the game, render at the wrong scale (Hyprland fractional scale vs Electron's scale factor), take input away from PoE, and warp the cursor.

## Solution

On Hyprland 0.56+, track the overlay through `hyprctl` instead of the native X11 tracker. A poller plus the Hyprland event socket emit the same `attach`/`moveresize`/`focus`/`blur`/`detach` events, so nothing downstream changes.

- `hyprland-policy.ts` — pure helpers: Hyprland coordinates → Electron DIPs, and whether Scalpel owns input (the game is active, or one of our overlays on the game's workspace).
- `hyprland-focus.ts` — the focus handoff as a single `hyprctl eval` Lua callback. It suppresses cursor warps and pointer-follow for the duration and restores both afterwards, including when the dispatch fails, so user config is never left modified.
- The dialog owns input until it is explicitly dismissed (Escape, close button, click outside, or the opening shortcut as a toggle). Pointer movement and dragging can no longer hand focus back mid-interaction. Escape remains registered during the initial PoE-to-XWayland focus handoff, so it closes the dialog immediately without requiring a mouse interaction first. On dismissal it focuses the game *before* unmapping — click-through alone still lets Hyprland hit-test the window on the next physical click.
- Input-authorizing paths re-check the compositor instead of trusting Electron's cached X11 focus, which goes stale under Wayland.

Older Hyprland releases lack the Lua API this drives and keep using the X11 tracker unchanged.

## Requires a user-owned window rule

Hyprland otherwise decorates, dims and initially focuses the overlay:

```lua
o.window({ class = "^scalpel$", title = "^Scalpel Overlay.*$" }, {
  float = true, no_initial_focus = true, no_dim = true, no_blur = true,
  border_size = 0, rounding = 0, opacity = "1 1",
})
```

Overlay windows are titled `Scalpel Overlay[: …]` on this path so the compositor can target them.

## Notes for review

- `windowAtPoint` now skips hidden windows on all platforms: a hidden window keeps its last reported rects until its renderer clears them, and shouldn't be made interactive on stale geometry.

## Testing

`npm run typecheck` and `npm test` clean.

Exercised live with PoE2 on Omarchy 4 / Hyprland 0.56 with an RTX 5080, nvidia-smi 610.57.04, single 3840x2160 display at Hyprland scale 1.6 / Electron scale 2: the overlay opens on the game's workspace and takes focus without Alt-Tab, dragging and pointer movement outside the dialog keep it, and Escape/close/outside-click return focus to the game with the cursor left where it was.

Other monitor layouts and XWayland scaling modes are untested.