### PR TITLE
fix(linux): silence expected hook priority denial

### DIFF
--- a/patches/uiohook-napi+1.5.4.patch
+++ b/patches/uiohook-napi+1.5.4.patch
@@ -23,7 +23,19 @@ index 0fb0bc0..9ab4af3 100644
 +            const char *layout_name = XGetAtomName(helper_disp, desc->names->keycodes);
 +            logger(LOG_LEVEL_DEBUG, "%s [%u]: Found keycode atom '%s' (%i)!\n",
 +                    __FUNCTION__, __LINE__, layout_name, (unsigned int) desc->names->keycodes);
-+
+ 
+-        const char *prefix_xfree86 = "xfree86_";
+-        #ifdef USE_EVDEV
+-        const char *prefix_evdev = "evdev_";
+-        if (strncmp(layout_name, prefix_evdev, strlen(prefix_evdev)) == 0) {
+-            is_evdev = true;
+-        } else
+-        #endif
+-        if (strncmp(layout_name, prefix_xfree86, strlen(prefix_xfree86)) != 0) {
+-            logger(LOG_LEVEL_ERROR, "%s [%u]: Unknown keycode name '%s', please file a bug report!\n",
+-                    __FUNCTION__, __LINE__, layout_name);
+-        } else if (layout_name == NULL) {
+-            logger(LOG_LEVEL_ERROR, "%s [%u]: X atom name failure for desc->names->keycodes!\n",
 +            const char *prefix_xfree86 = "xfree86_";
 +            #ifdef USE_EVDEV
 +            // Match "evdev" not "evdev_": the real keycodes atom on modern
@@ -41,19 +53,7 @@ index 0fb0bc0..9ab4af3 100644
 +                logger(LOG_LEVEL_ERROR, "%s [%u]: X atom name failure for desc->names->keycodes!\n",
 +                        __FUNCTION__, __LINE__);
 +            }
- 
--        const char *prefix_xfree86 = "xfree86_";
--        #ifdef USE_EVDEV
--        const char *prefix_evdev = "evdev_";
--        if (strncmp(layout_name, prefix_evdev, strlen(prefix_evdev)) == 0) {
--            is_evdev = true;
--        } else
--        #endif
--        if (strncmp(layout_name, prefix_xfree86, strlen(prefix_xfree86)) != 0) {
--            logger(LOG_LEVEL_ERROR, "%s [%u]: Unknown keycode name '%s', please file a bug report!\n",
--                    __FUNCTION__, __LINE__, layout_name);
--        } else if (layout_name == NULL) {
--            logger(LOG_LEVEL_ERROR, "%s [%u]: X atom name failure for desc->names->keycodes!\n",
++
 +            XkbFreeNames(desc, XkbKeycodesNameMask, True);
 +        } else {
 +            logger(LOG_LEVEL_ERROR, "%s [%u]: XkbGetNames failed to locate a valid keyboard!\n",
@@ -68,3 +68,27 @@ index 0fb0bc0..9ab4af3 100644
                  __FUNCTION__, __LINE__);
      }
  
+diff --git a/node_modules/uiohook-napi/src/lib/uiohook_worker.c b/node_modules/uiohook-napi/src/lib/uiohook_worker.c
+index cc80da1..1520d0c 100644
+--- a/node_modules/uiohook-napi/src/lib/uiohook_worker.c
++++ b/node_modules/uiohook-napi/src/lib/uiohook_worker.c
+@@ -8,6 +8,7 @@
+ #else
+ #include <pthread.h>
+ #include <sched.h>
++#include <errno.h>
+ #endif
+ 
+ #include "uiohook_worker.h"
+@@ -96,7 +97,10 @@ void hook_thread_proc(void* arg) {
+   struct sched_param params = {
+     .sched_priority = (sched_get_priority_max(SCHED_RR) / 2)
+   };
+-  if (pthread_setschedparam(this_thread, SCHED_RR, &params) != 0) {
++  // Unprivileged desktop processes normally cannot request real-time priority.
++  // Keep the default scheduler in that case; report unexpected failures only.
++  int priority_status = pthread_setschedparam(this_thread, SCHED_RR, &params);
++  if (priority_status != 0 && priority_status != EPERM && priority_status != EACCES) {
+     logger_proc(LOG_LEVEL_WARN, "%s [%u]: Could not set thread priority %i for thread 0x%lX!\n",
+       __FUNCTION__, __LINE__, params.sched_priority, (unsigned long)this_thread);
+   }


### PR DESCRIPTION
## Environment

Reproduced on Linux running Omarchy 4 with Scalpel under XWayland.

## Issue

At startup, `uiohook-napi` attempts to move its input-hook thread to the real-time `SCHED_RR` scheduler at priority 49. Normal unprivileged desktop applications are not allowed to request real-time scheduling, so `pthread_setschedparam()` returns `EPERM` (or `EACCES`) and prints:

```text
hook_thread_proc: Could not set thread priority 49
```

This is not an input-hook failure. The thread remains functional using the normal scheduler, so warning for these expected permission results is misleading.

## Fix

Capture the return value from `pthread_setschedparam()` and treat `EPERM` and `EACCES` as expected outcomes. The existing warning remains for every other error so genuine scheduler failures are still visible.

This does not grant Scalpel additional privileges, change the scheduler, or change input behavior. It only avoids reporting the normal unprivileged fallback as an error. The change extends the existing `uiohook-napi` patch, which is applied before the native dependency is rebuilt on Linux.

## Verification

The warning is absent in a rebuilt Linux binary, global input remains functional, and the full test suite passes.