### PR TITLE
fix(linux): support Hyprland OCR capture and interactive annotation panels

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -361,6 +361,14 @@ resolves to a raw RGBA frame. It resolves to `null` when PoE is not the focused
 window - the capture is scoped to the game window and never grabs the rest of the
 desktop, other apps, or other monitors.
 
+On the Hyprland overlay backend, capture requires `grim` on `PATH`. Scalpel
+captures the game's logical rectangle directly, without a screen-sharing picker
+that could take input away from the game. It verifies compositor focus before
+and after the grab and discards the frame if focus changes. Captures retain up
+to 2160 pixels of vertical resolution for OCR; always use the returned `scale`
+when positioning annotations. A missing `grim` or failed capture returns `null`
+and is logged when `SCALPEL_DEBUG_LOG` is enabled.
+
 ```ts
 interface GameRect {
   x: number      // game CSS px from the game window's left edge

--- a/src/main/hotkeys.test.ts
+++ b/src/main/hotkeys.test.ts
@@ -53,6 +53,10 @@ const focusMockState: { scalpelBrowserWindowFocused: boolean } = {
   scalpelBrowserWindowFocused: false,
 }
 
+// Whether the compositor-driven overlay path is in charge. Mocked rather than
+// derived from the environment so no test shells out to hyprctl.
+const hyprlandMockState = { overlayActive: false }
+
 vi.mock('electron', () => ({
   globalShortcut: globalShortcutMock,
   clipboard: {
@@ -96,6 +100,11 @@ vi.mock('./windowing', () => ({
   isAnyScalpelBrowserWindowFocused: () => focusMockState.scalpelBrowserWindowFocused,
 }))
 
+vi.mock('./hyprland', () => ({
+  hyprlandOverlayActive: () => hyprlandMockState.overlayActive,
+  hyprlandInputAllowed: () => true,
+}))
+
 vi.mock('./diagnostics', () => ({
   guardNativeListener:
     (_label: string, fn: (...args: unknown[]) => void) =>
@@ -127,6 +136,7 @@ async function loadHotkeys(onEscape: () => void) {
   windowingMockState.hideFocusedOrAnyVisibleSecondaryOverlay.mockReset()
   windowingMockState.hideFocusedOrAnyVisibleSecondaryOverlay.mockReturnValue(false)
   focusMockState.scalpelBrowserWindowFocused = false
+  hyprlandMockState.overlayActive = false
 
   const hotkeys = await import('./hotkeys')
   hotkeys.startHotkeyListener(() => {})
@@ -141,6 +151,19 @@ function lastEscapeCallback(): () => void {
   if (!cb) throw new Error('Escape shortcut was never registered')
   return cb
 }
+
+describe('Hyprland dialog shortcut dismissal', () => {
+  it('uses the close handler instead of starting another filter lookup', async () => {
+    const close = vi.fn()
+    const hotkeys = await loadHotkeys(close)
+    hyprlandMockState.overlayActive = true
+    overlayControllerState.targetHasFocus = true
+    overlayMockState.visibilityListener?.(true)
+    hotkeys.setHotkey('Ctrl+C')
+    activeGlobalShortcuts.get('Ctrl+C')?.()
+    expect(close).toHaveBeenCalledOnce()
+  })
+})
 
 describe('Escape globalShortcut sync', () => {
   afterEach(() => {

--- a/src/main/hotkeys.test.ts
+++ b/src/main/hotkeys.test.ts
@@ -185,6 +185,34 @@ describe('Escape globalShortcut sync', () => {
     expect(globalShortcutMock.register).toHaveBeenCalledTimes(1)
   })
 
+  it('stays registered through the initial Hyprland dialog focus handoff', async () => {
+    const onEscape = vi.fn()
+    await loadHotkeys(onEscape)
+    hyprlandMockState.overlayActive = true
+    overlayControllerState.targetHasFocus = true
+    overlayMockState.visibilityListener?.(true)
+
+    overlayControllerState.targetHasFocus = false
+    overlayControllerState.events.emit('blur')
+
+    expect(globalShortcutMock.unregister).not.toHaveBeenCalled()
+    lastEscapeCallback()()
+    expect(onEscape).toHaveBeenCalledOnce()
+  })
+
+  it('closes from the uiohook path during the initial Hyprland dialog focus handoff', async () => {
+    const onEscape = vi.fn()
+    await loadHotkeys(onEscape)
+    hyprlandMockState.overlayActive = true
+    overlayControllerState.targetHasFocus = false
+    focusMockState.scalpelBrowserWindowFocused = false
+    overlayMockState.visibilityListener?.(true)
+
+    emitKeydown(ESCAPE_KEYDOWN)
+
+    expect(onEscape).toHaveBeenCalledOnce()
+  })
+
   it('unregisters on overlay hide and on game blur; re-registers on refocus while still visible', async () => {
     const onEscape = vi.fn()
     await loadHotkeys(onEscape)

--- a/src/main/hotkeys.ts
+++ b/src/main/hotkeys.ts
@@ -13,6 +13,7 @@ import {
 } from './diagnostics'
 import { getPoeVersion } from './game-state'
 import { focusGameWindow, isTypingInOverlay, setOverlayVisibilityListener } from './overlay'
+import { hyprlandInputAllowed, hyprlandOverlayActive } from './hyprland'
 import { advancedCopyTracker } from './trade/advanced-copy'
 import { hideFocusedOrAnyVisibleSecondaryOverlay, isAnyScalpelBrowserWindowFocused } from './windowing'
 
@@ -97,6 +98,10 @@ function fireTrigger(): void {
   if (now - lastTriggerFireAt < DEDUPE_MS) return
   lastTriggerFireAt = now
   releaseHotkeyKey(triggerCombo)
+  if (hyprlandOverlayActive() && overlayVisibleForEscape && onEscape) {
+    onEscape()
+    return
+  }
   if (onTrigger) onTrigger()
 }
 
@@ -106,6 +111,10 @@ function firePriceCheck(): void {
   if (now - lastPriceCheckFireAt < DEDUPE_MS) return
   lastPriceCheckFireAt = now
   releaseHotkeyKey(priceCheckCombo)
+  if (hyprlandOverlayActive() && overlayVisibleForEscape && onEscape) {
+    onEscape()
+    return
+  }
   if (onPriceCheck) onPriceCheck()
 }
 
@@ -275,7 +284,7 @@ export function startHotkeyListener(handler: () => void): void {
     guardNativeListener('wheel', (e) => {
       const modHeld =
         stashScrollModifier === 'Ctrl' ? e.ctrlKey : stashScrollModifier === 'Shift' ? e.shiftKey : e.altKey
-      if (!stashScrollEnabled || !modHeld || !OverlayController.targetHasFocus) return
+      if (!stashScrollEnabled || !modHeld || !OverlayController.targetHasFocus || !hyprlandInputAllowed()) return
       const tb = OverlayController.targetBounds
       if (!tb?.width) return
       // Only act when cursor is inside the PoE window but outside the stash grid area
@@ -400,7 +409,11 @@ function applySuspendTransition(wasSuspended: boolean, rearmReason: string): voi
  *  or one of Scalpel's gameplay overlays. Registration follows the same focus
  *  lifecycle, and this dispatch-time check closes uIOhook and transition races. */
 function hotkeyContextIsActive(): boolean {
-  return !hotkeysAreSuspended() && (OverlayController.targetHasFocus || isAnyScalpelBrowserWindowFocused())
+  return (
+    hyprlandInputAllowed() &&
+    !hotkeysAreSuspended() &&
+    (OverlayController.targetHasFocus || isAnyScalpelBrowserWindowFocused())
+  )
 }
 
 /** Idempotent: gameplay focus left PoE/Scalpel (PoE blur, overlay leave, boot).
@@ -662,10 +675,12 @@ const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms)
  *  the paste. targetHasFocus is the same signal that authorizes every gameplay
  *  hotkey (see hotkeyContextIsActive). */
 async function awaitGameFocus(): Promise<void> {
+  if (!hyprlandInputAllowed()) throw new Error('Game workspace is inactive - input not sent')
   if (OverlayController.targetHasFocus) return
   focusGameWindow()
   for (let waited = 0; waited < FOCUS_WAIT_MS; waited += FOCUS_POLL_MS) {
     await wait(FOCUS_POLL_MS)
+    if (!hyprlandInputAllowed()) throw new Error('Game workspace is inactive - input not sent')
     if (OverlayController.targetHasFocus) return
   }
   throw new Error('PoE did not take focus - chat command not sent')
@@ -1021,6 +1036,7 @@ function releaseCKeyedRegistrationsForInjection(): (() => void) | null {
  * releaseCKeyedRegistrationsForInjection (#601).
  */
 export async function sendCtrlCToPoE(opts?: { withAlt?: boolean }): Promise<void> {
+  if (!hyprlandInputAllowed()) return
   injecting = true
   const restoreCKeyedRegistrations = releaseCKeyedRegistrationsForInjection()
 

--- a/src/main/hotkeys.ts
+++ b/src/main/hotkeys.ts
@@ -122,7 +122,7 @@ function firePriceCheck(): void {
  *  registered by syncEscapeShortcut, and the uiohook fallback keydown branch
  *  below). Both can deliver for the same physical press - see DEDUPE_MS. */
 function fireEscape(): void {
-  if (injecting || isTypingInOverlay() || !hotkeyContextIsActive()) return
+  if (injecting || isTypingInOverlay() || !escapeContextIsActive()) return
   const now = Date.now()
   if (now - lastEscapeFireAt < DEDUPE_MS) return
   lastEscapeFireAt = now
@@ -138,7 +138,17 @@ function fireEscape(): void {
  *  Safe to call from anywhere - it's a no-op when the desired state already
  *  matches the registered state. */
 function syncEscapeShortcut(): void {
-  const desired = !!onEscape && overlayVisibleForEscape && OverlayController.targetHasFocus && !hotkeysAreSuspended()
+  // On Hyprland, activating the XWayland overlay takes focus away from PoE
+  // before Electron reliably reports the overlay BrowserWindow as focused.
+  // Keep Escape registered across that handoff; hyprlandInputAllowed() in
+  // escapeContextIsActive() still rejects delivery after leaving the gameplay
+  // context or switching workspace.
+  const ownsHyprlandDialog = hyprlandOverlayActive() && overlayVisibleForEscape
+  const desired =
+    !!onEscape &&
+    overlayVisibleForEscape &&
+    (OverlayController.targetHasFocus || ownsHyprlandDialog) &&
+    !hotkeysAreSuspended()
   if (desired === escapeShortcutRegistered) return
   if (desired) {
     try {
@@ -413,6 +423,20 @@ function hotkeyContextIsActive(): boolean {
     hyprlandInputAllowed() &&
     !hotkeysAreSuspended() &&
     (OverlayController.targetHasFocus || isAnyScalpelBrowserWindowFocused())
+  )
+}
+
+/** Escape must remain usable during Hyprland's PoE -> XWayland overlay focus
+ * handoff. Electron can report neither window focused until the first pointer
+ * interaction, while Hyprland already considers the visible overlay part of
+ * the active game context. Other hotkeys retain the stricter focus gate. */
+function escapeContextIsActive(): boolean {
+  return (
+    hyprlandInputAllowed() &&
+    !hotkeysAreSuspended() &&
+    (OverlayController.targetHasFocus ||
+      isAnyScalpelBrowserWindowFocused() ||
+      (hyprlandOverlayActive() && overlayVisibleForEscape))
   )
 }
 

--- a/src/main/hyprland-focus.test.ts
+++ b/src/main/hyprland-focus.test.ts
@@ -1,0 +1,48 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+import { hyprlandFocusScript } from './hyprland-focus'
+
+describe('Hyprland focus script', () => {
+  it('rejects invalid selectors before constructing Lua', () => {
+    expect(() => hyprlandFocusScript('bad"selector', '0x2', 1)).toThrow()
+    expect(() => hyprlandFocusScript('0x1', '0x2', 0)).toThrow()
+  })
+  // Exercise the actual generated callback when a Lua interpreter is available.
+  describe.skipIf(spawnSync('lua', ['-v']).status !== 0)('Lua handoff', () => {
+    for (const fail of [false, true]) {
+      it(`transfers pointer and keyboard focus and restores policies (failure=${fail})`, () => {
+        const script = `
+local config = { ["cursor.no_warps"] = false, ["input.follow_mouse"] = 1 }
+local target = { address = "0x1", workspace = { id = 2 } }
+local game = { address = "0x2", workspace = { id = 2 } }
+local dispatched = false
+hl = {
+  get_window = function(s) return s == "address:0x1" and target or game end,
+  get_active_window = function() return game end,
+  get_config = function(k) return config[k] end,
+  config = function(c)
+    config["cursor.no_warps"] = c.cursor.no_warps
+    config["input.follow_mouse"] = c.input.follow_mouse
+  end,
+  dsp = { focus = function(args) return args end },
+  dispatch = function(args)
+    assert(args.window == "address:0x1")
+    assert(config["cursor.no_warps"] == true)
+    assert(config["input.follow_mouse"] == 0)
+    dispatched = true
+    ${fail ? 'error("simulated failure")' : ''}
+  end,
+}
+local ok = pcall(function()
+${hyprlandFocusScript('0x1', '0x2', 10)}
+end)
+assert(ok == ${!fail})
+assert(dispatched)
+assert(config["cursor.no_warps"] == false)
+assert(config["input.follow_mouse"] == 1)
+`
+        expect(() => execFileSync('lua', ['-'], { input: script })).not.toThrow()
+      })
+    }
+  })
+})

--- a/src/main/hyprland-focus.ts
+++ b/src/main/hyprland-focus.ts
@@ -1,0 +1,34 @@
+/** Run the focus handoff and restore the user's cursor policy in one compositor
+ * callback. Separate IPC calls would leave a window for cursor warps or a stuck
+ * setting if Scalpel exits between them. */
+export function hyprlandFocusScript(targetAddress: string, gameAddress: string, pid: number): string {
+  if (
+    ![targetAddress, gameAddress].every((address) => /^0x[0-9a-f]+$/i.test(address)) ||
+    !Number.isSafeInteger(pid) ||
+    pid <= 0
+  ) {
+    throw new Error('Invalid Hyprland focus target')
+  }
+  return `
+local target = hl.get_window("address:${targetAddress}")
+local game = hl.get_window("address:${gameAddress}")
+local active = hl.get_active_window()
+if not target or not game or not active then return end
+if active.workspace.id ~= game.workspace.id or target.workspace.id ~= game.workspace.id then return end
+if active.address ~= game.address and not (active.pid == ${pid} and active.title:match("^Scalpel Overlay")) then return end
+if active.address == target.address then return end
+local original = hl.get_config("cursor.no_warps")
+local followMouse = hl.get_config("input.follow_mouse")
+if type(original) ~= "boolean" then error("Cannot read cursor warp policy") end
+if type(followMouse) ~= "number" then error("Cannot read pointer focus policy") end
+-- In Hyprland 0.56, rawWindowFocus only sends pointer enter to the new
+-- surface when follow_mouse is 0. Otherwise keyboard focus changes but
+-- pointer focus waits for physical movement (Alt-Tab uses a different path).
+hl.config({ cursor = { no_warps = true }, input = { follow_mouse = 0 } })
+local ok, err = pcall(function()
+  hl.dispatch(hl.dsp.focus({ window = "address:${targetAddress}" }))
+end)
+hl.config({ cursor = { no_warps = original }, input = { follow_mouse = followMouse } })
+if not ok then error(err) end
+`
+}

--- a/src/main/hyprland-policy.test.ts
+++ b/src/main/hyprland-policy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import {
+  type HyprClient,
+  hyprlandOverlayBounds,
+  hyprlandVersionAtLeast,
+  isHyprlandGameContext,
+} from './hyprland-policy'
+
+const game: HyprClient = {
+  address: '0x1',
+  pid: 10,
+  title: 'Path of Exile 2',
+  workspace: { id: 2 },
+  at: [0, 0],
+  size: [2400, 1350],
+  floating: true,
+}
+describe('Hyprland input ownership', () => {
+  it('converts fractional Hyprland scaling to Electron DIP without clipping', () => {
+    expect(hyprlandOverlayBounds(game, { x: 0, y: 0, scale: 1.6 }, { bounds: { x: 0, y: 0 }, scaleFactor: 2 })).toEqual(
+      {
+        dip: { x: 0, y: 0, width: 1920, height: 1080 },
+        physical: { x: 0, y: 0, width: 3840, height: 2160 },
+      },
+    )
+  })
+  it('allows the focused game', () => expect(isHyprlandGameContext(game, game, 20)).toBe(true))
+  it('allows our overlay on the game workspace', () => {
+    expect(isHyprlandGameContext({ ...game, address: '0x2', pid: 20, title: 'Scalpel Overlay' }, game, 20)).toBe(true)
+  })
+  it('rejects our overlay on another workspace', () => {
+    expect(
+      isHyprlandGameContext(
+        { ...game, address: '0x2', pid: 20, title: 'Scalpel Overlay', workspace: { id: 1 } },
+        game,
+        20,
+      ),
+    ).toBe(false)
+  })
+  it('rejects other applications, settings, and missing compositor state', () => {
+    expect(isHyprlandGameContext({ ...game, address: '0x3', pid: 30 }, game, 20)).toBe(false)
+    expect(isHyprlandGameContext({ ...game, address: '0x3', pid: 20, title: 'Scalpel' }, game, 20)).toBe(false)
+    expect(isHyprlandGameContext(null, game, 20)).toBe(false)
+    expect(isHyprlandGameContext(game, null, 20)).toBe(false)
+  })
+})
+
+describe('Hyprland version gate', () => {
+  const version = (tag: string) => JSON.stringify({ branch: 'main', tag })
+  it('accepts the minimum release and newer', () => {
+    expect(hyprlandVersionAtLeast(version('v0.56.0'))).toBe(true)
+    expect(hyprlandVersionAtLeast(version('v0.57.1'))).toBe(true)
+    expect(hyprlandVersionAtLeast(version('v1.0.0'))).toBe(true)
+  })
+  it('accepts -git builds of the minimum release', () => {
+    expect(hyprlandVersionAtLeast(version('v0.56.0-13-gdeadbee'))).toBe(true)
+  })
+  it('rejects older releases', () => {
+    expect(hyprlandVersionAtLeast(version('v0.55.9'))).toBe(false)
+    expect(hyprlandVersionAtLeast(version('v0.9.0'))).toBe(false)
+  })
+  it('fails closed on output it cannot read', () => {
+    expect(hyprlandVersionAtLeast('not json')).toBe(false)
+    expect(hyprlandVersionAtLeast(version('unknown'))).toBe(false)
+    expect(hyprlandVersionAtLeast('{}')).toBe(false)
+  })
+})

--- a/src/main/hyprland-policy.ts
+++ b/src/main/hyprland-policy.ts
@@ -1,0 +1,62 @@
+export interface HyprClient {
+  address: string
+  pid: number
+  title: string
+  workspace: { id: number }
+  at: [number, number]
+  size: [number, number]
+  floating: boolean
+  monitor?: number
+}
+
+/** Oldest Hyprland this overlay path is exercised against. Earlier releases
+ *  lack the `hyprctl eval` Lua API it drives (hl.get_config, hl.dsp.*) and keep
+ *  using the X11 tracker, which is what they run today. */
+export const MIN_HYPRLAND: readonly [number, number, number] = [0, 56, 0]
+
+/** `hyprctl -j version` reports tags like "v0.56.0", or "v0.56.0-13-gdeadbee"
+ *  for -git builds. Unreadable output fails closed: keep the X11 tracker rather
+ *  than drive a compositor whose capabilities we couldn't confirm. */
+export function hyprlandVersionAtLeast(versionJson: string, min = MIN_HYPRLAND): boolean {
+  let tag: unknown
+  try {
+    tag = (JSON.parse(versionJson) as { tag?: unknown }).tag
+  } catch {
+    return false
+  }
+  const parsed = typeof tag === 'string' ? /^v?(\d+)\.(\d+)\.(\d+)/.exec(tag) : null
+  if (!parsed) return false
+  for (const [index, bound] of min.entries()) {
+    const part = Number(parsed[index + 1])
+    if (part !== bound) return part > bound
+  }
+  return true
+}
+
+export function hyprlandOverlayBounds(
+  client: HyprClient,
+  monitor: { x: number; y: number; scale: number },
+  display: { bounds: { x: number; y: number }; scaleFactor: number },
+) {
+  const ratio = monitor.scale / display.scaleFactor
+  const dip = {
+    x: Math.round(display.bounds.x + (client.at[0] - monitor.x) * ratio),
+    y: Math.round(display.bounds.y + (client.at[1] - monitor.y) * ratio),
+    width: Math.round(client.size[0] * ratio),
+    height: Math.round(client.size[1] * ratio),
+  }
+  return {
+    dip,
+    physical: {
+      x: Math.round(dip.x * display.scaleFactor),
+      y: Math.round(dip.y * display.scaleFactor),
+      width: Math.round(client.size[0] * monitor.scale),
+      height: Math.round(client.size[1] * monitor.scale),
+    },
+  }
+}
+
+export function isHyprlandGameContext(active: HyprClient | null, game: HyprClient | null, pid: number): boolean {
+  if (!active?.address || !game?.address || active.workspace?.id !== game.workspace.id) return false
+  return active.address === game.address || (active.pid === pid && active.title.startsWith('Scalpel Overlay'))
+}

--- a/src/main/hyprland.ts
+++ b/src/main/hyprland.ts
@@ -1,0 +1,250 @@
+import { execFile, execFileSync } from 'node:child_process'
+import { promisify } from 'node:util'
+import { createConnection } from 'node:net'
+import { join } from 'node:path'
+import { app, type BrowserWindow, screen } from 'electron'
+import { OverlayController } from 'electron-overlay-window'
+import {
+  type HyprClient,
+  MIN_HYPRLAND,
+  hyprlandOverlayBounds,
+  hyprlandVersionAtLeast,
+  isHyprlandGameContext,
+} from './hyprland-policy'
+import { hyprlandFocusScript } from './hyprland-focus'
+
+const isHyprland = process.platform === 'linux' && !!process.env.HYPRLAND_INSTANCE_SIGNATURE
+const exec = promisify(execFile)
+let game: HyprClient | null = null
+let tracking = false
+let overlayActive: boolean | null = null
+
+/** Whether to drive the compositor instead of the native X11 tracker. Resolved
+ *  once, on first use: the version query costs a subprocess, and Hyprland can't
+ *  be swapped underneath a running process. */
+export function hyprlandOverlayActive(): boolean {
+  if (!isHyprland) return false
+  if (overlayActive === null) {
+    try {
+      overlayActive = hyprlandVersionAtLeast(
+        execFileSync('hyprctl', ['-j', 'version'], { encoding: 'utf8', timeout: 1000 }),
+      )
+      if (!overlayActive) console.warn(`[hyprland] older than ${MIN_HYPRLAND.join('.')}; using the X11 overlay tracker`)
+    } catch (error) {
+      overlayActive = false
+      console.warn('[hyprland] version query failed; using the X11 overlay tracker:', String(error))
+    }
+  }
+  return overlayActive
+}
+
+// Native X11 focus can remain stale when focus moves to a Wayland client.
+// Recheck with the compositor at the point of input/focus dispatch; fail closed.
+// Off the Hyprland path `tracking` is never set, so this stays a no-op.
+export function hyprlandInputAllowed(): boolean {
+  if (!tracking) return true
+  try {
+    const active = JSON.parse(execFileSync('hyprctl', ['-j', 'activewindow'], { encoding: 'utf8', timeout: 500 }))
+    return isHyprlandGameContext(active, game, process.pid)
+  } catch {
+    return false
+  }
+}
+
+export function nameHyprlandOverlay(win: BrowserWindow): void {
+  if (!hyprlandOverlayActive()) return
+  win.setTitle('Scalpel Overlay')
+  win.on('page-title-updated', (event, title) => {
+    event.preventDefault()
+    win.setTitle(`Scalpel Overlay: ${title}`)
+  })
+}
+
+/** Hyprland owns workspace, focus and logical geometry. Avoid the native X11
+ * override-redirect window and direct xcb_set_input_focus entirely here. */
+export function attachHyprlandOverlay(win: BrowserWindow, initialTitles: string[]): void {
+  tracking = true
+  let titles = initialTitles
+  let lastAddress = ''
+  let overlayAddress = ''
+  let focusRequestedUntil = 0
+  let focusConfirmedSince = 0
+  let lastGeometry = ''
+  let lastFocused = false
+  let lastContextActive = false
+  let stopped = false
+  let busy = false
+  let dirty = false
+  let eventsConnected = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const dispatch = async (expression: string) => {
+    const result = await exec('hyprctl', ['dispatch', expression], { timeout: 1000 })
+    if (result.stdout.startsWith('error:')) throw new Error(result.stdout)
+  }
+  OverlayController.activateOverlay = () => {
+    if (!hyprlandInputAllowed() || win.isDestroyed()) return
+    focusRequestedUntil = Date.now() + 1500
+    focusConfirmedSince = 0
+    win.setIgnoreMouseEvents(false)
+    if (timer) clearTimeout(timer)
+    if (busy) dirty = true
+    else timer = setTimeout(poll, 0)
+  }
+  OverlayController.focusTarget = () => {
+    focusRequestedUntil = 0
+    focusConfirmedSince = 0
+    if (!hyprlandInputAllowed() || !game) return
+    if (!/^0x[0-9a-f]+$/i.test(game.address)) return
+    try {
+      execFileSync('hyprctl', ['eval', hyprlandFocusScript(game.address, game.address, process.pid)], {
+        timeout: 1000,
+      })
+      win.setIgnoreMouseEvents(true)
+    } catch (error) {
+      console.warn('[hyprland] game focus handoff failed:', String(error))
+    }
+  }
+  OverlayController.setTargetTitles = (next) => {
+    titles = next
+  }
+  OverlayController.clearTarget = () => {
+    titles = []
+  }
+
+  const poll = async () => {
+    if (stopped || busy || win.isDestroyed()) return
+    busy = true
+    try {
+      const [clientResult, activeResult, monitorResult] = await Promise.all([
+        exec('hyprctl', ['-j', 'clients'], { timeout: 1000 }),
+        exec('hyprctl', ['-j', 'activewindow'], { timeout: 1000 }),
+        exec('hyprctl', ['-j', 'monitors'], { timeout: 1000 }),
+      ])
+      if (stopped || win.isDestroyed()) return
+      const clients: HyprClient[] = JSON.parse(clientResult.stdout)
+      overlayAddress = clients.find((c) => c.pid === process.pid && c.title === win.getTitle())?.address ?? ''
+      const active: HyprClient = JSON.parse(activeResult.stdout)
+      game =
+        clients.find((c) => c.address === active.address && titles.includes(c.title)) ??
+        clients.find((c) => c.address === lastAddress && titles.includes(c.title)) ??
+        clients.find((c) => titles.includes(c.title)) ??
+        null
+      if (!game) {
+        if (lastAddress) OverlayController.events.emit('detach')
+        lastAddress = ''
+        lastGeometry = ''
+      } else {
+        const monitors: Array<{ id: number; name: string; x: number; y: number; scale: number }> = JSON.parse(
+          monitorResult.stdout,
+        )
+        const monitor = monitors.find((m) => m.id === game?.monitor)
+        if (!monitor) throw new Error('Game monitor is unavailable')
+        const display =
+          screen.getAllDisplays().find((d) => d.label === monitor.name) ??
+          screen.getDisplayNearestPoint({ x: monitor.x, y: monitor.y })
+        const { dip: bounds, physical } = hyprlandOverlayBounds(game, monitor, display)
+        const geometry = JSON.stringify(bounds)
+        if (game.address !== lastAddress) {
+          OverlayController.events.emit('attach', { ...physical, titleIndex: titles.indexOf(game.title) })
+        } else if (geometry !== lastGeometry) {
+          OverlayController.events.emit('moveresize', physical)
+        }
+        lastAddress = game.address
+
+        // Move only our gameplay overlays, never Scalpel's settings window or
+        // the game itself. Silent moves must not switch the user's workspace.
+        for (const overlay of clients.filter((c) => c.pid === process.pid && c.title.startsWith('Scalpel Overlay'))) {
+          if (!/^0x[0-9a-f]+$/i.test(overlay.address)) continue
+          if (!overlay.floating)
+            await dispatch(`hl.dsp.window.float({ window = "address:${overlay.address}", action = "set" })`)
+          if (overlay.workspace.id !== game.workspace.id) {
+            if (!Number.isInteger(game.workspace.id)) continue
+            await dispatch(
+              `hl.dsp.window.move({ window = "address:${overlay.address}", workspace = "${game.workspace.id}", follow = false })`,
+            )
+          }
+        }
+        if (!win.isDestroyed() && geometry !== lastGeometry) win.setBounds(bounds)
+        lastGeometry = geometry
+      }
+      const contextActive = isHyprlandGameContext(active, game, process.pid)
+      const focused = !!game && active.address === game.address
+      if (focused !== lastFocused || OverlayController.targetHasFocus !== focused) {
+        OverlayController.events.emit(focused ? 'focus' : 'blur')
+      } else if (lastContextActive && !contextActive) {
+        // Leaving a focused overlay must hide it too, even though the game
+        // had already lost focus when the pointer entered that overlay.
+        OverlayController.events.emit('blur')
+      }
+      lastFocused = focused
+      lastContextActive = contextActive
+      if (!contextActive) focusRequestedUntil = 0
+      if (active.address === overlayAddress && win.isFocused()) {
+        focusConfirmedSince ||= Date.now()
+        if (Date.now() - focusConfirmedSince >= 100) focusRequestedUntil = 0
+      } else focusConfirmedSince = 0
+      if (focusRequestedUntil > Date.now() && overlayAddress && game && win.isVisible()) {
+        // Never trust Electron's cached X11 focus. Resolve the compositor window
+        // after mapping/workspace placement and check context again inside Lua.
+        execFileSync('hyprctl', ['eval', hyprlandFocusScript(overlayAddress, game.address, process.pid)], {
+          timeout: 1000,
+        })
+      }
+    } catch (error) {
+      game = null
+      if (lastContextActive || lastFocused || OverlayController.targetHasFocus) OverlayController.events.emit('blur')
+      lastFocused = false
+      lastContextActive = false
+      console.warn('[hyprland] overlay tracking failed:', String(error))
+    } finally {
+      busy = false
+      if (!stopped)
+        timer = setTimeout(poll, dirty || focusRequestedUntil > Date.now() ? 25 : eventsConnected ? 2000 : 250)
+      dirty = false
+    }
+  }
+  const stop = () => {
+    stopped = true
+    if (timer) clearTimeout(timer)
+    socket.destroy()
+    game = null
+  }
+  win.once('closed', stop)
+  app.once('before-quit', stop)
+  // React promptly to workspace/focus changes without spawning compositor
+  // queries continuously during gameplay. Periodic refresh covers geometry
+  // changes for which the event socket doesn't provide coordinates.
+  const socket = createConnection(
+    join(
+      process.env.XDG_RUNTIME_DIR ?? `/run/user/${process.getuid?.()}`,
+      'hypr',
+      process.env.HYPRLAND_INSTANCE_SIGNATURE!,
+      '.socket2.sock',
+    ),
+  )
+  socket.on('connect', () => {
+    eventsConnected = true
+  })
+  socket.on('error', () => {
+    eventsConnected = false
+  })
+  socket.on('close', () => {
+    eventsConnected = false
+  })
+  socket.on('data', (data) => {
+    if (
+      !/(activewindow|workspace|movewindow|openwindow|closewindow|monitor|fullscreen|windowtitle|changefloatingmode|configreloaded)/.test(
+        data.toString(),
+      )
+    )
+      return
+    if (busy) {
+      dirty = true
+      return
+    }
+    if (timer) clearTimeout(timer)
+    timer = setTimeout(poll, 25)
+  })
+  void poll()
+}

--- a/src/main/hyprland.ts
+++ b/src/main/hyprland.ts
@@ -16,6 +16,32 @@ import { hyprlandFocusScript } from './hyprland-focus'
 const isHyprland = process.platform === 'linux' && !!process.env.HYPRLAND_INSTANCE_SIGNATURE
 const exec = promisify(execFile)
 let game: HyprClient | null = null
+let gameDipBounds: Electron.Rectangle | null = null
+
+export function getHyprlandGame(): HyprClient | null {
+  return game
+}
+
+export function getHyprlandGameBounds(): Electron.Rectangle | null {
+  return gameDipBounds
+}
+
+/** uiohook's XWayland coordinates need not be physical monitor pixels. Match
+ * pointer hit testing to the same compositor geometry used for annotations. */
+export function getHyprlandPointerPhysical(): Electron.Point | null {
+  const bounds = OverlayController.targetBounds
+  if (!game || !bounds?.width || game.size[0] <= 0 || game.size[1] <= 0) return null
+  try {
+    const point = JSON.parse(execFileSync('hyprctl', ['-j', 'cursorpos'], { encoding: 'utf8', timeout: 500 }))
+    return {
+      x: bounds.x + ((point.x - game.at[0]) * bounds.width) / game.size[0],
+      y: bounds.y + ((point.y - game.at[1]) * bounds.height) / game.size[1],
+    }
+  } catch {
+    return null
+  }
+}
+
 let tracking = false
 let overlayActive: boolean | null = null
 
@@ -58,6 +84,23 @@ export function nameHyprlandOverlay(win: BrowserWindow): void {
     event.preventDefault()
     win.setTitle(`Scalpel Overlay: ${title}`)
   })
+}
+
+/** Secondary annotation panels need the same pointer + keyboard handoff as
+ * the main dialog. Changing the X11 input shape alone does not transfer
+ * Hyprland's pointer focus away from the fullscreen game. */
+export function focusHyprlandPanel(win: BrowserWindow): void {
+  if (!hyprlandInputAllowed() || !game || win.isDestroyed()) return
+  try {
+    const clients: HyprClient[] = JSON.parse(
+      execFileSync('hyprctl', ['-j', 'clients'], { encoding: 'utf8', timeout: 1000 }),
+    )
+    const target = clients.find((c) => c.pid === process.pid && c.title === win.getTitle())
+    if (!target) return
+    execFileSync('hyprctl', ['eval', hyprlandFocusScript(target.address, game.address, process.pid)], { timeout: 1000 })
+  } catch (error) {
+    console.warn('[hyprland] annotation focus handoff failed:', String(error))
+  }
 }
 
 /** Hyprland owns workspace, focus and logical geometry. Avoid the native X11
@@ -131,6 +174,7 @@ export function attachHyprlandOverlay(win: BrowserWindow, initialTitles: string[
         clients.find((c) => titles.includes(c.title)) ??
         null
       if (!game) {
+        gameDipBounds = null
         if (lastAddress) OverlayController.events.emit('detach')
         lastAddress = ''
         lastGeometry = ''
@@ -144,6 +188,7 @@ export function attachHyprlandOverlay(win: BrowserWindow, initialTitles: string[
           screen.getAllDisplays().find((d) => d.label === monitor.name) ??
           screen.getDisplayNearestPoint({ x: monitor.x, y: monitor.y })
         const { dip: bounds, physical } = hyprlandOverlayBounds(game, monitor, display)
+        gameDipBounds = bounds
         const geometry = JSON.stringify(bounds)
         if (game.address !== lastAddress) {
           OverlayController.events.emit('attach', { ...physical, titleIndex: titles.indexOf(game.title) })
@@ -193,6 +238,7 @@ export function attachHyprlandOverlay(win: BrowserWindow, initialTitles: string[
       }
     } catch (error) {
       game = null
+      gameDipBounds = null
       if (lastContextActive || lastFocused || OverlayController.targetHasFocus) OverlayController.events.emit('blur')
       lastFocused = false
       lastContextActive = false
@@ -209,6 +255,7 @@ export function attachHyprlandOverlay(win: BrowserWindow, initialTitles: string[
     if (timer) clearTimeout(timer)
     socket.destroy()
     game = null
+    gameDipBounds = null
   }
   win.once('closed', stop)
   app.once('before-quit', stop)

--- a/src/main/overlay-manual-focus.test.ts
+++ b/src/main/overlay-manual-focus.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mock = vi.hoisted(() => ({
+  mouse: {} as Record<string, (event: { x: number; y: number }) => void>,
+  ipc: {} as Record<string, (...args: any[]) => void>,
+  ignore: vi.fn(),
+  activate: vi.fn(),
+  focus: vi.fn(),
+  unmap: vi.fn(),
+  allowed: true,
+}))
+vi.mock('electron', () => ({
+  BrowserWindow: class {
+    static fromWebContents() {
+      return window
+    }
+    setIgnoreMouseEvents = mock.ignore
+    webContents = { send: vi.fn(), id: 1 }
+    on = vi.fn()
+    loadFile = vi.fn()
+    setAlwaysOnTop = vi.fn()
+    setOpacity = vi.fn()
+    setSkipTaskbar = vi.fn()
+    hide = mock.unmap
+    showInactive = vi.fn()
+    isVisible = () => true
+    isDestroyed = () => false
+  },
+  ipcMain: {
+    on: (name: string, cb: any) => {
+      mock.ipc[name] = cb
+    },
+    handle: vi.fn(),
+  },
+  screen: { getDisplayNearestPoint: () => ({ scaleFactor: 1 }), getPrimaryDisplay: () => ({ scaleFactor: 1 }) },
+  webContents: {},
+}))
+vi.mock('electron-overlay-window', () => ({
+  OVERLAY_WINDOW_OPTS: {},
+  OverlayController: {
+    targetHasFocus: true,
+    targetBounds: { x: 0, y: 0, width: 1000, height: 800 },
+    events: { on: vi.fn() },
+    activateOverlay: mock.activate,
+    focusTarget: mock.focus,
+  },
+}))
+vi.mock('uiohook-napi', () => ({
+  uIOhook: {
+    on: (name: string, cb: any) => {
+      mock.mouse[name] = cb
+    },
+  },
+}))
+vi.mock('./hyprland', () => ({
+  hyprlandOverlayActive: () => true,
+  hyprlandInputAllowed: () => mock.allowed,
+  nameHyprlandOverlay: vi.fn(),
+  attachHyprlandOverlay: vi.fn(),
+}))
+vi.mock('./diagnostics', () => ({
+  guardNativeListener: (_: string, cb: any) => cb,
+  registerDiagnosticProvider: vi.fn(),
+}))
+vi.mock('./client-log', () => ({ startClientLogWatcher: vi.fn() }))
+vi.mock('./game-state', () => ({ getPoeVersion: () => 2, setPoeVersion: vi.fn() }))
+vi.mock('./tier-data', () => ({ loadTierData: async () => {}, refreshTierData: async () => {} }))
+vi.mock('./premium-mods', () => ({ loadPremiumMods: async () => {}, refreshPremiumMods: async () => {} }))
+vi.mock('./trade/endgame-filter-support', () => ({
+  loadEndgameFilterSupport: async () => {},
+  refreshEndgameFilterSupport: async () => {},
+}))
+vi.mock('./windowing', () => ({
+  closeAllOverlaysOnPoeExit: vi.fn(),
+  isAnyScalpelWindowFocused: () => false,
+  isInsideAnySecondaryOverlay: () => false,
+}))
+vi.mock('./whiteboard', () => ({ getWhiteboardOverlay: () => null }))
+
+import { createOverlayWindow, hideOverlay, showOverlay, setCloseOnClickOutside } from './overlay'
+let window: ReturnType<typeof createOverlayWindow>
+
+describe('Hyprland manual dialog focus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mock.allowed = true
+    window = createOverlayWindow(2)
+    setCloseOnClickOutside(false)
+    showOverlay()
+    mock.ipc['report-panel-rect']({ sender: { id: 1 } }, { left: 100, top: 100, width: 200, height: 200 })
+  })
+  afterEach(() => {
+    hideOverlay()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+  it('explicitly requests focus on open without waiting for mouse movement', () => {
+    expect(mock.activate).toHaveBeenCalledOnce()
+    expect(mock.ignore).toHaveBeenLastCalledWith(false)
+  })
+  it('does not release focus when moving outside or dragging past stale panel bounds', async () => {
+    mock.mouse.mousemove({ x: 150, y: 150 })
+    mock.mouse.mousedown({ x: 150, y: 150 })
+    mock.mouse.mousemove({ x: 900, y: 700 })
+    await vi.advanceTimersByTimeAsync(100)
+    expect(mock.focus).not.toHaveBeenCalled()
+    expect(mock.ignore).toHaveBeenLastCalledWith(false)
+  })
+  it('dismisses on outside click even when the legacy preference is disabled', () => {
+    mock.mouse.mousedown({ x: 900, y: 700 })
+    expect(mock.focus).toHaveBeenCalledOnce()
+    expect(mock.focus.mock.invocationCallOrder[0]).toBeLessThan(mock.ignore.mock.invocationCallOrder.at(-1)!)
+    expect(mock.ignore).toHaveBeenLastCalledWith(true)
+  })
+  it('keeps input while dropdowns unlock and panel reports are refreshed', () => {
+    mock.ipc['unlock-interactive']()
+    mock.ipc['clear-panel-rect']({ sender: { id: 1 } })
+    expect(mock.ignore).toHaveBeenLastCalledWith(false)
+    expect(mock.focus).not.toHaveBeenCalled()
+  })
+  it('does not react to clicks in an unrelated workspace', () => {
+    mock.allowed = false
+    mock.mouse.mousedown({ x: 900, y: 700 })
+    expect(mock.focus).not.toHaveBeenCalled()
+  })
+  it('does not reactivate a dismissed panel before its renderer clears the old rects', () => {
+    hideOverlay()
+    expect(mock.unmap).toHaveBeenCalledOnce()
+    expect(window.isVisible()).toBe(false)
+    mock.activate.mockClear()
+    mock.mouse.mousemove({ x: 150, y: 150 })
+    expect(mock.activate).not.toHaveBeenCalled()
+    expect(mock.ignore).toHaveBeenLastCalledWith(true)
+  })
+  it('maps the dialog again after a deliberate dismissal', () => {
+    hideOverlay()
+    showOverlay()
+    expect(window.isVisible()).toBe(true)
+    expect(mock.activate).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/overlay-manual-focus.test.ts
+++ b/src/main/overlay-manual-focus.test.ts
@@ -8,11 +8,14 @@ const mock = vi.hoisted(() => ({
   focus: vi.fn(),
   unmap: vi.fn(),
   allowed: true,
+  panelFocus: vi.fn(),
+  pointer: { x: 150, y: 150 },
+  secondary: null as any,
 }))
 vi.mock('electron', () => ({
   BrowserWindow: class {
-    static fromWebContents() {
-      return window
+    static fromWebContents(sender: { id: number }) {
+      return sender.id === 2 ? mock.secondary : window
     }
     setIgnoreMouseEvents = mock.ignore
     webContents = { send: vi.fn(), id: 1 }
@@ -57,6 +60,9 @@ vi.mock('./hyprland', () => ({
   hyprlandInputAllowed: () => mock.allowed,
   nameHyprlandOverlay: vi.fn(),
   attachHyprlandOverlay: vi.fn(),
+  focusHyprlandPanel: mock.panelFocus,
+  getHyprlandPointerPhysical: () => mock.pointer,
+  getHyprlandGameBounds: () => ({ x: 0, y: 0, width: 1000, height: 800 }),
 }))
 vi.mock('./diagnostics', () => ({
   guardNativeListener: (_: string, cb: any) => cb,
@@ -138,5 +144,29 @@ describe('Hyprland manual dialog focus', () => {
     showOverlay()
     expect(window.isVisible()).toBe(true)
     expect(mock.activate).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('Hyprland annotation interaction', () => {
+  it('focuses a secondary panel on hover and returns focus to the game on exit', async () => {
+    vi.useFakeTimers()
+    mock.allowed = true
+    mock.secondary = { isDestroyed: () => false, isVisible: () => true, setIgnoreMouseEvents: vi.fn() }
+    mock.panelFocus.mockClear()
+    mock.focus.mockClear()
+    mock.ipc['report-panel-rect']({ sender: { id: 2 } }, { left: 100, top: 100, width: 200, height: 200 })
+    mock.pointer = { x: 150, y: 150 }
+    await vi.advanceTimersByTimeAsync(100)
+    mock.mouse.mousemove({ x: 2500, y: 2500 })
+    expect(mock.panelFocus).toHaveBeenCalledWith(mock.secondary)
+    expect(mock.secondary.setIgnoreMouseEvents).toHaveBeenLastCalledWith(false)
+    await vi.advanceTimersByTimeAsync(40)
+    mock.pointer = { x: 900, y: 700 }
+    mock.mouse.mousemove({ x: 150, y: 150 })
+    await vi.advanceTimersByTimeAsync(60)
+    expect(mock.secondary.setIgnoreMouseEvents).toHaveBeenLastCalledWith(true)
+    expect(mock.focus).toHaveBeenCalledOnce()
+    mock.ipc['clear-panel-rect']({ sender: { id: 2 } })
+    vi.useRealTimers()
   })
 })

--- a/src/main/overlay.ts
+++ b/src/main/overlay.ts
@@ -13,8 +13,10 @@ import { getWhiteboardOverlay } from './whiteboard'
 import { POE_SIDEBAR_RATIO } from '@shared/poe-geometry'
 import { GAME_TITLES } from '@shared/contracts/game-variant'
 import { IPC_CHANNELS } from '@shared/contracts/ipc'
+import { attachHyprlandOverlay, hyprlandInputAllowed, hyprlandOverlayActive, nameHyprlandOverlay } from './hyprland'
 
 let overlayWindow: BrowserWindow | null = null
+let unmapHyprlandDialog: (() => void) | null = null
 let overlayVisible = false
 let mouseOverPanel = false
 let closeOnClickOutside = false
@@ -76,9 +78,13 @@ function flatPanelRects(): PhysRect[] {
 /** Return the window that owns the topmost rect containing (x, y), or null. */
 function windowAtPoint(x: number, y: number): BrowserWindow | null {
   for (const entry of panelRectsBySender.values()) {
+    // A hidden window keeps its last reported rects until its renderer clears
+    // them, and must not be made interactive on the strength of stale geometry.
+    if (entry.win.isDestroyed() || !entry.win.isVisible()) continue
+    if (hyprlandOverlayActive() && entry.win === overlayWindow && !overlayVisible) continue
     for (const r of entry.rects) {
       if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
-        return entry.win.isDestroyed() ? null : entry.win
+        return entry.win
       }
     }
   }
@@ -124,7 +130,7 @@ ipcMain.on('clear-panel-rect', (event) => {
   // unmount time).
   if (entry && !entry.win.isDestroyed()) {
     try {
-      entry.win.setIgnoreMouseEvents(true)
+      entry.win.setIgnoreMouseEvents(!(hyprlandOverlayActive() && overlayVisible && entry.win === overlayWindow))
     } catch {}
   }
   if (currentInteractiveWindow === entry?.win) currentInteractiveWindow = null
@@ -154,6 +160,7 @@ ipcMain.on('lock-interactive', () => {
 })
 ipcMain.on('unlock-interactive', () => {
   interactiveLocked = false
+  if (hyprlandOverlayActive() && overlayVisible) return
   // Re-evaluate based on current mouse position
   if (!mouseOverPanel) setInteractive(false)
 })
@@ -173,6 +180,8 @@ let currentInteractiveWindow: BrowserWindow | null = null
  *  Setting a different window to interactive automatically reverts the prior
  *  one to click-through, so we never end up with two windows competing. */
 function setInteractiveWindow(win: BrowserWindow | null): void {
+  if (hyprlandOverlayActive() && overlayVisible && win !== overlayWindow) return
+  if (!hyprlandInputAllowed()) return
   if (currentInteractiveWindow === win) return
   // Revert prior window to click-through.
   const prev = currentInteractiveWindow
@@ -226,6 +235,9 @@ let exitTimer: ReturnType<typeof setTimeout> | null = null
 uIOhook.on(
   'mousemove',
   guardNativeListener('mousemove', (e) => {
+    // A dialog owns input until explicitly dismissed. Hit-test updates can lag
+    // behind dragging; neither leaving a rect nor stale geometry may release it.
+    if (hyprlandOverlayActive() && overlayVisible) return
     // No rects reported yet -- skip hit testing. (Whiteboard registers its own
     // rects independently of the main overlay's `overlayVisible` flag.)
     if (panelRectsBySender.size === 0) return
@@ -256,6 +268,7 @@ uIOhook.on(
   'mousedown',
   guardNativeListener('mousedown-overlay', (e) => {
     if (!overlayVisible) return
+    if (!hyprlandInputAllowed()) return
     // Only process clicks if the overlay window is actually visible on screen
     if (!overlayWindow || overlayWindow.isDestroyed() || !overlayWindow.isVisible()) return
     if (!isInsidePanel(e.x, e.y)) {
@@ -266,6 +279,10 @@ uIOhook.on(
       // panel rect, so every click on it looks like a click "outside". Bail so we don't
       // disable interactivity (click-through to PoE) or close the overlay.
       if (interactiveLocked) return
+      if (hyprlandOverlayActive()) {
+        hideOverlay()
+        return
+      }
       // Ensure click-through is enabled so the click reaches the game
       if (mouseOverPanel) {
         mouseOverPanel = false
@@ -325,6 +342,7 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
       contextIsolation: true,
     },
   })
+  nameHyprlandOverlay(overlayWindow)
 
   if (process.env.ELECTRON_RENDERER_URL) {
     overlayWindow.loadURL(process.env.ELECTRON_RENDERER_URL)
@@ -337,25 +355,37 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
 
   overlayWindow.on('closed', () => {
     overlayWindow = null
+    unmapHyprlandDialog = null
   })
 
   // Prevent Windows show/hide animation by using opacity instead of hide/show.
   // electron-overlay-window calls hide()/showInactive() on focus changes, which
   // triggers the OS zoom animation. We intercept to use opacity instead.
   const origShowInactive = overlayWindow.showInactive.bind(overlayWindow)
+  const origHide = overlayWindow.hide.bind(overlayWindow)
   let opacityHidden = false
+  unmapHyprlandDialog = () => {
+    origHide()
+    opacityHidden = true
+  }
 
   overlayWindow.hide = () => {
-    if (Date.now() - lastShowTime < 100) return
+    if (!hyprlandOverlayActive() && Date.now() - lastShowTime < 100) return
 
     // electron-overlay-window's native code calls .hide() on PoE blur. Skip
     // the hide when focus actually moved to another Scalpel window (cheat
     // sheets etc.) - that's an in-app interaction, not "user left the app".
-    if (isAnyScalpelWindowFocused()) return
+    if (hyprlandOverlayActive() ? hyprlandInputAllowed() : isAnyScalpelWindowFocused()) return
 
     // Make it invisible and click-through - don't actually hide from OS to avoid animation
-    overlayWindow?.setOpacity(0)
+    if (hyprlandOverlayActive()) origHide()
+    else overlayWindow?.setOpacity(0)
     overlayWindow?.setIgnoreMouseEvents(true)
+    currentInteractiveWindow = null
+    interactiveLocked = false
+    mouseOverPanel = false
+    if (exitTimer) clearTimeout(exitTimer)
+    exitTimer = null
 
     opacityHidden = true
     if (onGameBlur) setImmediate(onGameBlur)
@@ -363,7 +393,7 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
 
   overlayWindow.showInactive = () => {
     // Only show the overlay if POE actually has focus (alt-tab fix)
-    if (!OverlayController.targetHasFocus) return
+    if (hyprlandOverlayActive() ? !hyprlandInputAllowed() : !OverlayController.targetHasFocus) return
 
     // Restore opacity before showing so it's visible immediately
     overlayWindow?.setOpacity(1)
@@ -385,7 +415,12 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
   // In multi-title mode (experimental), pass both titles so the native tracker
   // can find either PoE1 or PoE2 without a restart. In single-title mode
   // (stable), attach to the specific game version only.
-  if (multiTitleMode) {
+  if (hyprlandOverlayActive()) {
+    overlayWindow.setAlwaysOnTop(true, 'screen-saver')
+    OverlayController.events.on('blur', () => overlayWindow?.hide())
+    OverlayController.events.on('detach', () => overlayWindow?.hide())
+    attachHyprlandOverlay(overlayWindow, multiTitleMode ? [GAME_TITLES[1], GAME_TITLES[2]] : [GAME_TITLES[version]])
+  } else if (multiTitleMode) {
     OverlayController.attachByTitles(overlayWindow, [GAME_TITLES[1], GAME_TITLES[2]])
   } else {
     OverlayController.attachByTitle(overlayWindow, GAME_TITLES[version])
@@ -427,7 +462,7 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
       getWhiteboardOverlay()?.send(IPC_CHANNELS.SCREEN.SOURCE_INVALIDATED_EVENT)
       mouseOverPanel = false
       if (overlayVisible && overlayWindow && !overlayWindow.isDestroyed()) {
-        overlayWindow.setIgnoreMouseEvents(true)
+        overlayWindow.setIgnoreMouseEvents(!hyprlandOverlayActive())
         if (currentInteractiveWindow === overlayWindow) currentInteractiveWindow = null
         overlayWindow.webContents.send('skip-animation')
       }
@@ -478,7 +513,7 @@ export function createOverlayWindow(version: 1 | 2 = 1, options?: CreateOverlayO
         // hotkeys and restores any hidden secondary overlays.
         overlayWindow.showInactive()
         mouseOverPanel = false
-        overlayWindow.setIgnoreMouseEvents(true)
+        overlayWindow.setIgnoreMouseEvents(!hyprlandOverlayActive())
         if (currentInteractiveWindow === overlayWindow) currentInteractiveWindow = null
       } else if (onGameFocus) {
         // Main overlay is closed but PoE just refocused -- still need to resume
@@ -557,6 +592,7 @@ export function showOverlay(): void {
   // Direct setOpacity(1) alone doesn't reset the closure flag, so the next hide/show cycle
   // from electron-overlay-window can re-zero the opacity.
   try {
+    if (hyprlandOverlayActive()) setInteractive(true)
     overlayWindow.showInactive()
   } catch {}
   // If a persisting whiteboard is visible, raise the eval above it so the
@@ -576,19 +612,37 @@ export function showOverlay(): void {
     console.error('[overlay] Error in showOverlay:', err)
   }
   overlayVisibilityListener?.(true)
+  if (hyprlandOverlayActive()) {
+    if (exitTimer) clearTimeout(exitTimer)
+    exitTimer = null
+    setInteractive(true)
+    OverlayController.activateOverlay()
+  }
 }
 
 export function hideOverlay(): void {
   if (!overlayWindow || overlayWindow.isDestroyed() || !overlayVisible) return
   overlayVisible = false
   mouseOverPanel = false
+  if (hyprlandOverlayActive()) {
+    interactiveLocked = false
+    currentInteractiveWindow = null
+    if (exitTimer) clearTimeout(exitTimer)
+    exitTimer = null
+    // Focus before removing the input region: otherwise pointer-follow-focus
+    // can activate the game outside our no-warp handoff.
+    OverlayController.focusTarget()
+    // X11 input-shape click-through is not enough: Hyprland can still
+    // hit-test the mapped full-screen window on the next physical click.
+    unmapHyprlandDialog?.()
+  }
   try {
     overlayWindow.setIgnoreMouseEvents(true)
   } catch {}
   // Tell renderer to hide its content (don't call overlayWindow.hide() -
   // OverlayController manages window visibility and would re-show it, causing flicker)
   overlayWindow.webContents.send('overlay-hide')
-  OverlayController.focusTarget()
+  if (!hyprlandOverlayActive()) OverlayController.focusTarget()
   overlayVisibilityListener?.(false)
 }
 

--- a/src/main/overlay.ts
+++ b/src/main/overlay.ts
@@ -13,7 +13,15 @@ import { getWhiteboardOverlay } from './whiteboard'
 import { POE_SIDEBAR_RATIO } from '@shared/poe-geometry'
 import { GAME_TITLES } from '@shared/contracts/game-variant'
 import { IPC_CHANNELS } from '@shared/contracts/ipc'
-import { attachHyprlandOverlay, hyprlandInputAllowed, hyprlandOverlayActive, nameHyprlandOverlay } from './hyprland'
+import {
+  attachHyprlandOverlay,
+  focusHyprlandPanel,
+  getHyprlandPointerPhysical,
+  getHyprlandGameBounds,
+  hyprlandInputAllowed,
+  hyprlandOverlayActive,
+  nameHyprlandOverlay,
+} from './hyprland'
 
 let overlayWindow: BrowserWindow | null = null
 let unmapHyprlandDialog: (() => void) | null = null
@@ -96,6 +104,10 @@ function getScaleFactor(): number {
   // Multi-monitor setups with different DPIs need the correct scale factor.
   const tb = OverlayController.targetBounds
   if (tb?.width) {
+    if (hyprlandOverlayActive()) {
+      const dip = getHyprlandGameBounds()
+      if (dip?.width) return tb.width / dip.width
+    }
     return screen.getDisplayNearestPoint({ x: tb.x + tb.width / 2, y: tb.y + tb.height / 2 }).scaleFactor
   }
   return screen.getPrimaryDisplay().scaleFactor
@@ -120,6 +132,7 @@ ipcMain.on('report-panel-rect', (event, payload: unknown) => {
   const win = BrowserWindow.fromWebContents(event.sender)
   if (!win) return
   panelRectsBySender.set(event.sender.id, { win, rects: phys })
+  if (phys.length === 0 && currentInteractiveWindow === win) setInteractiveWindow(null)
 })
 
 ipcMain.on('clear-panel-rect', (event) => {
@@ -185,6 +198,7 @@ function setInteractiveWindow(win: BrowserWindow | null): void {
   if (currentInteractiveWindow === win) return
   // Revert prior window to click-through.
   const prev = currentInteractiveWindow
+  if (!win && prev && hyprlandOverlayActive()) OverlayController.focusTarget()
   if (prev && !prev.isDestroyed()) {
     try {
       prev.setIgnoreMouseEvents(true)
@@ -201,12 +215,14 @@ function setInteractiveWindow(win: BrowserWindow | null): void {
     // exposes activateOverlay() for exactly this (it runs the native lib.activateOverlay()
     // on Linux). Only the attached main overlay can be activated this way, so secondary
     // windows (whiteboard, cheat sheets) fall outside this path. See issue #30.
-    if (process.platform === 'linux' && win === overlayWindow) {
+    if (hyprlandOverlayActive() && win !== overlayWindow) {
+      focusHyprlandPanel(win)
+    } else if (process.platform === 'linux' && win === overlayWindow) {
       try {
         OverlayController.activateOverlay()
       } catch {}
     }
-  } else if (process.platform === 'linux' && prev === overlayWindow) {
+  } else if (process.platform === 'linux' && !hyprlandOverlayActive() && prev === overlayWindow) {
     // Cursor left the main overlay: hand native input focus back to PoE so the
     // game keeps receiving input (mirrors the focusTarget() handoff hideOverlay uses).
     try {
@@ -231,17 +247,38 @@ function setInteractive(interactive: boolean): void {
 // Track mouse position via uiohook to toggle click-through
 // Debounce exit to prevent flickering at DPI-scaled boundaries
 let exitTimer: ReturnType<typeof setTimeout> | null = null
+let lastHyprlandPointerCheck = 0
+let hyprlandPointerTimer: ReturnType<typeof setTimeout> | null = null
 
 uIOhook.on(
   'mousemove',
-  guardNativeListener('mousemove', (e) => {
+  guardNativeListener('mousemove', function trackPointer(e) {
     // A dialog owns input until explicitly dismissed. Hit-test updates can lag
     // behind dragging; neither leaving a rect nor stale geometry may release it.
     if (hyprlandOverlayActive() && overlayVisible) return
     // No rects reported yet -- skip hit testing. (Whiteboard registers its own
     // rects independently of the main overlay's `overlayVisible` flag.)
     if (panelRectsBySender.size === 0) return
-    const winUnder = windowAtPoint(e.x, e.y)
+    let point = e
+    if (hyprlandOverlayActive()) {
+      // Limit compositor queries for high polling-rate gaming mice.
+      const elapsed = Date.now() - lastHyprlandPointerCheck
+      if (elapsed < 32) {
+        // Sample once more after the last motion event, even if the pointer
+        // stops immediately upon entering a button or drag grip.
+        if (!hyprlandPointerTimer)
+          hyprlandPointerTimer = setTimeout(() => {
+            hyprlandPointerTimer = null
+            trackPointer(e)
+          }, 32 - elapsed)
+        return
+      }
+      lastHyprlandPointerCheck = Date.now()
+      const cursor = getHyprlandPointerPhysical()
+      if (!cursor) return
+      point = { ...e, ...cursor }
+    }
+    const winUnder = windowAtPoint(point.x, point.y)
     if (winUnder) {
       if (exitTimer) {
         clearTimeout(exitTimer)

--- a/src/main/screen-capture/capture.test.ts
+++ b/src/main/screen-capture/capture.test.ts
@@ -32,6 +32,8 @@ vi.mock('electron-overlay-window', () => ({
   },
 }))
 
+vi.mock('../hyprland', () => ({ hyprlandOverlayActive: () => false }))
+
 import { captureGameWindow, captureGameWindowResult } from './capture'
 
 /** A screen source whose thumbnail is `w`x`h` of opaque BGRA. */

--- a/src/main/screen-capture/capture.ts
+++ b/src/main/screen-capture/capture.ts
@@ -1,5 +1,7 @@
 import { desktopCapturer, screen } from 'electron'
 import { OverlayController } from 'electron-overlay-window'
+import { hyprlandOverlayActive } from '../hyprland'
+import { captureHyprlandGame } from './hyprland-capture'
 
 /** A captured game-window frame. `data` is BGRA, row-major, (0,0) at the game
  *  window's top-left. `width`/`height` are the frame's px dimensions (downscaled
@@ -55,6 +57,7 @@ export async function captureGameWindow(opts?: CaptureOptions): Promise<CaptureF
 }
 
 export async function captureGameWindowResult(opts?: CaptureOptions): Promise<CaptureResult> {
+  if (hyprlandOverlayActive()) return captureHyprlandGame(opts)
   if (!opts?.skipFocusGate && !OverlayController.targetHasFocus) return fail('focus')
   const tb = OverlayController.targetBounds
   if (!tb?.width || !tb.height) return fail('bounds')

--- a/src/main/screen-capture/hyprland-capture.test.ts
+++ b/src/main/screen-capture/hyprland-capture.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mock = vi.hoisted(() => ({ exec: vi.fn(), game: vi.fn(), displays: vi.fn(), image: vi.fn() }))
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }))
+vi.mock('node:util', () => ({ promisify: () => mock.exec }))
+vi.mock('../hyprland', () => ({ getHyprlandGame: mock.game }))
+vi.mock('electron', () => ({
+  nativeImage: { createFromBuffer: mock.image },
+  screen: { getAllDisplays: mock.displays },
+}))
+import { captureHyprlandGame } from './hyprland-capture'
+
+const game = {
+  address: '0x1',
+  pid: 100,
+  title: 'Path of Exile 2',
+  workspace: { id: 2 },
+  at: [2400, 0],
+  size: [2400, 1350],
+  monitor: 1,
+}
+let active = game
+beforeEach(() => {
+  vi.clearAllMocks()
+  active = game
+  mock.game.mockReturnValue(game)
+  mock.displays.mockReturnValue([{ label: 'DP-2', bounds: { x: 1920, y: 0 }, scaleFactor: 2 }])
+  mock.exec.mockImplementation(async (cmd: string, args: string[]) => {
+    if (cmd === 'grim') return { stdout: Buffer.from('png') }
+    const value =
+      args[1] === 'activewindow'
+        ? active
+        : args[1] === 'clients'
+          ? [game]
+          : [{ id: 1, name: 'DP-2', x: 2400, y: 0, scale: 1.6 }]
+    return { stdout: JSON.stringify(value) }
+  })
+  mock.image.mockReturnValue({
+    isEmpty: () => false,
+    getSize: () => ({ width: 3840, height: 2160 }),
+    toBitmap: () => Buffer.from('bgra'),
+  })
+})
+
+describe('Hyprland game capture', () => {
+  it('captures the game region without a picker, preserving physical pixels and Electron CSS scale', async () => {
+    expect(await captureHyprlandGame()).toEqual({
+      frame: {
+        data: Buffer.from('bgra'),
+        width: 3840,
+        height: 2160,
+        gameSize: { width: 1920, height: 1080 },
+        scale: 2,
+      },
+    })
+    expect(mock.exec).toHaveBeenCalledWith(
+      'grim',
+      ['-g', '2400,0 2400x1350', '-s', '1.6', '-l', '1', '-'],
+      expect.objectContaining({ encoding: 'buffer', timeout: 5000 }),
+    )
+  })
+  it('accepts an unnamed XWayland display on a single-monitor desktop', async () => {
+    mock.displays.mockReturnValue([{ label: '', bounds: { x: 1920, y: 0 }, scaleFactor: 2 }])
+    expect((await captureHyprlandGame()).frame).toMatchObject({ width: 3840, scale: 2 })
+  })
+  it('rejects stale tracker focus before starting a screenshot', async () => {
+    active = { ...game, address: '0x2' }
+    expect(await captureHyprlandGame()).toEqual({ frame: null, failure: 'focus' })
+    expect(mock.exec).toHaveBeenCalledTimes(1)
+  })
+  it('discards a screenshot when the user switches apps during capture', async () => {
+    const original = mock.exec.getMockImplementation()!
+    mock.exec.mockImplementation(async (cmd, args) => {
+      const result = await original(cmd, args)
+      if (cmd === 'grim') active = { ...game, address: '0x2' }
+      return result
+    })
+    expect(await captureHyprlandGame()).toEqual({ frame: null, failure: 'focus' })
+    expect(mock.image).not.toHaveBeenCalled()
+  })
+  it('does not allow skipFocusGate to capture unrelated applications', async () => {
+    active = { ...game, address: '0x2', pid: 200 }
+    expect(await captureHyprlandGame({ skipFocusGate: true })).toEqual({ frame: null, failure: 'focus' })
+  })
+  it('rejects unknown monitor mappings instead of grabbing the first display', async () => {
+    mock.displays.mockReturnValue([])
+    expect(await captureHyprlandGame()).toEqual({ frame: null, failure: 'geometry' })
+    expect(mock.exec.mock.calls.some(([cmd]) => cmd === 'grim')).toBe(false)
+  })
+  it('reports a missing grim without opening a portal picker', async () => {
+    mock.exec.mockRejectedValue(Object.assign(new Error('missing grim'), { code: 'ENOENT' }))
+    expect(await captureHyprlandGame()).toEqual({ frame: null, failure: 'error' })
+  })
+  it('rejects a moved game and empty images', async () => {
+    const original = mock.exec.getMockImplementation()!
+    mock.exec.mockImplementation(async (cmd, args) => {
+      const result = await original(cmd, args)
+      if (cmd === 'grim') active = { ...game, at: [2000, 0] }
+      return result
+    })
+    expect(await captureHyprlandGame()).toEqual({ frame: null, failure: 'geometry' })
+    active = game
+    mock.exec.mockImplementation(original)
+    mock.image.mockReturnValue({ isEmpty: () => true })
+    expect(await captureHyprlandGame()).toEqual({ frame: null, failure: 'empty-frame' })
+  })
+})

--- a/src/main/screen-capture/hyprland-capture.ts
+++ b/src/main/screen-capture/hyprland-capture.ts
@@ -1,0 +1,82 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import { nativeImage, screen } from 'electron'
+import { getHyprlandGame } from '../hyprland'
+import { type HyprClient, hyprlandOverlayBounds, isHyprlandGameContext } from '../hyprland-policy'
+import type { CaptureOptions, CaptureResult } from './capture'
+
+const exec = promisify(execFile)
+
+/** One-shot compositor capture. The portal picker steals input from fullscreen
+ * games and can end up in its own thumbnail. grim captures only the game's
+ * logical rectangle, without a picker, cursor or intermediate screenshot file.
+ * Never fall back to the portal on failure: ambient callers also use this API. */
+export async function captureHyprlandGame(opts?: CaptureOptions): Promise<CaptureResult> {
+  const target = getHyprlandGame()
+  if (!target) return { frame: null, failure: 'bounds' }
+  try {
+    const readActive = async (): Promise<HyprClient> =>
+      JSON.parse((await exec('hyprctl', ['-j', 'activewindow'], { timeout: 1000 })).stdout)
+    const allowed = (active: HyprClient) =>
+      opts?.skipFocusGate ? isHyprlandGameContext(active, target, process.pid) : active.address === target.address
+    const active = await readActive()
+    if (!allowed(active)) return { frame: null, failure: 'focus' }
+    // Read fresh geometry, rather than the tracker's last periodic snapshot.
+    const clients: HyprClient[] = JSON.parse((await exec('hyprctl', ['-j', 'clients'], { timeout: 1000 })).stdout)
+    const game = clients.find((client) => client.address === target.address)
+    if (!game) return { frame: null, failure: 'bounds' }
+    const monitors: Array<{ id: number; name: string; x: number; y: number; scale: number }> = JSON.parse(
+      (await exec('hyprctl', ['-j', 'monitors'], { timeout: 1000 })).stdout,
+    )
+    const monitor = monitors.find((m) => m.id === game.monitor)
+    const displays = screen.getAllDisplays()
+    // XWayland can omit physical connector names. A single-monitor desktop
+    // is unambiguous; never guess the first display in a multi-monitor setup.
+    const display =
+      displays.find((d) => d.label === monitor?.name) ??
+      (monitors.length === 1 && displays.length === 1 ? displays[0] : undefined)
+    if (!monitor || !display) return { frame: null, failure: 'geometry' }
+    const [x, y] = game.at
+    const [w, h] = game.size
+    if (![x, y, w, h].every(Number.isInteger) || w <= 0 || h <= 0) {
+      return { frame: null, failure: 'geometry' }
+    }
+    const dip = hyprlandOverlayBounds(game, monitor, display).dip
+    // Keep native resolution for OCR, bounded at 2160p. The old 1080p cap
+    // discarded small affix lettering on high-resolution displays.
+    const scale = Math.min(monitor.scale, 2160 / h)
+    const { stdout } = await exec('grim', ['-g', `${x},${y} ${w}x${h}`, '-s', String(scale), '-l', '1', '-'], {
+      encoding: 'buffer',
+      timeout: 5000,
+      maxBuffer: 64 * 1024 * 1024,
+    })
+    // A workspace/focus change during capture must never leak another app's
+    // pixels to the plugin. Also reject moves/resizes during the grab.
+    const after = await readActive()
+    if (!allowed(after)) return { frame: null, failure: 'focus' }
+    if (
+      after.address === game.address &&
+      (after.at[0] !== x || after.at[1] !== y || after.size[0] !== w || after.size[1] !== h)
+    ) {
+      return { frame: null, failure: 'geometry' }
+    }
+    const img = nativeImage.createFromBuffer(stdout)
+    if (img.isEmpty()) return { frame: null, failure: 'empty-frame' }
+    const { width, height } = img.getSize()
+    if (Math.abs(width - w * scale) > 1 || Math.abs(height - h * scale) > 1) {
+      return { frame: null, failure: 'geometry' }
+    }
+    return {
+      frame: {
+        data: img.toBitmap(),
+        width,
+        height,
+        gameSize: { width: dip.width, height: dip.height },
+        scale: width / dip.width,
+      },
+    }
+  } catch (error) {
+    if (process.env.SCALPEL_DEBUG_LOG) console.error('[screen-capture] Hyprland capture failed (requires grim):', error)
+    return { frame: null, failure: 'error' }
+  }
+}

--- a/src/main/windowing/focus.test.ts
+++ b/src/main/windowing/focus.test.ts
@@ -13,6 +13,9 @@ vi.mock('./snap-canvas', () => ({
     snapGhostCalls.push(rect)
   },
 }))
+// These cases cover focus bookkeeping off the compositor-driven path, where the
+// Hyprland gate is a no-op. Mocked so the suite never loads the native tracker.
+vi.mock('../hyprland', () => ({ hyprlandInputAllowed: () => true }))
 import {
   aroundNativeDialog,
   closeAllOverlaysOnPoeExit,

--- a/src/main/windowing/focus.ts
+++ b/src/main/windowing/focus.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, screen } from 'electron'
+import { hyprlandInputAllowed } from '../hyprland'
 import { getSnapCanvasWindow, setSnapGhost } from './snap-canvas'
 import { firePoeLeaveHooks, getAuxiliaryScalpelWindows, getMainOverlay, overlays } from './state'
 
@@ -69,6 +70,7 @@ function collectScalpelWindows(): BrowserWindow[] {
  *  dialogs are intentionally excluded: callers that authorize keyboard input
  *  must not treat a file picker as an injection target. */
 export function isAnyScalpelBrowserWindowFocused(): boolean {
+  if (!hyprlandInputAllowed()) return false
   const focused = BrowserWindow.getFocusedWindow()
   if (!focused || focused.isDestroyed()) return false
   if (focused === getMainOverlay()) return true

--- a/src/main/windowing/geometry.test.ts
+++ b/src/main/windowing/geometry.test.ts
@@ -1,0 +1,27 @@
+import { afterEach, expect, it, vi } from 'vitest'
+const mock = vi.hoisted(() => ({ active: vi.fn(), bounds: vi.fn(), point: vi.fn(), display: vi.fn() }))
+vi.mock('../hyprland', () => ({ hyprlandOverlayActive: mock.active, getHyprlandGameBounds: mock.bounds }))
+vi.mock('electron-overlay-window', () => ({
+  OverlayController: { targetBounds: { x: 3840, y: 0, width: 3840, height: 2160 } },
+}))
+// Deliberately no screenToDipRect: Electron does not expose it on Linux.
+vi.mock('electron', () => ({ screen: { screenToDipPoint: mock.point, getDisplayNearestPoint: mock.display } }))
+import { gameDipBounds } from './geometry'
+afterEach(() => vi.unstubAllGlobals())
+it('uses the same fractional-scale bounds as the Hyprland main overlay', () => {
+  mock.active.mockReturnValue(true)
+  mock.bounds.mockReturnValue({ x: 1920, y: 0, width: 1920, height: 1080 })
+  expect(gameDipBounds(null)).toEqual({ x: 1920, y: 0, width: 1920, height: 1080 })
+})
+it('returns null when Hyprland has no attached game', () => {
+  mock.active.mockReturnValue(true)
+  mock.bounds.mockReturnValue(null)
+  expect(gameDipBounds(null)).toBeNull()
+})
+it('converts an X11 rectangle without a Windows-only API', () => {
+  vi.stubGlobal('process', { ...process, platform: 'linux' })
+  mock.active.mockReturnValue(false)
+  mock.point.mockReturnValue({ x: 1920, y: 0 })
+  mock.display.mockReturnValue({ scaleFactor: 2 })
+  expect(gameDipBounds(null)).toEqual({ x: 1920, y: 0, width: 1920, height: 1080 })
+})

--- a/src/main/windowing/geometry.ts
+++ b/src/main/windowing/geometry.ts
@@ -1,0 +1,19 @@
+import { type BrowserWindow, screen } from 'electron'
+import { OverlayController } from 'electron-overlay-window'
+import { getHyprlandGameBounds, hyprlandOverlayActive } from '../hyprland'
+
+/** screenToDipRect is Windows-only. Hyprland already supplies the exact DIP
+ * rectangle used by the main overlay, including mixed monitor scaling. */
+export function gameDipBounds(win: BrowserWindow | null): Electron.Rectangle | null {
+  if (hyprlandOverlayActive()) return getHyprlandGameBounds()
+  const tb = OverlayController.targetBounds
+  if (!tb || tb.width <= 0 || tb.height <= 0) return null
+  if (process.platform === 'win32') return screen.screenToDipRect(win, tb)
+  const point = screen.screenToDipPoint({ x: tb.x, y: tb.y })
+  const display = screen.getDisplayNearestPoint(point)
+  return {
+    ...point,
+    width: Math.round(tb.width / display.scaleFactor),
+    height: Math.round(tb.height / display.scaleFactor),
+  }
+}

--- a/src/main/windowing/index.ts
+++ b/src/main/windowing/index.ts
@@ -1,6 +1,7 @@
 import { app, type BrowserWindow, screen } from 'electron'
 import { OverlayController } from 'electron-overlay-window'
 import { uIOhook } from 'uiohook-napi'
+import { gameDipBounds } from './geometry'
 import { guardNativeListener } from '../diagnostics'
 import { hideAllOnPoeBlur, isAnyScalpelWindowFocused } from './focus'
 import { seedUserPinned } from './pin'
@@ -105,27 +106,15 @@ function anchorTimes(anchor: OverlayAnchor, base: Rect): Rect {
   }
 }
 
-/** Compute the DIP (logical) bounds an overlay window should occupy for the
- *  given anchor. Uses `screen.screenToDipRect(win, physRect)` - the same path
- *  the electron-overlay-window library uses for the main overlay - so behavior
- *  matches across all DPI / multi-monitor configurations.
- *
- *  Returns null when PoE bounds aren't available yet. */
+/** Anchors are fractions of the game's logical rectangle on every platform. */
 function anchorToDipBounds(win: BrowserWindow, anchor: OverlayAnchor): Rect | null {
-  const tb = OverlayController.targetBounds
-  if (!tb || tb.width <= 0 || tb.height <= 0) return null
-  const phys = anchorTimes(anchor, { x: tb.x, y: tb.y, width: tb.width, height: tb.height })
-  return screen.screenToDipRect(win, phys)
+  const base = gameDipBounds(win)
+  return base ? anchorTimes(anchor, base) : null
 }
 
-/** Compute an anchor from a window's current DIP bounds. Converts PoE's
- *  physical bounds to DIP using the same `screenToDipRect` path so the
- *  numerator and denominator are in the same coordinate space. */
 function boundsToAnchor(win: BrowserWindow): OverlayAnchor | null {
-  const tb = OverlayController.targetBounds
-  if (!tb || tb.width <= 0 || tb.height <= 0) return null
-  const poeDip = screen.screenToDipRect(win, { x: tb.x, y: tb.y, width: tb.width, height: tb.height })
-  if (poeDip.width <= 0 || poeDip.height <= 0) return null
+  const poeDip = gameDipBounds(win)
+  if (!poeDip || poeDip.width <= 0 || poeDip.height <= 0) return null
   const cur = win.getBounds()
   return {
     fracX: (cur.x - poeDip.x) / poeDip.width,
@@ -428,7 +417,7 @@ function makeOverlayApi(state: OverlayState): SecondaryOverlay {
 
 function ensureWin(state: OverlayState): BrowserWindow {
   if (state.win && !state.win.isDestroyed()) return state.win
-  // Window must exist before we can call `screen.screenToDipRect(win, ...)`
+  // Create the window before resolving its display-dependent bounds.
   // (the same path the library uses for the main overlay), so create at a
   // sensible placeholder - the display PoE is on if known, otherwise primary
   // workArea - then immediately overwrite with the anchor-derived DIP bounds.

--- a/src/main/windowing/window.ts
+++ b/src/main/windowing/window.ts
@@ -2,6 +2,7 @@ import { join } from 'node:path'
 import { BrowserWindow } from 'electron'
 import { OVERLAY_WINDOW_OPTS } from 'electron-overlay-window'
 import type { Rect } from './snap-canvas'
+import { hyprlandOverlayActive, nameHyprlandOverlay } from '../hyprland'
 
 interface CreateOptions {
   htmlEntry: string
@@ -27,6 +28,7 @@ export function createOverlayWindow({ htmlEntry, bounds }: CreateOptions): Brows
       nodeIntegration: false,
     },
   })
+  nameHyprlandOverlay(win)
   // 'screen-saver' is the level the main overlay uses (set by electron-overlay-
   // window on attach). It sits above PoE, the taskbar, and other floating
   // windows, and lets the window's full bounds render including the taskbar
@@ -56,10 +58,12 @@ export function createOverlayWindow({ htmlEntry, bounds }: CreateOptions): Brows
  *  for interaction; we just don't take focus on our own. */
 function installOpacityHideShow(win: BrowserWindow): void {
   const origShowInactive = win.showInactive.bind(win)
+  const origHide = win.hide.bind(win)
   const origIsVisible = win.isVisible.bind(win)
   let opacityHidden = false
   win.hide = (): void => {
-    win.setOpacity(0)
+    if (hyprlandOverlayActive()) origHide()
+    else win.setOpacity(0)
     win.setIgnoreMouseEvents(true)
     opacityHidden = true
   }

--- a/src/renderer/src/plugin-annotation-overlay/App.tsx
+++ b/src/renderer/src/plugin-annotation-overlay/App.tsx
@@ -1,18 +1,27 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+import { createPanelDragController } from './panel-drag'
+import type { GameRect } from '../../../plugin-sdk/src/types'
 import { useActivatePlugin } from '../plugins/use-activate-plugin'
 
 export function App({ pluginId }: { pluginId: string }): JSX.Element {
-  const { captured, error } = useActivatePlugin(pluginId)
+  const panelRef = useRef<ReturnType<typeof createPanelDragController> | null>(null)
+  const onRegion = useCallback((rect: GameRect | null) => panelRef.current?.setRegion(rect), [])
+  const { captured, error } = useActivatePlugin(pluginId, onRegion)
   const bodyRef = useRef<HTMLDivElement>(null)
   const cleanupRef = useRef<(() => void) | void>(undefined)
 
   // Mount the captured render into the body once both exist.
   useEffect(() => {
     if (!captured || !bodyRef.current) return
+    panelRef.current = createPanelDragController(bodyRef.current, (rect) => {
+      window.api.reportPanelRect(rect ? [{ left: rect.x, top: rect.y, width: rect.width, height: rect.height }] : [])
+    })
     cleanupRef.current = captured.render(bodyRef.current)
     return () => {
       if (typeof cleanupRef.current === 'function') cleanupRef.current()
       cleanupRef.current = undefined
+      panelRef.current?.dispose()
+      panelRef.current = null
     }
   }, [captured])
 

--- a/src/renderer/src/plugin-annotation-overlay/panel-drag.test.tsx
+++ b/src/renderer/src/plugin-annotation-overlay/panel-drag.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import type { GameRect } from '../../../plugin-sdk/src/types'
+import { createPanelDragController } from './panel-drag'
+
+let container: HTMLDivElement
+let report = vi.fn<(rect: GameRect | null) => void>()
+let controller: ReturnType<typeof createPanelDragController>
+function card() {
+  const element = document.createElement('div')
+  element.style.pointerEvents = 'auto'
+  element.getBoundingClientRect = () =>
+    ({
+      x: Number.parseFloat(element.style.left) || 0,
+      y: Number.parseFloat(element.style.top) || 100,
+      width: 300,
+      height: 200,
+    }) as DOMRect
+  container.appendChild(element)
+  return element
+}
+function pointer(handle: HTMLElement, type: string, x: number, y: number) {
+  const event = new Event(type, { bubbles: true })
+  Object.assign(event, { clientX: x, clientY: y, pointerId: 1, button: 0 })
+  handle.dispatchEvent(event)
+}
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      disconnect() {}
+    },
+  )
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  report = vi.fn()
+  controller = createPanelDragController(container, report)
+})
+afterEach(() => {
+  controller.dispose()
+  container.remove()
+  vi.unstubAllGlobals()
+})
+it('moves the interactive card, updates its input region, and leaves labels fixed', () => {
+  const panel = card()
+  const label = document.createElement('div')
+  label.style.cssText = 'position:absolute;left:500px;top:400px;pointer-events:none'
+  container.appendChild(label)
+  controller.setRegion({ x: 0, y: 100, width: 300, height: 200 })
+  const grip = panel.querySelector('button')!
+  grip.setPointerCapture = vi.fn()
+  pointer(grip, 'pointerdown', 250, 110)
+  pointer(grip, 'pointermove', 450, 210)
+  pointer(grip, 'pointerup', 450, 210)
+  expect(panel.style.left).toBe('200px')
+  expect(panel.style.top).toBe('200px')
+  expect(report).toHaveBeenLastCalledWith({ x: 200, y: 200, width: 300, height: 200 })
+  expect(label.style.left).toBe('500px')
+  expect(label.style.top).toBe('400px')
+  panel.remove()
+  const replacement = card()
+  controller.setRegion({ x: 0, y: 100, width: 300, height: 200 })
+  expect(replacement.style.left).toBe('200px')
+  expect(replacement.querySelectorAll('button')).toHaveLength(1)
+})
+it('clears interaction on close without leaving a drag grip behind', () => {
+  const panel = card()
+  controller.setRegion({ x: 0, y: 100, width: 300, height: 200 })
+  controller.setRegion(null)
+  expect(panel.querySelector('button')).toBeNull()
+  expect(report).toHaveBeenLastCalledWith(null)
+})
+it('preserves unknown plugin layouts without adding dragging', () => {
+  const panel = card()
+  const region = { x: 400, y: 300, width: 100, height: 80 }
+  controller.setRegion(region)
+  expect(panel.querySelector('button')).toBeNull()
+  expect(report).toHaveBeenLastCalledWith(region)
+})

--- a/src/renderer/src/plugin-annotation-overlay/panel-drag.ts
+++ b/src/renderer/src/plugin-annotation-overlay/panel-drag.ts
@@ -1,0 +1,99 @@
+import type { GameRect } from '../../../plugin-sdk/src/types'
+
+/** Move only the plugin's interactive card, never its game-aligned labels or
+ * full-screen annotation window. Position survives the plugin rebuilding its
+ * card after OCR completes, for this overlay session. */
+export function createPanelDragController(container: HTMLElement, report: (rect: GameRect | null) => void) {
+  let panel: HTMLElement | null = null
+  let position: { x: number; y: number } | null = null
+  let detach: (() => void) | null = null
+  const publish = () => {
+    if (!panel) return
+    const r = panel.getBoundingClientRect()
+    report({ x: r.x, y: r.y, width: r.width, height: r.height })
+  }
+  const place = (x: number, y: number) => {
+    if (!panel) return
+    const r = panel.getBoundingClientRect()
+    position = {
+      x: Math.max(0, Math.min(x, window.innerWidth - r.width)),
+      y: Math.max(0, Math.min(y, window.innerHeight - r.height)),
+    }
+    panel.style.left = `${position.x}px`
+    panel.style.top = `${position.y}px`
+    panel.style.right = 'auto'
+    panel.style.bottom = 'auto'
+    publish()
+  }
+  const resize = () => {
+    if (position) place(position.x, position.y)
+    else publish()
+  }
+  window.addEventListener('resize', resize)
+  return {
+    setRegion(rect: GameRect | null) {
+      detach?.()
+      detach = null
+      panel = null
+      if (!rect || rect.width <= 0 || rect.height <= 0) {
+        report(null)
+        return
+      }
+      // Only enhance an explicitly declared, top-level interactive panel.
+      // Unknown plugin layouts retain their declared input region unchanged.
+      panel =
+        Array.from(container.children).find((child): child is HTMLElement => {
+          if (!(child instanceof HTMLElement) || getComputedStyle(child).pointerEvents === 'none') return false
+          const r = child.getBoundingClientRect()
+          return (
+            Math.abs(r.x - rect.x) < 2 &&
+            Math.abs(r.y - rect.y) < 2 &&
+            Math.abs(r.width - rect.width) < 2 &&
+            Math.abs(r.height - rect.height) < 2
+          )
+        }) ?? null
+      if (!panel) {
+        report(rect)
+        return
+      }
+      const handle = document.createElement('button')
+      handle.type = 'button'
+      handle.textContent = '⠿'
+      handle.title = 'Drag panel'
+      handle.setAttribute('aria-label', 'Move annotation panel')
+      handle.style.cssText =
+        'position:absolute;right:36px;top:5px;width:24px;height:30px;border:0;border-radius:4px;background:#23232e;color:#c8a96e;cursor:move;pointer-events:auto;touch-action:none;z-index:1'
+      const card = panel
+      let drag: { id: number; x: number; y: number } | null = null
+      handle.onpointerdown = (event) => {
+        if (event.button !== 0) return
+        event.preventDefault()
+        event.stopPropagation()
+        const r = card.getBoundingClientRect()
+        drag = { id: event.pointerId, x: event.clientX - r.x, y: event.clientY - r.y }
+        handle.setPointerCapture(event.pointerId)
+      }
+      handle.onpointermove = (event) => {
+        if (drag?.id === event.pointerId) place(event.clientX - drag.x, event.clientY - drag.y)
+      }
+      handle.onpointerup = handle.onpointercancel = () => {
+        drag = null
+      }
+      card.appendChild(handle)
+      const observer = new ResizeObserver(resize)
+      observer.observe(card)
+      detach = () => {
+        observer.disconnect()
+        handle.remove()
+      }
+      if (position) place(position.x, position.y)
+      else publish()
+    },
+    dispose() {
+      detach?.()
+      panel = null
+      window.removeEventListener('resize', resize)
+      report(null)
+    },
+  }
+}

--- a/src/renderer/src/plugins/use-activate-plugin.ts
+++ b/src/renderer/src/plugins/use-activate-plugin.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react'
-import type { PluginActivate, RegisterOverlayOptions, ScalpelPluginContext } from '../../../plugin-sdk/src/types'
+import type {
+  GameRect,
+  PluginActivate,
+  RegisterOverlayOptions,
+  ScalpelPluginContext,
+} from '../../../plugin-sdk/src/types'
 import type { PoeItem, Zone } from '@shared/types'
 import { importPluginModule } from './import-plugin-module'
 import { resolveLeagueOptions } from '@renderer/shared/league-options'
@@ -9,7 +14,10 @@ export interface ActivatedPlugin {
   error: string | null
 }
 
-export function useActivatePlugin(pluginId: string): ActivatedPlugin {
+export function useActivatePlugin(
+  pluginId: string,
+  onInteractiveRegion?: (rect: GameRect | null) => void,
+): ActivatedPlugin {
   const [captured, setCaptured] = useState<ActivatedPlugin['captured']>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -72,6 +80,10 @@ export function useActivatePlugin(pluginId: string): ActivatedPlugin {
         },
         onOverlayVisibility: (h) => window.api.onPluginOverlayVisibility(h),
         setInteractiveRegion: (rect) => {
+          if (onInteractiveRegion) {
+            onInteractiveRegion(rect)
+            return
+          }
           // Report the rect (in this window's CSS px) as an interactive panel so
           // the main-process uiohook hit-test flips THIS overlay window clickable
           // while the cursor is inside it. Empty array clears (stays click-through).
@@ -137,7 +149,7 @@ export function useActivatePlugin(pluginId: string): ActivatedPlugin {
       unsubItem()
       unsubZone()
     }
-  }, [pluginId])
+  }, [pluginId, onInteractiveRegion])
 
   return { captured, error }
 }


### PR DESCRIPTION
On Hyprland, pressing the OCR plugin opens a capture picker that cannot receive clicks: input still goes to the game. After capture, OCR annotation panels also need compositor focus to accept clicks, close, or drag.

This uses `grim` to capture the tracked game rectangle directly, validates game focus and geometry around capture, and maps fractional-scale compositor coordinates into Electron DIPs. Annotation panels acquire focus within their declared interactive regions and return it to the game on exit. A renderer drag grip moves the panel and updates its input region.

### Dependencies and review scope

Depends on #617. This draft targets `main`, so its diff currently includes that PR's Hyprland foundation, rebased onto current upstream. The new OCR work is commit a63d337; [review only the OCR changes](https://github.com/jborlum/scalpel-upstream/compare/370b910...a63d337). Rebase away the prerequisite commits once #617 merges. The native dependency changes in #621 are excluded.

Requires Hyprland 0.56+, `grim` on PATH, and the compositor window rule documented in #617. This is Hyprland support; other Wayland compositors need their own integration.

### Validation

- Production build passes on this PR branch.
- Full suite: 3,922 passed, 3 skipped on this PR branch.
- The user verified OCR capture and panel interaction in live PoE2 on Hyprland using the development build (which also includes #621's native lifecycle changes).
- Automated coverage includes capture focus/geometry checks, fractional-scale mapping, focus handoff, and panel dragging.

The local checks reuse the development checkout's installed dependencies. A fresh install with upstream's dependency versions and Windows/multi-monitor runtime testing remain unverified.
